### PR TITLE
chore: wire backend logging (#85)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -8,7 +8,7 @@ from backend.api.products import router as products_router
 from backend.config import SERVICE_NAME, backend_settings
 from backend.errors import register_exception_handlers
 
-setup_logging(SERVICE_NAME)
+setup_logging(SERVICE_NAME, level=settings.LOG_LEVEL)
 
 app = FastAPI(title="SAQ Sommelier", version="0.1.0", debug=settings.DEBUG)
 

--- a/backend/errors.py
+++ b/backend/errors.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, status
 from fastapi.requests import Request
 from fastapi.responses import JSONResponse
+from loguru import logger
 
 from backend.exceptions import NotFoundError
 
@@ -10,6 +11,7 @@ def register_exception_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(NotFoundError)
     async def not_found_handler(request: Request, exc: NotFoundError) -> JSONResponse:
+        logger.warning("{} {} — {}", request.method, request.url.path, exc)
         return JSONResponse(
             status_code=status.HTTP_404_NOT_FOUND,
             content={"detail": str(exc)},


### PR DESCRIPTION
## Summary

Wire `setup_logging` to the env-configurable `LOG_LEVEL` and add structured warning logs to domain exception handlers.

## Related issue(s)

Closes #85

## Changes

- **`backend/app.py`**: Pass `settings.LOG_LEVEL` to `setup_logging()` (was using default `"INFO"` with no env override)
- **`backend/errors.py`**: Add `logger.warning` in the `NotFoundError` handler — logs method, path, and message for 404s

## How to test

```bash
make lint && make test   # all green
make dev                 # start backend, check stderr shows "Logging initialized for backend"
curl localhost:8000/api/v1/products/NONEXISTENT  # 404, check log shows WARNING with path + message
```