### PR TITLE
feat: sort by recent/price + random product endpoint (#99, #100)

### DIFF
--- a/backend/api/products.py
+++ b/backend/api/products.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from typing import Literal
 
 from fastapi import APIRouter, Depends, Path, Query
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,7 +13,7 @@ from backend.config import (
 )
 from backend.db import get_db
 from backend.schemas.product import FacetsResponse, PaginatedResponse, ProductResponse
-from backend.services.products import get_facets, get_product, list_products
+from backend.services.products import get_facets, get_product, get_random_product, list_products
 
 router = APIRouter(prefix="/products", tags=["products"])
 
@@ -21,6 +22,7 @@ router = APIRouter(prefix="/products", tags=["products"])
 async def get_products(
     page: int = Query(default=1, ge=1),
     per_page: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    sort: Literal["recent", "price_asc", "price_desc"] | None = Query(default=None),
     q: str | None = Query(default=None, min_length=1, max_length=MAX_SEARCH_LENGTH),
     category: str | None = Query(default=None, max_length=MAX_FILTER_LENGTH),
     country: str | None = Query(default=None, max_length=MAX_FILTER_LENGTH),
@@ -30,11 +32,12 @@ async def get_products(
     available: bool | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
 ) -> PaginatedResponse:
-    """List products with offset-based pagination and optional filters."""
+    """List products with offset-based pagination and optional filters and sorting options."""
     return await list_products(
         db,
         page,
         per_page,
+        sort=sort,
         q=q,
         category=category,
         country=country,
@@ -51,6 +54,28 @@ async def get_product_facets(
 ) -> FacetsResponse:
     """Return distinct filter values and price range for the catalog."""
     return await get_facets(db)
+
+
+@router.get("/random", response_model=ProductResponse)
+async def get_random(
+    category: str | None = Query(default=None, max_length=MAX_FILTER_LENGTH),
+    country: str | None = Query(default=None, max_length=MAX_FILTER_LENGTH),
+    region: str | None = Query(default=None, max_length=MAX_FILTER_LENGTH),
+    min_price: Decimal | None = Query(default=None, ge=0),
+    max_price: Decimal | None = Query(default=None, ge=0),
+    available: bool | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+) -> ProductResponse:
+    """Return a single random product matching the given filters."""
+    return await get_random_product(
+        db,
+        category=category,
+        country=country,
+        region=region,
+        min_price=min_price,
+        max_price=max_price,
+        available=available,
+    )
 
 
 @router.get("/{sku}", response_model=ProductResponse)


### PR DESCRIPTION
## Summary

Add sorting options and a random product endpoint to power the Telegram bot's `/new`, `/random`, and price browsing commands.

## Related issue(s)

Closes #99, closes #100

## Changes

- **Sorting** — `?sort=recent|price_asc|price_desc` on `GET /products`. Dict-based `_SORT_ORDERS` pattern for extensibility; defaults to alphabetical. FastAPI `Literal` type auto-rejects invalid values (422).
- **Random endpoint** — `GET /products/random` with all list filters minus `q`. Returns a single random product (200) or 404 if nothing matches. Uses `ORDER BY RANDOM() LIMIT 1`.
- **Repository layer** — `find_random()` function, `sort` param on `find_page()`, both reuse `_apply_filters` for consistent WHERE clauses.
- **Tests** — 12 new tests: sort happy-path (200), invalid sort (422), SQL assertions for each sort order, random found/not-found/with-filters/excludes-delisted.

## How to test

```bash
make lint-backend && make test-backend
# 43 tests pass, 97% coverage

# With server running:
curl 'localhost:8000/api/v1/products?sort=recent'
curl 'localhost:8000/api/v1/products?sort=price_asc&category=Vin'
curl 'localhost:8000/api/v1/products/random'
curl 'localhost:8000/api/v1/products/random?category=Vin&min_price=20'
```