### PR TITLE
chore: add security CI gate — pip-audit + gitleaks (#194)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,67 @@ jobs:
       - run: cd bot && poetry install --no-interaction
       - run: make coverage-bot
 
+  audit-backend:
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.core == 'true' || needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: pip install poetry==${{ env.POETRY_VERSION }}
+      - uses: actions/cache@v5
+        with:
+          path: backend/.venv
+          key: venv-backend-audit-${{ hashFiles('backend/poetry.lock') }}
+      - run: cd backend && poetry install --only main --no-interaction
+      - run: cd backend && .venv/bin/pip install pip-audit && .venv/bin/pip-audit
+
+  audit-scraper:
+    needs: [changes]
+    if: needs.changes.outputs.scraper == 'true' || needs.changes.outputs.core == 'true' || needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: pip install poetry==${{ env.POETRY_VERSION }}
+      - uses: actions/cache@v5
+        with:
+          path: scraper/.venv
+          key: venv-scraper-audit-${{ hashFiles('scraper/poetry.lock') }}
+      - run: cd scraper && poetry install --only main --no-interaction
+      - run: cd scraper && .venv/bin/pip install pip-audit && .venv/bin/pip-audit
+
+  audit-bot:
+    needs: [changes]
+    if: needs.changes.outputs.bot == 'true' || needs.changes.outputs.core == 'true' || needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: pip install poetry==${{ env.POETRY_VERSION }}
+      - uses: actions/cache@v5
+        with:
+          path: bot/.venv
+          key: venv-bot-audit-${{ hashFiles('bot/poetry.lock') }}
+      - run: cd bot && poetry install --only main --no-interaction
+      - run: cd bot && .venv/bin/pip install pip-audit && .venv/bin/pip-audit
+
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   lint:
     needs: [lint-backend, lint-scraper, lint-core, lint-bot, lint-dockerfiles]
     runs-on: ubuntu-latest
@@ -203,6 +264,22 @@ jobs:
             "${{ needs.test-backend.result }}" \
             "${{ needs.test-scraper.result }}" \
             "${{ needs.test-bot.result }}"; do
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              exit 1
+            fi
+          done
+
+  security:
+    needs: [audit-backend, audit-scraper, audit-bot, gitleaks]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - run: |
+          for result in \
+            "${{ needs.audit-backend.result }}" \
+            "${{ needs.audit-scraper.result }}" \
+            "${{ needs.audit-bot.result }}" \
+            "${{ needs.gitleaks.result }}"; do
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               exit 1
             fi

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,2 @@
+[allowlist]
+paths = [".env.example"]

--- a/docs/roadmaps/security.md
+++ b/docs/roadmaps/security.md
@@ -20,13 +20,14 @@ Part of the [project roadmap](../ROADMAP.md). Access control, supply chain, secr
 
 - [x] Dependabot — weekly updates for pip + github-actions (#61)
 - [x] Hadolint — Dockerfile linting in CI (#73)
-- [ ] pip-audit in CI — fail on known vulnerabilities in dependencies
+- [x] pip-audit in CI — fail on known vulnerabilities in dependencies (#194)
 - ~~Trivy container scan~~ — descoped (#74)
 
 ## Phase 4 — Secret Management (~half day)
 
 - [ ] Docker secrets for production — bot token, DB password, future Claude API key via files, not env vars
 - [ ] Secret rotation procedure — documented steps for rotating bot token, DB credentials
+- [x] gitleaks in CI — scan git history for committed secrets (#194)
 - [ ] `.env` audit — verify no secrets committed in repo history (`git log -S`)
 
 ## Phase 5 — Infrastructure Hardening (~1 day)


### PR DESCRIPTION
## Summary

- Add a `security` summary gate to CI (same pattern as `lint` and `test`)
- pip-audit scans Python deps for known CVEs (one job per service)
- gitleaks scans git history for accidentally committed secrets

## Related issue(s)

Closes #194

## Changes

- `.github/workflows/ci.yml` — 4 new jobs (`audit-backend`, `audit-scraper`, `audit-bot`, `gitleaks`) + `security` summary gate
- `.gitleaks.toml` — allowlist `.env.example` (placeholder values, not real secrets)
- `docs/roadmaps/security.md` — check off pip-audit (Phase 3) and gitleaks (Phase 4)

## How to test

CI will run all three gates (`lint`, `test`, `security`) on this PR. All should be green.