### PR TITLE
docs: improve systemd setup instructions and roadmap maintenance

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -76,6 +76,14 @@ Backend endpoints driven by Telegram bot needs. See [TELEGRAM_BOT.md](TELEGRAM_B
 - [x] Post-scrape restock notifications — proactive alerts when watched products come back (#138)
 - [x] Bot Dockerfile + Compose service (#121, #44)
 
+### Phase 5a — Bot UX Polish
+
+- [ ] Improve category selection UX (#162)
+- [ ] "Back" button to return to previous results (#163)
+- [ ] Main menu with navigation buttons (#164)
+- [ ] Disable link preview for multi-result messages (#165)
+- [ ] Paginated results with next/previous buttons (#167)
+
 ### Phase 5b — Store Availability
 
 See [STORE_AVAILABILITY.md](STORE_AVAILABILITY.md) for API reference and engineering plan.

--- a/docs/SCRAPER.md
+++ b/docs/SCRAPER.md
@@ -25,20 +25,23 @@ The scraper runs weekly via a **systemd timer** on the VPS. Systemd handles sche
 
 Source files: [`deploy/saq-scraper.service`](../deploy/saq-scraper.service) and [`deploy/saq-scraper.timer`](../deploy/saq-scraper.timer).
 
-Copy to the VPS:
+The service file assumes `WorkingDirectory=/opt/saq-sommelier`. If your repo lives elsewhere, either symlink it:
+
+```bash
+sudo ln -s /path/to/your/saq-sommelier /opt/saq-sommelier
+```
+
+Or edit `WorkingDirectory` in the installed service file after copying.
+
+### Installation
 
 ```bash
 sudo cp deploy/saq-scraper.{service,timer} /etc/systemd/system/
-```
-
-`Persistent=true` in the timer means if the VPS was off during the scheduled time, it runs on next boot.
-
-### Setup
-
-```bash
 sudo systemctl daemon-reload
 sudo systemctl enable --now saq-scraper.timer
 ```
+
+`Persistent=true` in the timer means if the VPS was off during the scheduled time, it runs on next boot. Only the timer is enabled — it triggers the oneshot service on schedule.
 
 ### Checking status
 

--- a/docs/roadmaps/platform-engineering.md
+++ b/docs/roadmaps/platform-engineering.md
@@ -41,6 +41,6 @@ Moved to dedicated [Security Roadmap](security.md). Dependabot (#61) and Hadolin
 ## Phase 7 — Advanced Platform (~2 days, portfolio polish)
 
 - [ ] Grafana dashboards as code — provisioned from JSON files in repo
-- [ ] Port assignment convention — docs/PORTS.md
+- [x] Port assignment convention (#53)
 - [ ] `/health/detailed` endpoint — see [SRE Phase 2](sre.md) for health check design
 - [ ] Terraform GCP — Cloud Run + Cloud SQL + Artifact Registry (documented only, not deployed)

--- a/docs/roadmaps/security.md
+++ b/docs/roadmaps/security.md
@@ -21,8 +21,7 @@ Part of the [project roadmap](../ROADMAP.md). Access control, supply chain, secr
 - [x] Dependabot — weekly updates for pip + github-actions (#61)
 - [x] Hadolint — Dockerfile linting in CI (#73)
 - [ ] pip-audit in CI — fail on known vulnerabilities in dependencies
-- [ ] Trivy container scan — scan built images in CI, weekly schedule
-- [ ] Poetry lockfile verification — `poetry check --lock` in CI (already in pre-push hook)
+- ~~Trivy container scan~~ — descoped (#74)
 
 ## Phase 4 — Secret Management (~half day)
 


### PR DESCRIPTION
## Summary

Improves scraper systemd setup docs with clearer installation steps, and performs roadmap maintenance — adding Phase 5a (Bot UX Polish), marking completed items, and descoping Trivy.

## Related issue(s)

No single issue — housekeeping across docs.

## Changes

- **docs/SCRAPER.md**: Reorganized systemd setup section — added symlink approach for `WorkingDirectory`, reordered steps into a clearer Installation flow, clarified that only the timer is enabled
- **docs/ROADMAP.md**: Added Phase 5a (Bot UX Polish) with issues #162–#167
- **docs/roadmaps/platform-engineering.md**: Marked port assignment convention as done (#53)
- **docs/roadmaps/security.md**: Descoped Trivy container scan (#74), removed Poetry lockfile verification (already in pre-push hook)