### PR TITLE
feat(scraper): add run summary and exit codes (#52)

### DIFF
--- a/.github/badges/coverage-scraper.svg
+++ b/.github/badges/coverage-scraper.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="57.0" y="15" fill="#010101" fill-opacity=".3">scraper coverage</text>
     <text x="57.0" y="14">scraper coverage</text>
-    <text x="130.25" y="15" fill="#010101" fill-opacity=".3">83%</text>
-    <text x="130.25" y="14">83%</text>
+    <text x="130.25" y="15" fill="#010101" fill-opacity=".3">79%</text>
+    <text x="130.25" y="14">79%</text>
   </g>
 </svg>

--- a/scraper/tests/test_incremental.py
+++ b/scraper/tests/test_incremental.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from src.__main__ import _needs_scrape
+from src.__main__ import _exit_code, _needs_scrape
 from src.sitemap import SitemapEntry
 
 
@@ -28,3 +28,17 @@ class TestNeedsScrape:
         entry = SitemapEntry(url="https://www.saq.com/fr/10327701", lastmod="2026-01-15")
         updated_dates = {"10327701": date(2026, 2, 1)}
         assert _needs_scrape(entry, updated_dates) is False
+
+
+class TestExitCode:
+    def test_clean_run(self) -> None:
+        assert _exit_code(saved=10, errors=0) == 0
+
+    def test_no_work_is_clean(self) -> None:
+        assert _exit_code(saved=0, errors=0) == 0
+
+    def test_partial_failure(self) -> None:
+        assert _exit_code(saved=8, errors=2) == 1
+
+    def test_total_failure(self) -> None:
+        assert _exit_code(saved=0, errors=5) == 2


### PR DESCRIPTION
## Summary

Add a structured run summary at the end of each scraper execution with health metrics and meaningful exit codes for cronjob alerting.

## Related issue(s)

Closes #52

## Changes

- Add `_exit_code()` helper: 0 (clean), 1 (partial failure), 2 (total failure)
- Track counters during scrape loop: saved, inserted, updated, errors
- Distinguish insert vs update using the already-loaded `updated_dates` dict
- Log structured summary at end (duration, sitemap URLs, fetched, inserted, updated, failed, skipped)
- Wire `sys.exit()` to propagate exit code to the OS
- 4 new tests for exit code logic

## How to test

```bash
make lint       # all green
make test       # 43/43 scraper tests pass
```