### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-02-20
+
 ### Security
 - Telegram user allowlist and per-user rate limiting (#178)
 
@@ -34,5 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docker Compose deployment with Caddy reverse proxy
 - CI pipeline with per-service linting, testing, and coverage thresholds
 
-[Unreleased]: https://github.com/vpatrin/saq-sommelier/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/vpatrin/saq-sommelier/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/vpatrin/saq-sommelier/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/vpatrin/saq-sommelier/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary

Promote `[Unreleased]` changelog entries to `[1.1.0] - 2026-02-20`.

## Related issue(s)

None — release housekeeping.

## Changes

- CHANGELOG.md: `[Unreleased]` → `[1.1.0]`, fresh empty `[Unreleased]` section, updated comparison links