### PR TITLE
chore: scope git hooks to changed services (#220)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,13 +1,43 @@
 #!/usr/bin/env bash
-# Pre-commit hook — fast lint only
+# Pre-commit hook — lint only changed services
 # Install with: make install
 
 set -e
 
-echo "🔍 Running pre-commit checks..."
+SERVICES=(backend scraper core bot)
+changed_dirs=$(git diff --cached --name-only | cut -d/ -f1 | sort -u)
 
-echo ""
-make lint
+# Detect which services have staged changes
+to_lint=()
+core_changed=false
+
+for dir in $changed_dirs; do
+  for svc in "${SERVICES[@]}"; do
+    if [ "$dir" = "$svc" ]; then
+      to_lint+=("$svc")
+      [ "$svc" = "core" ] && core_changed=true
+    fi
+  done
+done
+
+# Core cascade: core changes affect all services
+if $core_changed; then
+  to_lint=(backend scraper core bot)
+fi
+
+# Deduplicate
+to_lint=($(printf '%s\n' "${to_lint[@]}" | sort -u))
+
+if [ ${#to_lint[@]} -eq 0 ]; then
+  echo "No service changes staged — skipping lint."
+  exit 0
+fi
+
+echo "🔍 Linting changed services: ${to_lint[*]}"
+
+for svc in "${to_lint[@]}"; do
+  make "lint-$svc"
+done
 
 echo ""
 echo "✅ Lint passed — committing."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pre-push hook — run tests, check lock files.
+# Pre-push hook — test only changed services, check lock files.
 # Install with: make install
 
 set -e
@@ -29,8 +29,40 @@ if [ -n "$(git log "$RANGE" -1 --format=%H -- 'core/db/models*.py' 'core/db/base
   exit 1
 fi
 
-echo ""
-make coverage
+# Detect which services changed on this branch
+TESTABLE=(backend scraper bot)
+changed_dirs=$(git diff --name-only main..HEAD | cut -d/ -f1 | sort -u)
+
+to_test=()
+core_changed=false
+
+for dir in $changed_dirs; do
+  for svc in "${TESTABLE[@]}"; do
+    if [ "$dir" = "$svc" ]; then
+      to_test+=("$svc")
+    fi
+  done
+  [ "$dir" = "core" ] && core_changed=true
+done
+
+# Core cascade: core changes affect all testable services
+if $core_changed; then
+  to_test=(backend scraper bot)
+fi
+
+# Deduplicate
+to_test=($(printf '%s\n' "${to_test[@]}" | sort -u))
+
+if [ ${#to_test[@]} -eq 0 ]; then
+  echo ""
+  echo "No testable service changes — skipping coverage."
+else
+  echo ""
+  echo "🧪 Testing changed services: ${to_test[*]}"
+  for svc in "${to_test[@]}"; do
+    make "coverage-$svc"
+  done
+fi
 
 echo ""
 echo "✅ All checks passed — pushing."


### PR DESCRIPTION
## Summary

Git hooks now only lint/test services that actually changed, instead of running all services every time. Mirrors CI's `dorny/paths-filter` behavior locally.

## Related issue(s)

Closes #220

## Changes

- **Pre-commit**: detects staged files, only runs `make lint-{service}` for affected services. Skips entirely for non-service changes (docs, CI config).
- **Pre-push**: detects branch diff against main, only runs `make coverage-{service}` for changed services. Lock check and migration guard unchanged (already fast/scoped).
- **Core cascade**: if `core/` changed, lint/test all dependent services (backend, scraper, bot) — same logic as CI.
- **Badge generation**: no longer runs on push (individual `coverage-*` targets don't generate badges). Use `make coverage` manually or via `/review`.