### PR TITLE
fix: parser HTML attrs + JSON-LD merge (#106)

### DIFF
--- a/scraper/tests/conftest.py
+++ b/scraper/tests/conftest.py
@@ -45,7 +45,7 @@ def sub_sitemap_xml() -> str:
 
 @pytest.fixture
 def product_page_html() -> str:
-    """Product page HTML with JSON-LD and attribute list."""
+    """Product page HTML matching real SAQ structure (two JSON-LD blocks)."""
     return """<html><head>
 <script type="application/ld+json">
 {
@@ -54,25 +54,33 @@ def product_page_html() -> str:
   "sku": "10327701",
   "description": "A fine red wine",
   "category": "Vin rouge",
-  "countryOfOrigin": "France",
-  "gtin12": "00012345678901",
-  "color": "Rouge",
-  "size": "750 ml",
   "image": "https://www.saq.com/media/image.png?width=600&quality=80",
   "offers": {
     "price": 22.50,
     "priceCurrency": "CAD",
     "availability": "http://schema.org/InStock"
-  },
+  }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@type": "Product",
+  "name": "Ch&acirc;teau Example Bordeaux",
+  "sku": "10327701",
+  "gtin12": "00012345678901",
+  "category": "Vin rouge",
   "manufacturer": {"name": "Ch&acirc;teau Example"},
   "aggregateRating": {
-    "ratingValue": 4.5,
-    "reviewCount": 100
+    "ratingValue": "4,5",
+    "reviewCount": "100"
   }
 }
 </script>
 </head><body>
 <ul class="list-attributs">
+  <li><strong data-th="Pays">France</strong></li>
+  <li><strong data-th="Couleur">Rouge</strong></li>
+  <li><strong data-th="Format">750 ml</strong></li>
   <li><strong data-th="Région">Bordeaux</strong></li>
   <li><strong data-th="Appellation d'origine">Bordeaux AOC</strong></li>
   <li><strong data-th="Cépage">Merlot 60 %, Cabernet sauvignon 40 %</strong></li>


### PR DESCRIPTION
## Summary

Fix scraper parser to correctly extract country, color, and size from HTML attributes instead of JSON-LD (where they don't exist on real SAQ pages). Also fix JSON-LD parsing to merge both Product blocks emitted by SAQ pages, enabling rating and review extraction.

## Related issue(s)

Closes #106

## Changes

- **HTML attrs extraction**: Move `country`, `color`, `size` from JSON-LD string fields to `_LABEL_MAP` (`Pays`, `Couleur`, `Format`) — these fields only exist in the HTML attribute list on real SAQ pages
- **JSON-LD block merge**: SAQ emits two Product blocks (minimal + rich). Parser now merges all blocks instead of returning after the first, picking up `rating`, `review_count`, and `barcode` from block 2
- **French decimal comma**: Handle `"4,5"` → `4.5` in rating values (block 2 uses French locale)
- **Availability guard**: Only set `availability` when the offers block explicitly provides it, preventing block 2 (no offers) from overwriting block 1's value
- **Drop manufacturer extraction**: Redundant with `producer` from HTML attrs — column cleanup in #108

## How to test

```bash
make test-scraper   # 52 tests pass

# Live verification (requires DB):
SCRAPE_LIMIT=5 make scrape
curl localhost:8000/products | jq '.items[0] | {country, color, size, rating}'
# Should show non-null values for all fields
```