### PR TITLE
fix(scraper): add settings validators and SCRAPE_LIMIT (#84)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,8 @@ ENVIRONMENT=development
 LOG_LEVEL=INFO
 DEBUG=false
 DATABASE_ECHO=false
+
+# ============================================================================
+# Scraper
+# ============================================================================
+SCRAPE_LIMIT=50             # 0 = all products (production)

--- a/scraper/src/__main__.py
+++ b/scraper/src/__main__.py
@@ -13,13 +13,8 @@ from .sitemap import fetch_sitemap_index, fetch_sub_sitemap
 setup_logging(settings.SERVICE_NAME, level=settings.LOG_LEVEL)
 
 
-async def main(max_products: int = 5) -> None:
-    """Fetch sitemap, scrape products, write to database.
-
-    Args:
-        max_products: Number of products to scrape (default 5, for testing).
-                     Set to None or a very large number to scrape all products.
-    """
+async def main() -> None:
+    """Fetch sitemap, scrape products, write to database."""
 
     # async with keeps a connection pool open (reuses TCP connections)
     # User-Agent identifies us as a bot (ethical scraping)
@@ -43,8 +38,8 @@ async def main(max_products: int = 5) -> None:
             len(sub_sitemap_urls),
         )
 
-        # If max_products is None, scrape all
-        products_to_scrape = entries[:max_products] if max_products else entries
+        limit = settings.SCRAPE_LIMIT
+        products_to_scrape = entries[:limit] if limit else entries
         logger.info("Scraping {} products...", len(products_to_scrape))
 
         # Main scrape loop

--- a/scraper/src/config.py
+++ b/scraper/src/config.py
@@ -1,4 +1,7 @@
+from typing import Annotated
+
 from core.config.settings import settings as core_settings
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -17,10 +20,13 @@ class ScraperSettings(BaseSettings):
 
     # HTTP client settings
     USER_AGENT: str = "SAQSommelier/0.1.0 (personal project; contact@victorpatrin.dev)"
-    REQUEST_TIMEOUT: int = 30
+    REQUEST_TIMEOUT: Annotated[int, Field(ge=1)] = 30
 
     # Rate limiting (ethical scraping)
-    RATE_LIMIT_SECONDS: int = 2
+    RATE_LIMIT_SECONDS: Annotated[int, Field(ge=1)] = 2
+
+    # Dev convenience: limit how many products to scrape (0 = unlimited)
+    SCRAPE_LIMIT: Annotated[int, Field(ge=0)] = 0
 
     # Logging (per-service override — scraper might want DEBUG while backend stays INFO)
     LOG_LEVEL: str = "INFO"

--- a/scraper/tests/test_config.py
+++ b/scraper/tests/test_config.py
@@ -1,0 +1,36 @@
+import pytest
+from pydantic import ValidationError
+
+from src.config import ScraperSettings
+
+
+class TestScraperSettingsValidators:
+    def test_rejects_zero_rate_limit(self) -> None:
+        with pytest.raises(ValidationError, match="RATE_LIMIT_SECONDS"):
+            ScraperSettings(RATE_LIMIT_SECONDS=0)
+
+    def test_rejects_negative_rate_limit(self) -> None:
+        with pytest.raises(ValidationError, match="RATE_LIMIT_SECONDS"):
+            ScraperSettings(RATE_LIMIT_SECONDS=-1)
+
+    def test_rejects_zero_timeout(self) -> None:
+        with pytest.raises(ValidationError, match="REQUEST_TIMEOUT"):
+            ScraperSettings(REQUEST_TIMEOUT=0)
+
+    def test_rejects_negative_timeout(self) -> None:
+        with pytest.raises(ValidationError, match="REQUEST_TIMEOUT"):
+            ScraperSettings(REQUEST_TIMEOUT=-5)
+
+    def test_rejects_negative_scrape_limit(self) -> None:
+        with pytest.raises(ValidationError, match="SCRAPE_LIMIT"):
+            ScraperSettings(SCRAPE_LIMIT=-1)
+
+    def test_accepts_zero_scrape_limit(self) -> None:
+        s = ScraperSettings(SCRAPE_LIMIT=0)
+        assert s.SCRAPE_LIMIT == 0
+
+    def test_accepts_valid_values(self) -> None:
+        s = ScraperSettings(RATE_LIMIT_SECONDS=1, REQUEST_TIMEOUT=10, SCRAPE_LIMIT=50)
+        assert s.RATE_LIMIT_SECONDS == 1
+        assert s.REQUEST_TIMEOUT == 10
+        assert s.SCRAPE_LIMIT == 50


### PR DESCRIPTION
## Summary

Add Pydantic validators to ScraperSettings so invalid config values fail fast at startup instead of causing silent runtime issues. Also replace the hardcoded `max_products=5` parameter with an env-driven `SCRAPE_LIMIT` setting.

## Related issue(s)

Closes #84

## Changes

- Add `Field(ge=1)` validators to `REQUEST_TIMEOUT` and `RATE_LIMIT_SECONDS` — rejects zero/negative at startup
- Add `SCRAPE_LIMIT` setting (`Field(ge=0)`, default `0` = unlimited) to cap product scraping via env var
- Wire `SCRAPE_LIMIT` into `__main__.py`, replacing hardcoded `max_products=5` parameter
- Add `SCRAPE_LIMIT=50` to `.env.example` as dev-safe default
- Add 7 validator tests covering boundary conditions for all three fields

## How to test

```bash
make lint && make test   # 30/30 scraper tests pass
SCRAPE_LIMIT=-1 python -c "from scraper.src.config import ScraperSettings; ScraperSettings()"  # ValidationError
```