### PR TITLE
fix: scraper crashes on datetime lastmod from SAQ sitemap (#140)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,13 +105,13 @@ coverage: coverage-backend coverage-scraper coverage-bot
 
 # Build
 build-backend:
-	docker build -f backend/Dockerfile -t saq-backend .
+	docker compose build backend
 
 build-scraper:
-	docker build -f scraper/Dockerfile -t saq-scraper .
+	docker compose build scraper
 
 build-bot:
-	docker build -f bot/Dockerfile -t saq-bot .
+	docker compose build bot
 
 build: build-backend build-scraper build-bot
 

--- a/scraper/src/__main__.py
+++ b/scraper/src/__main__.py
@@ -1,7 +1,7 @@
 import asyncio
 import sys
 import time
-from datetime import date
+from datetime import date, datetime
 
 import httpx
 from core.logging import setup_logging
@@ -37,7 +37,7 @@ def _needs_scrape(entry: SitemapEntry, updated_dates: dict[str, date]) -> bool:
         return True
     if entry.sku not in updated_dates:
         return True
-    return date.fromisoformat(entry.lastmod) > updated_dates[entry.sku]
+    return datetime.fromisoformat(entry.lastmod).date() > updated_dates[entry.sku]
 
 
 async def main() -> int:

--- a/scraper/tests/test_incremental.py
+++ b/scraper/tests/test_incremental.py
@@ -29,6 +29,20 @@ class TestNeedsScrape:
         updated_dates = {"10327701": date(2026, 2, 1)}
         assert _needs_scrape(entry, updated_dates) is False
 
+    def test_datetime_lastmod_with_timezone(self) -> None:
+        entry = SitemapEntry(
+            url="https://www.saq.com/fr/10327701", lastmod="2026-02-18T15:21:49+00:00"
+        )
+        updated_dates = {"10327701": date(2026, 2, 1)}
+        assert _needs_scrape(entry, updated_dates) is True
+
+    def test_datetime_lastmod_same_day_skips(self) -> None:
+        entry = SitemapEntry(
+            url="https://www.saq.com/fr/10327701", lastmod="2026-02-01T10:30:00+00:00"
+        )
+        updated_dates = {"10327701": date(2026, 2, 1)}
+        assert _needs_scrape(entry, updated_dates) is False
+
 
 class TestExitCode:
     def test_clean_run(self) -> None:


### PR DESCRIPTION
## Summary

SAQ's sitemap changed `<lastmod>` from date-only (`2026-02-18`) to full ISO datetime with timezone (`2026-02-18T15:21:49+00:00`). `date.fromisoformat()` can't parse this format, crashing the scraper during incremental runs.

Also fixes a Makefile inconsistency where `make build-*` used raw `docker build` (producing `saq-scraper` images) while `make run-*` used `docker compose run` (expecting `saq-sommelier-scraper` images), causing stale code to run after rebuilds.

## Related issue(s)

Closes #140

## Changes

- Use `datetime.fromisoformat().date()` instead of `date.fromisoformat()` in `_needs_scrape` — handles both date-only and full datetime formats (Python 3.11+)
- Add two test cases for timezone-aware lastmod strings (newer + same-day)
- Switch Makefile `build-*` targets from `docker build` to `docker compose build` for consistent image naming

## How to test

```bash
make test-scraper          # 53 tests pass, including 2 new datetime cases
make build-scraper         # now uses compose — produces correct image
make run-scraper           # runs with the freshly built image
```