### PR TITLE
docs: add security discipline roadmap (#168)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-One project, six disciplines. Detailed task breakdowns in [roadmaps/](roadmaps/).
+One project, seven disciplines. Detailed task breakdowns in [roadmaps/](roadmaps/).
 
 | Discipline | Roadmap |
 | --- | --- |
@@ -10,6 +10,7 @@ One project, six disciplines. Detailed task breakdowns in [roadmaps/](roadmaps/)
 | Platform Engineering | [platform-engineering.md](roadmaps/platform-engineering.md) |
 | Observability | [observability.md](roadmaps/observability.md) |
 | Environment Segregation | [environment-segregation.md](roadmaps/environment-segregation.md) |
+| Security | [security.md](roadmaps/security.md) |
 
 ---
 

--- a/docs/roadmaps/platform-engineering.md
+++ b/docs/roadmaps/platform-engineering.md
@@ -34,11 +34,9 @@ Part of the [project roadmap](../ROADMAP.md). DX tooling, Docker hardening, CI/C
 - [ ] Systemd timer — daily 3am backup
 - [ ] docs/DISASTER_RECOVERY.md — recovery procedures for container crash, VPS death, bad deploy, DB corruption, ChromaDB corruption
 
-## Phase 6 — Security Hardening (~half day)
+## Phase 6 — Security Hardening
 
-- [x] Dependabot — weekly updates for pip + github-actions (#61)
-- [ ] VPS hardening via Ansible — disable root SSH, disable password auth, UFW, unattended-upgrades
-- [ ] Supply chain security — pip-audit + Trivy container scan in CI, weekly schedule
+Moved to dedicated [Security Roadmap](security.md). Dependabot (#61) and Hadolint (#73) already done.
 
 ## Phase 7 — Advanced Platform (~2 days, portfolio polish)
 

--- a/docs/roadmaps/security.md
+++ b/docs/roadmaps/security.md
@@ -1,0 +1,50 @@
+# Security Roadmap
+
+Part of the [project roadmap](../ROADMAP.md). Access control, supply chain, secret management, infrastructure hardening.
+
+## Phase 1 — Bot Access Control (~half day)
+
+- [ ] Telegram user allowlisting — `ALLOWED_USER_IDS` env var, reject unknown users with polite message
+- [ ] Per-user rate limiting — throttle commands to prevent abuse (e.g., 10 commands/minute)
+- [ ] Command audit logging — log user_id + command to stdout for traceability
+
+## Phase 2 — API Security (~half day)
+
+- [x] CORS origins — env-driven allowlist via BackendSettings (PR #80)
+- [x] Input validation — query param bounds, max lengths (PR #80)
+- [ ] API authentication — bot→backend calls require API key (`X-API-Key` header)
+- [ ] Rate limiting middleware — slowapi or custom, per-IP, protect against crawlers on CX22
+
+## Phase 3 — Supply Chain Security (~half day)
+
+- [x] Dependabot — weekly updates for pip + github-actions (#61)
+- [x] Hadolint — Dockerfile linting in CI (#73)
+- [ ] pip-audit in CI — fail on known vulnerabilities in dependencies
+- [ ] Trivy container scan — scan built images in CI, weekly schedule
+- [ ] Poetry lockfile verification — `poetry check --lock` in CI (already in pre-push hook)
+
+## Phase 4 — Secret Management (~half day)
+
+- [ ] Docker secrets for production — bot token, DB password, future Claude API key via files, not env vars
+- [ ] Secret rotation procedure — documented steps for rotating bot token, DB credentials
+- [ ] `.env` audit — verify no secrets committed in repo history (`git log -S`)
+
+## Phase 5 — Infrastructure Hardening (~1 day)
+
+- [ ] SSH hardening — disable root login, disable password auth, key-only
+- [ ] UFW firewall — allow only 22 (SSH), 80/443 (Caddy), deny all else
+- [ ] Fail2ban — protect SSH against brute force
+- [ ] Unattended-upgrades — automatic OS security patches
+- [ ] Docker daemon hardening — no `--privileged`, read-only rootfs where feasible
+
+## Phase 6 — Security Monitoring (~half day)
+
+- [ ] Security headers audit — verify Caddy sets HSTS, X-Content-Type-Options, X-Frame-Options
+- [ ] Failed request logging — 4xx/5xx patterns for anomaly detection
+- [ ] Quarterly dependency audit — manual review of pip-audit + Trivy reports
+
+## Phase 7 — Documentation (~half day, portfolio)
+
+- [ ] SECURITY.md — responsible disclosure policy (even for a personal project, signals maturity)
+- [ ] Threat model — identify assets, trust boundaries, attack surfaces (bot, API, scraper, VPS)
+- [ ] Security checklist for new services — template for adding a service securely


### PR DESCRIPTION
## Summary

Add a dedicated security discipline roadmap, extracting and expanding on what was previously a sub-section of Platform Engineering Phase 6.

## Related issue(s)

Closes #168

## Changes

- Create `docs/roadmaps/security.md` — 7 phases covering bot access control, API security, supply chain, secret management, infrastructure hardening, security monitoring, and documentation
- Add Security row to the discipline table in `docs/ROADMAP.md` (six → seven disciplines)
- Replace Platform Engineering Phase 6 content with cross-reference to the new security roadmap