### PR TITLE
docs: update stale documentation — testing roadmap, stock_events rename, scraper compliance (#202)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,7 +82,7 @@ saq-sommelier/
 │   ├── db/           SQLAlchemy base, models, session factory
 │   ├── config/       Pydantic Settings (DB connection)
 │   └── logging.py    Loguru setup
-├── scripts/          Exploration tools (not deployed)
+├── deploy/           Systemd unit files for production scheduling
 ├── docs/             Architecture and findings
 └── .github/          CI workflows
 ```
@@ -133,7 +133,7 @@ The design principle: add infrastructure when a bottleneck is measured, not when
 - **Host**: Hetzner CX22 (4GB RAM, 40GB SSD, Debian 13)
 - **Reverse proxy**: Caddy (SSL + routing via victorpatrin.dev subdomains)
 - **Containers**: Docker Compose (`make run` for full dev stack, `make run-db` for bare-metal dev)
-- **Database**: PostgreSQL 16 (shared instance, `wine_sommelier` database)
+- **Database**: PostgreSQL 16 (shared instance, `saq_sommelier` database)
 - **CI**: GitHub Actions (lint + test per service, summary gates)
 
 ## Legal constraints
@@ -147,4 +147,4 @@ SAQ scraping follows a sitemap-first approach for legal defensibility:
 - Never hotlink SAQ images
 - Respect all Disallow rules in robots.txt
 
-Full scraping findings documented in [scripts/FINDINGS.md](../scripts/FINDINGS.md).
+Scraper operations documented in [SCRAPER.md](SCRAPER.md).

--- a/docs/SCRAPER.md
+++ b/docs/SCRAPER.md
@@ -5,11 +5,14 @@
 The scraper is a one-shot batch job, not a long-running service. Each run:
 
 1. Fetches the SAQ sitemap index and all sub-sitemaps
-2. Compares sitemap `lastmod` dates against DB `updated_at` (incremental — skips unchanged products)
-3. Scrapes only new/updated product pages, upserts to PostgreSQL
-4. Detects delisted products (in DB but not in sitemap) and marks them with `delisted_at`
-5. Relists products that reappear in the sitemap
-6. Exits with a status code: `0` (clean), `1` (partial failure), `2` (total failure)
+2. Validates URLs against SAQ's `robots.txt` via `urllib.robotparser` — disallowed URLs are skipped, and the run aborts if `robots.txt` is unreachable (#196)
+3. Filters non-product URLs (only numeric SKU paths are scraped)
+4. Compares sitemap `lastmod` dates against DB `updated_at` (incremental — skips unchanged products)
+5. Scrapes only new/updated product pages, upserts to PostgreSQL
+6. Emits stock events when availability changes (restock or destock) for the notification pipeline
+7. Detects delisted products (in DB but not in sitemap) and marks them with `delisted_at`
+8. Relists products that reappear in the sitemap
+9. Exits with a named status code: `EXIT_SUCCESS` (0), `EXIT_PARTIAL` (1), `EXIT_FAILURE` (2)
 
 A typical incremental run scrapes ~50-200 products instead of the full ~38k catalog.
 
@@ -74,8 +77,19 @@ Delist detection is best-effort. If it fails, it logs an error and the next run 
 
 ## Exit codes
 
-| Code | Meaning | Action needed |
-|------|---------|---------------|
-| `0` | Clean run | None |
-| `1` | Partial failure (some products saved, some failed) | Check logs, usually transient |
-| `2` | Total failure (nothing saved) | Investigate — likely SAQ down or DB unreachable |
+Defined as named constants in `scraper/src/constants.py`.
+
+| Code | Constant | Meaning | Action needed |
+| ---- | -------- | ------- | ------------- |
+| `0` | `EXIT_SUCCESS` | Clean run | None |
+| `1` | `EXIT_PARTIAL` | Partial failure (some products saved, some failed) | Check logs, usually transient |
+| `2` | `EXIT_FAILURE` | Total failure (nothing saved) | Investigate — likely SAQ down or DB unreachable |
+
+## Robots.txt compliance
+
+The scraper programmatically enforces SAQ's `robots.txt` rules (#196):
+
+- On startup, fetches and parses `https://www.saq.com/robots.txt` via `urllib.robotparser`
+- Each URL is checked with `can_fetch()` before scraping — disallowed paths (e.g. `/catalog/product/view/`) are skipped with a warning
+- If `robots.txt` is unreachable, the run **aborts** rather than scraping blind — fail-safe over fail-open
+- Non-product URLs (paths without a numeric SKU) are also filtered out (#188)

--- a/docs/TELEGRAM_BOT.md
+++ b/docs/TELEGRAM_BOT.md
@@ -71,7 +71,7 @@ Telegram API → Bot service → FastAPI backend → PostgreSQL
 
 No auth needed — the bot is the only API consumer for now. If/when the React dashboard is added, we'll revisit auth.
 
-## Restock notifications (#138)
+## Stock event notifications (#138, #212)
 
 Event-driven pub/sub pattern using PostgreSQL as the queue.
 
@@ -84,10 +84,10 @@ Watches are static subscriptions. The scraper detects availability transitions d
 ```
 Scraper upsert                        Bot JobQueue (periodic)
   │                                     │
-  │ old=False, new=True?                │ GET /watches/notifications
+  │ availability changed?               │ GET /watches/notifications
   │         │                           │         │
-  │    INSERT restock_events            │    JOIN restock_events × watches
-  │    (sku, available=True)            │    WHERE processed_at IS NULL
+  │    INSERT stock_events              │    JOIN stock_events × watches
+  │    (sku, available=True/False)      │    WHERE processed_at IS NULL
   │                                     │         │
   │                                     │    Send Telegram messages
   │                                     │         │
@@ -95,7 +95,7 @@ Scraper upsert                        Bot JobQueue (periodic)
   │                                     │    (set processed_at = now)
 ```
 
-### Schema: `restock_events`
+### Schema: `stock_events`
 
 | Column | Type | Notes |
 |---|---|---|
@@ -107,19 +107,11 @@ Scraper upsert                        Bot JobQueue (periodic)
 
 ### Design decisions
 
-- **v1: restock only** — scraper only emits events when `available` flips `False → True`. Users watch products because they want them back. Destock notifications can be added later without schema changes.
+- **Restock + destock** — scraper emits events on both transitions: `False → True` (restock) and `True → False` (destock). Users get notified in both directions.
 - **`processed_at` per-event, not per-user** — at 20 users, one event fans out to all watchers in a single pass. A per-user delivery table (`notifications(event_id, user_id, sent_at)`) would be needed at scale but is over-engineering now.
 - **No `store_id`** — online availability only. In-store availability (Phase 5b) will use a separate `store_inventory` state table with its own event producer. The notification consumer (bot) stays the same.
 - **Bot polls via JobQueue** — the bot already runs 24/7. A periodic check every 6h is simpler than chaining a systemd unit after the scraper timer.
-
-### Task breakdown
-
-| # | Task | Service | Depends on |
-|---|------|---------|-----------|
-| 1 | `RestockEvent` model + migration | core | — |
-| 2 | Emit restock events during upsert | scraper | Task 1 |
-| 3 | Pending notifications + ack endpoints | backend | Task 1 |
-| 4 | Notification consumer (JobQueue) | bot | Task 3 |
+- **Periodic cleanup** — old processed events are purged to prevent table bloat (#158).
 
 ### Future: in-store availability
 
@@ -138,7 +130,7 @@ Endpoints the bot needs from the backend:
 | `/watch` | `POST /watches`, `DELETE /watches/{sku}` | Done (#101, PR #112) |
 | `/alerts` | `GET /watches?user_id=` | Done (#101, PR #112) |
 | Weekly digest | `GET /products?sort=recent` | Done (PR #107) |
-| Restock alerts | `GET /watches/notifications`, `POST /watches/notifications/ack` | #138 |
+| Stock alerts | `GET /watches/notifications`, `POST /watches/notifications/ack` | Done (#138, #212) |
 
 ## What's NOT in scope (yet)
 

--- a/docs/roadmaps/testing.md
+++ b/docs/roadmaps/testing.md
@@ -4,10 +4,10 @@ Part of the [project roadmap](../ROADMAP.md). Multi-layer test strategy: unit �
 
 ## Phase 1 — Unit Tests (~2 days)
 
-- [ ] Test infrastructure — conftest files, pytest markers (unit/integration/ml/slow), pyproject.toml config
-- [x] Scraper unit tests — parser, sitemap fetcher + saved HTML fixtures (#20)
-- [ ] Backend unit tests — scoring service, guardrails, LLM service (mocked Claude)
-- [ ] Bot unit tests — handlers (mocked Telegram), formatters
+- [x] Test infrastructure — conftest files in all 3 services, pyproject.toml config. Remaining: pytest markers (unit/integration/ml/slow) (#204)
+- [x] Scraper unit tests — parser, sitemap fetcher, DB writer, config, incremental logic (#20)
+- [x] Backend unit tests — products (list/detail/search/facets/sort/random), watches CRUD, health
+- [x] Bot unit tests — handlers, formatters, middleware, keyboards, config, API client, notifications
 
 ## Phase 2 — Integration Tests (~1.5 days)
 
@@ -43,4 +43,4 @@ Part of the [project roadmap](../ROADMAP.md). Multi-layer test strategy: unit �
 ## Phase 7 — Test Culture (ongoing)
 
 - [ ] docs/TESTING.md — coverage targets, classification table, bug-to-test rule
-- [ ] Product factory (`tests/fixtures/factory.py`) — `make_red()`, `make_white()`, `make_wines(n)`
+- [ ] Product factory (`tests/fixtures/factory.py`) — `make_red()`, `make_white()`, `make_wines(n)` → see #204


### PR DESCRIPTION
## Summary

Docs sweep to catch up with recent shipped work (v1.1.0 + post-deploy PRs). Fixes stale references, marks completed test phases, and documents new scraper features.

## Related issue(s)

Closes #202

## Changes

**docs/roadmaps/testing.md**
- Phase 1: mark all 4 items as complete (was 1/4) — backend has 54 tests, bot has ~75, scraper has 57
- Phase 7: cross-reference #204 for product factory work

**docs/TELEGRAM_BOT.md**
- Rename `restock_events` → `stock_events` throughout (PR #216)
- Update section title and data flow to reflect both restock + destock support (#212)
- Remove completed task breakdown table (all 4 tasks shipped)
- Add periodic cleanup design decision (#158)
- Mark stock alerts as Done in API dependencies table

**docs/SCRAPER.md**
- Expand "How it works" with robots.txt validation, URL filtering, stock event emission
- Reference named exit code constants (`scraper/src/constants.py`)
- Add new "Robots.txt compliance" section (#196, #188)

**docs/ARCHITECTURE.md**
- Fix `scripts/` → `deploy/` in project structure (scripts removed in PR #48)
- Fix database name `wine_sommelier` → `saq_sommelier`
- Fix dead link to `scripts/FINDINGS.md` → point to `SCRAPER.md`