### PR TITLE
fix: scraper parsing bugs — encoding, price comma, log spacing (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Parse prices with thousands separator (e.g. $1,624.75) instead of silently dropping them (#191)
+- Fix encoding mojibake on product names and categories with accented characters (#191)
+
 ## [1.1.0] - 2026-02-20
 
 ### Security

--- a/scraper/src/__main__.py
+++ b/scraper/src/__main__.py
@@ -105,12 +105,12 @@ async def main() -> int:
 
             try:
                 # Download HTML
-                logger.info("[{}/{}] Fetching {}...", i, len(products_to_scrape), entry.url)
+                logger.info("[{}/{}] Fetching {} ...", i, len(products_to_scrape), entry.url)
                 response = await client.get(entry.url)
                 response.raise_for_status()
 
                 # Parse HTML and create a ProductData instance
-                product = parse_product(response.text, url=entry.url)
+                product = parse_product(response.content, url=entry.url)
 
                 # Saves to DB (upsert)
                 await upsert_product(product)

--- a/scraper/src/parser.py
+++ b/scraper/src/parser.py
@@ -53,7 +53,7 @@ class ProductData:
         return dataclasses.asdict(self)
 
 
-def parse_product(html: str, url: str) -> ProductData:
+def parse_product(html: str | bytes, url: str) -> ProductData:
     """Parse a SAQ product page and return structured product data.
 
     Combines data from two sources in the HTML:
@@ -61,7 +61,7 @@ def parse_product(html: str, url: str) -> ProductData:
     - HTML attribute list (region, grape, alcohol, etc.)
 
     Args:
-        html: Raw HTML string of a SAQ product page.
+        html: Raw HTML of a SAQ product page (bytes preferred for correct encoding).
         url: Product page URL (for database record).
 
     Returns:
@@ -126,7 +126,7 @@ def _parse_jsonld(soup: BeautifulSoup, url: str) -> dict[str, Any]:
             price = offers.get("price")
             if price is not None:
                 try:
-                    fields["price"] = float(price)
+                    fields["price"] = float(str(price).replace(",", ""))
                 except (ValueError, TypeError):
                     logger.warning("Bad price value {!r} on {}", price, url)
             currency = offers.get("priceCurrency")

--- a/scraper/tests/conftest.py
+++ b/scraper/tests/conftest.py
@@ -93,6 +93,12 @@ def product_page_html() -> str:
 
 
 @pytest.fixture
+def product_page_html_bytes(product_page_html: str) -> bytes:
+    """Product page HTML as raw bytes (simulates response.content)."""
+    return product_page_html.encode("utf-8")
+
+
+@pytest.fixture
 def minimal_product_html() -> str:
     """Product page with minimal data (out of stock, few fields)."""
     return """<html><head>


### PR DESCRIPTION
## Summary

Three small scraper parsing bugs fixed in one PR:

1. **Encoding mojibake** — pass `response.content` (bytes) instead of `response.text` to BeautifulSoup, so it can detect charset from `<meta>` tags rather than trusting httpx's header-based detection. Fixes `BiÃ¨re` → `Bière`.
2. **Price $1,000+** — strip thousands comma before `float()` conversion. Fixes `"1,624.75"` → `1624.75` instead of silently dropping the price.
3. **Log URL clickability** — add space before ellipsis so terminal link detection works (`Fetching https://...15412657 ...` instead of `...15412657...`).

## Related issue(s)

Closes #191

## Changes

- `scraper/src/parser.py` — accept `str | bytes`, strip commas from price
- `scraper/src/__main__.py` — pass `response.content`, fix log format spacing
- `scraper/tests/conftest.py` — new `product_page_html_bytes` fixture
- `scraper/tests/test_parser.py` — 3 new tests (bytes input, accented chars, comma price)
- `CHANGELOG.md` — two entries under `[Unreleased] > Fixed`

## How to test

```bash
make lint && make test
# All 241 tests pass, lint clean
```

Existing mojibake and missing prices self-heal on next scrape run.