### PR TITLE
feat: catalog facets endpoint (#55)

### DIFF
--- a/.github/badges/coverage-backend.svg
+++ b/.github/badges/coverage-backend.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="57.0" y="15" fill="#010101" fill-opacity=".3">backend coverage</text>
     <text x="57.0" y="14">backend coverage</text>
-    <text x="130.25" y="15" fill="#010101" fill-opacity=".3">96%</text>
-    <text x="130.25" y="14">96%</text>
+    <text x="130.25" y="15" fill="#010101" fill-opacity=".3">97%</text>
+    <text x="130.25" y="14">97%</text>
   </g>
 </svg>

--- a/backend/api/products.py
+++ b/backend/api/products.py
@@ -11,8 +11,8 @@ from backend.config import (
     MAX_SKU_LENGTH,
 )
 from backend.db import get_db
-from backend.schemas.product import PaginatedResponse, ProductResponse
-from backend.services.products import get_product, list_products
+from backend.schemas.product import FacetsResponse, PaginatedResponse, ProductResponse
+from backend.services.products import get_facets, get_product, list_products
 
 router = APIRouter(prefix="/products", tags=["products"])
 
@@ -43,6 +43,14 @@ async def get_products(
         max_price=max_price,
         available=available,
     )
+
+
+@router.get("/facets", response_model=FacetsResponse)
+async def get_product_facets(
+    db: AsyncSession = Depends(get_db),
+) -> FacetsResponse:
+    """Return distinct filter values and price range for the catalog."""
+    return await get_facets(db)
 
 
 @router.get("/{sku}", response_model=ProductResponse)

--- a/backend/schemas/product.py
+++ b/backend/schemas/product.py
@@ -37,3 +37,16 @@ class PaginatedResponse(BaseModel):
     page: int
     per_page: int
     pages: int
+
+
+class PriceRange(BaseModel):
+    min: Decimal
+    max: Decimal
+
+
+class FacetsResponse(BaseModel):
+    categories: list[str]
+    countries: list[str]
+    regions: list[str]
+    grapes: list[str]
+    price_range: PriceRange | None


### PR DESCRIPTION
## Summary

Add `GET /api/v1/products/facets` returning distinct filter values and price range for the catalog. This powers data-driven filter buttons in the Telegram bot — no hardcoded values to maintain.

## Related issue(s)

Closes #55

## Changes

- **`backend/schemas/product.py`** — Add `PriceRange` and `FacetsResponse` models
- **`backend/repositories/products.py`** — Add generic `get_distinct_values(db, column)` and `get_price_range(db)` query functions
- **`backend/services/products.py`** — Add `get_facets` orchestrator assembling all 5 queries
- **`backend/api/products.py`** — Add `/facets` route (declared before `/{sku}` to avoid path conflict)
- **`backend/tests/test_products.py`** — 4 new tests (happy path, empty catalog, no prices, delisted exclusion) + mock helpers; moved in-function imports to top-level
- Coverage 96% → 97%

## How to test

```bash
make lint && make test
# With a running database:
curl http://localhost:8000/api/v1/products/facets | jq
```