### PR TITLE
chore: port assignment convention (#53)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,5 +36,5 @@ SCRAPE_LIMIT=50             # 0 = all products (production)
 # Telegram Bot
 # ============================================================================
 TELEGRAM_BOT_TOKEN=         # Get from @BotFather on Telegram
-BACKEND_URL=http://localhost:8000
+BACKEND_URL=http://localhost:8001
 NOTIFICATION_POLL_INTERVAL=60   # seconds (60 for dev, 21600 for prod)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install:
 	cd bot && poetry lock && poetry install
 
 dev-backend:
-	cd backend && poetry run uvicorn backend.app:app --reload --port 8000
+	cd backend && poetry run uvicorn backend.app:app --reload --port 8001
 
 dev-bot:
 	cd bot && poetry run python -m bot

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cp .env.example .env      # defaults work as-is
 make run-db               # start PostgreSQL (localhost:5432)
 make migrate              # create database tables
 make dev-scraper          # populate the database (~38k products)
-make dev-backend          # start the backend (localhost:8000)
+make dev-backend          # start the backend (localhost:8001)
 ```
 
 ## Development

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -36,6 +36,6 @@ COPY backend/ backend/
 RUN useradd --create-home appuser
 USER appuser
 
-EXPOSE 8000
+EXPOSE 8001
 
-CMD ["uvicorn", "backend.app:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "backend.app:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/backend/__main__.py
+++ b/backend/__main__.py
@@ -2,4 +2,4 @@ import uvicorn
 
 from backend.app import app
 
-uvicorn.run(app, host="0.0.0.0", port=8000)
+uvicorn.run(app, host="0.0.0.0", port=8001)

--- a/bot/bot/api_client.py
+++ b/bot/bot/api_client.py
@@ -29,7 +29,7 @@ class BackendClient:
     # ── Lifecycle ───────────────────────────────────────────────
 
     def __init__(self, base_url: str, timeout: float = 10.0) -> None:
-        self._base_url = base_url.rstrip("/")  # Prevents http://localhost:8000//api/v1
+        self._base_url = base_url.rstrip("/")  # Prevents double slash in URL
         self._timeout = timeout
         self._client: httpx.AsyncClient | None = None
 

--- a/bot/bot/config.py
+++ b/bot/bot/config.py
@@ -15,7 +15,7 @@ class BotSettings(BaseSettings):
     )
 
     TELEGRAM_BOT_TOKEN: str
-    BACKEND_URL: str = "http://localhost:8000"
+    BACKEND_URL: str = "http://localhost:8001"
     BACKEND_TIMEOUT: float = 10.0
     LOG_LEVEL: str = "INFO"
     NOTIFICATION_POLL_INTERVAL: int  # seconds — set in .env (60 dev, 21600 prod)

--- a/bot/tests/test_api_client.py
+++ b/bot/tests/test_api_client.py
@@ -26,7 +26,7 @@ def _response(
 
 @pytest.fixture
 def client() -> BackendClient:
-    bc = BackendClient(base_url="http://test:8000")
+    bc = BackendClient(base_url="http://test:8001")
     bc._client = AsyncMock(spec=httpx.AsyncClient)
     return bc
 
@@ -257,7 +257,7 @@ async def test_server_error(client: BackendClient) -> None:
 
 
 async def test_open_creates_client() -> None:
-    bc = BackendClient(base_url="http://test:8000")
+    bc = BackendClient(base_url="http://test:8001")
     assert bc._client is None
 
     await bc.open()
@@ -267,7 +267,7 @@ async def test_open_creates_client() -> None:
 
 
 async def test_close_cleans_up() -> None:
-    bc = BackendClient(base_url="http://test:8000")
+    bc = BackendClient(base_url="http://test:8001")
     await bc.open()
 
     await bc.close()
@@ -276,7 +276,7 @@ async def test_close_cleans_up() -> None:
 
 
 async def test_request_without_open_fails() -> None:
-    bc = BackendClient(base_url="http://test:8000")
+    bc = BackendClient(base_url="http://test:8001")
 
     with pytest.raises(AssertionError, match="Client not open"):
         await bc.list_products()

--- a/bot/tests/test_config.py
+++ b/bot/tests/test_config.py
@@ -9,5 +9,5 @@ def test_settings_reads_token_from_env(monkeypatch: object) -> None:
 
 def test_settings_defaults() -> None:
     s = BotSettings()
-    assert s.BACKEND_URL == "http://localhost:8000"
+    assert s.BACKEND_URL == "http://localhost:8001"
     assert s.LOG_LEVEL == "INFO"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,20 +17,25 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    networks:
+      - internal
 
   backend:
     build:
       context: .
       dockerfile: backend/Dockerfile
+    container_name: saq-backend
     env_file: .env
     environment:
       # Override localhost → Compose service name for container-to-container networking.
       DB_HOST: postgres
     ports:
-      - "127.0.0.1:8000:8000"
+      - "127.0.0.1:8001:8001"
     volumes:
       - ./backend:/app/backend
-    command: ["uvicorn", "backend.app:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]
+    command: ["uvicorn", "backend.app:app", "--reload", "--host", "0.0.0.0", "--port", "8001"]
+    networks:
+      - internal
     depends_on:
       postgres:
         condition: service_healthy
@@ -44,9 +49,11 @@ services:
     env_file: .env
     environment:
       # Override localhost → Compose service name for container-to-container networking.
-      BACKEND_URL: http://backend:8000
+      BACKEND_URL: http://backend:8001
     volumes:
       - ./bot/bot:/app/bot/bot
+    networks:
+      - internal
     depends_on:
       - backend
 
@@ -59,6 +66,8 @@ services:
       DB_HOST: postgres
     # One-shot job — don't restart after exit. Systemd timer handles scheduling.
     restart: "no"
+    networks:
+      - internal
     depends_on:
       postgres:
         condition: service_healthy
@@ -66,3 +75,7 @@ services:
 
 volumes:
   pgdata:
+
+networks:
+  internal:
+    external: true

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -14,7 +14,7 @@ cp .env.example .env      # defaults work as-is
 make run-db               # start PostgreSQL (localhost:5432)
 make migrate              # create database tables
 make dev-scraper          # populate the database (~38k products)
-make dev-backend          # start the backend (localhost:8000)
+make dev-backend          # start the backend (localhost:8001)
 ```
 
 Or skip Poetry entirely and run everything in Docker:
@@ -64,14 +64,14 @@ All services read from a single root `.env` file. See [.env.example](../.env.exa
 | `DEBUG` | no | `false` | Debug mode |
 | `DATABASE_ECHO` | no | `false` | Log SQL queries |
 | `TELEGRAM_BOT_TOKEN` | bot only | — | Token from @BotFather |
-| `BACKEND_URL` | no | `http://localhost:8000` | API URL for the bot |
+| `BACKEND_URL` | no | `http://localhost:8001` | API URL for the bot |
 
 ## Make targets
 
 ```bash
 # Development
 make install       # poetry install for all services
-make dev-backend   # uvicorn backend on localhost:8000
+make dev-backend   # uvicorn backend on localhost:8001
 make dev-bot       # telegram bot in polling mode
 make dev-scraper   # run the scraper
 make migrate       # alembic upgrade head
@@ -115,10 +115,10 @@ make reset-db && make dev-scraper
 The backend runs with hot reload — edit code, save, and uvicorn restarts automatically.
 
 ```bash
-make dev-backend          # start on localhost:8000
+make dev-backend          # start on localhost:8001
 ```
 
-API docs (Swagger UI) are available at [localhost:8000/docs](http://localhost:8000/docs).
+API docs (Swagger UI) are available at [localhost:8001/docs](http://localhost:8001/docs).
 
 The backend expects a populated database. If you see empty responses, run `make dev-scraper` first.
 


### PR DESCRIPTION
## Summary

- Backend port 8000→8001 to avoid collision with url-shortener on shared VPS
- All Compose services on shared `internal` Docker network for Caddy routing
- `container_name: saq-backend` to match Caddyfile reverse proxy target

## Related issue(s)

Closes #53

## Changes

- `docker-compose.yml` — port 8001:8001, `container_name: saq-backend`, all services on `internal` network
- `backend/Dockerfile` — EXPOSE and CMD updated to 8001
- `backend/__main__.py` — bare-metal entry point port updated
- `Makefile` — `make dev-backend` port updated
- `bot/bot/config.py` — default BACKEND_URL updated to 8001
- `.env.example`, `README.md`, `docs/DEVELOPMENT.md` — doc references updated
- `bot/tests/test_config.py`, `bot/tests/test_api_client.py` — test assertions updated
- `bot/bot/api_client.py` — stale port-specific comment cleaned up

## How to test

```bash
make dev-backend          # should start on localhost:8001
curl localhost:8001/docs  # Swagger UI
docker compose up -d      # requires `docker network create internal`
```