### PR TITLE
docs: Telegram bot design + roadmap refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for database setup options and fu
 - [Development](docs/DEVELOPMENT.md) — database setup, environment config, dev workflow
 - [Migrations](docs/MIGRATIONS.md) — Alembic setup, workflow, and troubleshooting
 - [Scraper Operations](docs/SCRAPER.md) — production scheduling, failure recovery, logging
+- [Telegram Bot](docs/TELEGRAM_BOT.md) — bot design, commands, API dependencies
 - [Roadmap](docs/ROADMAP.md) — project phases and progress
 
 ## Legal

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,7 +22,7 @@
 - [x] Product model + first migration (#17)
 - [x] DB writer (#18)
 
-### Phase 3 — Production Scraper (done, hardening in progress)
+### Phase 3 — Production Scraper (done)
 
 - [x] Sitemap fetcher service (#14)
 - [x] Product parser service (#15)
@@ -34,32 +34,38 @@
 - [x] Incremental scraping via lastmod (#50, PR #94)
 - [x] Detect delisted products (#51, PR #96)
 - [x] Run summary + exit codes (#52, PR #95)
-- [ ] Weekly cronjob (#49) — systemd timer + Compose service
+- [x] Weekly cronjob (#49, PR #97) — systemd timer + Compose service
 
-### Phase 4 — API + Business Logic (in progress)
+### Phase 4 — API for Bot (in progress)
+
+Backend endpoints driven by Telegram bot needs. See [TELEGRAM_BOT.md](TELEGRAM_BOT.md) for full design.
 
 - [x] Product list endpoint (#33)
 - [x] Product detail endpoint (#34)
 - [x] Product search + filtering (#35)
 - [x] Database indexes (#26)
 - [x] Structured exception handling (#41)
-- [ ] Catalog facets endpoint (#55)
-- [ ] Stats summary endpoint (#56)
-- [ ] Price history tracking (#57)
-- [ ] In-store availability tracking (#59)
-- [ ] Auth (if needed)
+- [ ] Exclude delisted + unavailable from API (#98) — prerequisite for all bot queries
+- [ ] Catalog facets endpoint (#55) — powers bot filter buttons
+- [ ] Sort by recent + random product endpoint — powers `/new` and `/random`
+- [ ] Watches resource (CRUD) — powers `/watch`, `/unwatch`, `/alerts`
+- [ ] Price history tracking (#57) — powers price drop alerts (post-MVP)
 
 ### Phase 5 — Telegram Bot
 
-- [ ] Basic bot scaffold
-- [ ] Wire to API — query wines from chat
-- [ ] Availability alerts (#58)
+- [ ] Bot scaffold (`bot/` service, python-telegram-bot)
+- [ ] `/search` — search wines with inline keyboard filters
+- [ ] `/new` — recently added/updated wines with filters
+- [ ] `/random` — random wine with filters
+- [ ] `/watch`, `/unwatch`, `/alerts` — price drop + restock alerts
+- [ ] Weekly digest — proactive post to group chat after scraper run
+- [ ] Bot Dockerfile + Compose service
 
 ### Phase 6 — AI Layer (RAG + Claude)
 
 - [ ] ChromaDB + embeddings
 - [ ] Claude API integration
-- [ ] Natural language recommendations via Telegram
+- [ ] `/recommend` — natural language recommendations via Telegram
 
 ## Infrastructure / Chores
 

--- a/docs/TELEGRAM_BOT.md
+++ b/docs/TELEGRAM_BOT.md
@@ -1,0 +1,91 @@
+# Telegram Bot
+
+## Why a bot?
+
+SAQ.com already lets you browse, search, and filter wines. The bot's value is **proactive intelligence** — things SAQ doesn't do:
+
+- Alert you when a watched wine's price drops or comes back in stock
+- Push a weekly digest of new arrivals and price changes to a group chat
+- Discover wines randomly or by filters without opening a browser
+- Eventually: natural language recommendations via Claude (Phase 6)
+
+Target audience: ~20 friends in a private group chat.
+
+## Commands
+
+| Command | Description | Example |
+|---|---|---|
+| `/search <query>` | Search wines by name | `/search mouton cadet` |
+| `/new` | Recently added or updated wines | `/new` → filter by type/price |
+| `/random` | Random wine suggestion | `/random` → filter by type/price |
+| `/watch <sku>` | Get alerts for price drops and restocks | `/watch 10327701` |
+| `/unwatch <sku>` | Stop watching a wine | `/unwatch 10327701` |
+| `/alerts` | List your watched wines and their status | `/alerts` |
+| `/help` | List available commands | `/help` |
+
+## Filter flow
+
+Commands like `/new`, `/random`, and `/search` present inline keyboard buttons to narrow results:
+
+```
+User: /new
+Bot:  [Rouge] [Blanc] [Rosé] [Mousseux]
+      [< 15$] [15-25$] [25-50$] [50$+]
+User: taps [Rouge] then [15-25$]
+Bot:  3 new reds under $25 this week:
+      1. Mouton Cadet 2022 — 16.95$
+      2. ...
+```
+
+Filter values (categories, price ranges) are populated dynamically from the catalog facets API endpoint — not hardcoded.
+
+## Weekly digest
+
+After the scraper runs (Monday 03:00), the bot proactively posts to the group chat:
+
+- New wines added this week
+- Price drops on popular categories
+- Restocks of previously delisted wines
+
+No command needed — it just shows up. Powered by the same data the scraper already collects.
+
+## Availability model
+
+All bot queries (`/search`, `/new`, `/random`) only return wines that are **available to buy online** — `delisted_at IS NULL AND availability = TRUE`. No point showing wines you can't purchase.
+
+`/watch` alerts on three events:
+
+- **Online restock** — `availability` flips from `False` to `True` (back in stock)
+- **Relist** — product reappears in the SAQ sitemap after being delisted
+- **Price drop** — price decreased since last scrape (requires price history)
+
+## Architecture
+
+The bot is a separate service (`bot/`) that calls the FastAPI backend over HTTP. It does NOT access the database directly.
+
+```
+Telegram API → Bot service → FastAPI backend → PostgreSQL
+```
+
+No auth needed — the bot is the only API consumer for now. If/when the React dashboard is added, we'll revisit auth.
+
+## API dependencies
+
+Endpoints the bot needs from the backend:
+
+| Bot feature | API endpoint | Status |
+|---|---|---|
+| `/search` | `GET /products?q=&category=&price_max=` | Exists |
+| `/new` | `GET /products?sort=recent` | Missing — needs sort param |
+| `/random` | `GET /products/random` | Missing — new endpoint |
+| Filter buttons | `GET /products/facets` | Missing — #55 |
+| `/watch` | `POST /watches`, `DELETE /watches/{sku}` | Missing — new resource |
+| `/alerts` | `GET /watches` | Missing — new resource |
+| Price drop alerts | Price history data | Missing — #57 |
+| Weekly digest | Recent changes query | Missing — needs sort param |
+
+## What's NOT in scope (yet)
+
+- **AI recommendations** (`/recommend`) — Phase 6, requires ChromaDB + Claude
+- **In-store availability** — would require scraping store-specific pages, not in sitemap data
+- **Auth** — 20 friends, private bot, not needed yet


### PR DESCRIPTION
## Summary

Design document for the Telegram bot MVP and roadmap cleanup to align Phase 4/5 with bot-driven API needs (YAGNI).

## Related issue(s)

Context for #98, #99, #100, #101, #55, #57

## Changes

- Add `docs/TELEGRAM_BOT.md` — bot commands, filter flow, availability model, architecture, API dependency table
- Update `docs/ROADMAP.md` — Phase 3 done, Phase 4 reframed around bot needs, #57 tagged post-MVP, #98 added as prerequisite
- Update `README.md` — add TELEGRAM_BOT.md to docs index
- Closed #56, #58, #59 as YAGNI (no bot consumer)
- Created `bot` label for future Phase 5 issues