### PR TITLE
chore: update docs for Phase 4 completion (#111)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,7 +36,7 @@
 - [x] Run summary + exit codes (#52, PR #95)
 - [x] Weekly cronjob (#49, PR #97) — systemd timer + Compose service
 
-### Phase 4 — API for Bot (in progress)
+### Phase 4 — API for Bot (done)
 
 Backend endpoints driven by Telegram bot needs. See [TELEGRAM_BOT.md](TELEGRAM_BOT.md) for full design.
 
@@ -45,11 +45,11 @@ Backend endpoints driven by Telegram bot needs. See [TELEGRAM_BOT.md](TELEGRAM_B
 - [x] Product search + filtering (#35)
 - [x] Database indexes (#26)
 - [x] Structured exception handling (#41)
-- [ ] Exclude delisted + unavailable from API (#98) — prerequisite for all bot queries
-- [ ] Catalog facets endpoint (#55) — powers bot filter buttons
-- [ ] Sort by recent + random product endpoint — powers `/new` and `/random`
-- [ ] Watches resource (CRUD) — powers `/watch`, `/unwatch`, `/alerts`
-- [ ] Price history tracking (#57) — powers price drop alerts (post-MVP)
+- [x] Exclude delisted + available filter (#98, PR #103)
+- [x] Catalog facets endpoint (#55, PR #105)
+- [x] Sort by recent + random product (#99, #100, PR #107)
+- [x] Watches CRUD (#101, PR #112) — powers `/watch`, `/unwatch`, `/alerts`
+- ~~Price history tracking (#57)~~ — descoped, SAQ prices are regulated
 
 ### Phase 5 — Telegram Bot
 
@@ -57,7 +57,7 @@ Backend endpoints driven by Telegram bot needs. See [TELEGRAM_BOT.md](TELEGRAM_B
 - [ ] `/search` — search wines with inline keyboard filters
 - [ ] `/new` — recently added/updated wines with filters
 - [ ] `/random` — random wine with filters
-- [ ] `/watch`, `/unwatch`, `/alerts` — price drop + restock alerts
+- [ ] `/watch`, `/unwatch`, `/alerts` — availability/restock alerts
 - [ ] Weekly digest — proactive post to group chat after scraper run
 - [ ] Bot Dockerfile + Compose service
 

--- a/docs/TELEGRAM_BOT.md
+++ b/docs/TELEGRAM_BOT.md
@@ -4,8 +4,8 @@
 
 SAQ.com already lets you browse, search, and filter wines. The bot's value is **proactive intelligence** — things SAQ doesn't do:
 
-- Alert you when a watched wine's price drops or comes back in stock
-- Push a weekly digest of new arrivals and price changes to a group chat
+- Alert you when a watched wine goes out of stock or comes back
+- Push a weekly digest of new arrivals and restocks to a group chat
 - Discover wines randomly or by filters without opening a browser
 - Eventually: natural language recommendations via Claude (Phase 6)
 
@@ -18,7 +18,7 @@ Target audience: ~20 friends in a private group chat.
 | `/search <query>` | Search wines by name | `/search mouton cadet` |
 | `/new` | Recently added or updated wines | `/new` → filter by type/price |
 | `/random` | Random wine suggestion | `/random` → filter by type/price |
-| `/watch <sku>` | Get alerts for price drops and restocks | `/watch 10327701` |
+| `/watch <sku>` | Get alerts for availability changes | `/watch 10327701` |
 | `/unwatch <sku>` | Stop watching a wine | `/unwatch 10327701` |
 | `/alerts` | List your watched wines and their status | `/alerts` |
 | `/help` | List available commands | `/help` |
@@ -44,8 +44,7 @@ Filter values (categories, price ranges) are populated dynamically from the cata
 After the scraper runs (Monday 03:00), the bot proactively posts to the group chat:
 
 - New wines added this week
-- Price drops on popular categories
-- Restocks of previously delisted wines
+- Restocks of previously unavailable or delisted wines
 
 No command needed — it just shows up. Powered by the same data the scraper already collects.
 
@@ -56,11 +55,11 @@ Delisted products (removed from SAQ sitemap) are always excluded from the API. O
 - `/search` — shows all products including out-of-stock, so users can find wines and set up alerts
 - `/new`, `/random` — only available wines (`?available=true`), no point suggesting something you can't buy
 
-`/watch` alerts on three events:
+`/watch` alerts on any availability change:
 
+- **Out of stock** — `availability` flips from `True` to `False`
 - **Online restock** — `availability` flips from `False` to `True` (back in stock)
 - **Relist** — product reappears in the SAQ sitemap after being delisted
-- **Price drop** — price decreased since last scrape (requires price history)
 
 ## Architecture
 
@@ -78,14 +77,13 @@ Endpoints the bot needs from the backend:
 
 | Bot feature | API endpoint | Status |
 |---|---|---|
-| `/search` | `GET /products?q=&category=&price_max=` | Exists |
-| `/new` | `GET /products?sort=recent` | Missing — needs sort param |
-| `/random` | `GET /products/random` | Missing — new endpoint |
-| Filter buttons | `GET /products/facets` | Missing — #55 |
-| `/watch` | `POST /watches`, `DELETE /watches/{sku}` | Missing — new resource |
-| `/alerts` | `GET /watches` | Missing — new resource |
-| Price drop alerts | Price history data | Missing — #57 |
-| Weekly digest | Recent changes query | Missing — needs sort param |
+| `/search` | `GET /products?q=&category=&price_max=` | Done |
+| `/new` | `GET /products?sort=recent` | Done (PR #107) |
+| `/random` | `GET /products/random` | Done (PR #107) |
+| Filter buttons | `GET /products/facets` | Done (#55, PR #105) |
+| `/watch` | `POST /watches`, `DELETE /watches/{sku}` | Done (#101, PR #112) |
+| `/alerts` | `GET /watches?user_id=` | Done (#101, PR #112) |
+| Weekly digest | `GET /products?sort=recent` | Done (PR #107) |
 
 ## What's NOT in scope (yet)
 


### PR DESCRIPTION
## Summary

Phase 4 (API for Bot) is complete — all endpoints the Telegram bot needs are built and tested. This PR updates the three affected docs to reflect current state.

Price history (#57) was descoped and closed — SAQ prices are regulated and rarely change. Watches focus on availability/restock alerts only.

## Related issue(s)

Closes #111

## Changes

- **ROADMAP.md** — Phase 4 marked done, all items checked off with PR refs, #57 struck through, Phase 5 `/watch` description updated to "availability/restock alerts"
- **TELEGRAM_BOT.md** — Price drop references replaced with availability alerts, API dependencies table all marked "Done" with PR refs, weekly digest simplified (no price drops)
- **ARCHITECTURE.md** — System diagram updated (current endpoints, `watches` table, removed `prices (?)` / `users (?)`), project structure reflects repositories + services layers, `main.py` → `app.py`, PostgreSQL section mentions `watches`