### PR TITLE
feat: targeted store availability fetch (#254)

### DIFF
--- a/.github/badges/coverage.svg
+++ b/.github/badges/coverage.svg
@@ -9,7 +9,7 @@
   <g mask="url(#a)">
     <rect width="62.0" height="20" fill="#555"/>
     <rect x="62.0" width="83.5" height="20" fill="#a3c51c"/>
-    <rect x="145.5" width="83.5" height="20" fill="#dfb317"/>
+    <rect x="145.5" width="83.5" height="20" fill="#a3c51c"/>
     <rect x="229.0" width="57.5" height="20" fill="#4c1"/>
     <rect width="286.5" height="20" fill="url(#b)"/>
   </g>
@@ -18,8 +18,8 @@
     <text x="31.0" y="14">coverage</text>
     <text x="103.75" y="15" fill="#010101" fill-opacity=".3">backend 87%</text>
     <text x="103.75" y="14">backend 87%</text>
-    <text x="187.25" y="15" fill="#010101" fill-opacity=".3">scraper 74%</text>
-    <text x="187.25" y="14">scraper 74%</text>
+    <text x="187.25" y="15" fill="#010101" fill-opacity=".3">scraper 75%</text>
+    <text x="187.25" y="14">scraper 75%</text>
     <text x="257.75" y="15" fill="#010101" fill-opacity=".3">bot 94%</text>
     <text x="257.75" y="14">bot 94%</text>
   </g>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Targeted store availability fetch — checks only preferred stores via lat/lng proximity instead of paginating all ~400 stores (#254)
 - HTTP 404s logged as warnings instead of errors, counted separately in run summary (#197)
 - Flat wine type filter keyboard (Rouge/Blanc/Rosé/Bulles) replaces two-level family hierarchy (#167)
 - Skip ~1,500 non-product URLs (recipes, accessories) during scrape, saving ~50 min per run (#188)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -87,6 +87,7 @@ See [specs/STORE_AVAILABILITY.md](specs/STORE_AVAILABILITY.md) for API reference
 - [x] `/stores` API endpoints — nearby + user preference CRUD (#232)
 - [x] `/mystores` bot command — GPS-based store picker (#233)
 - [x] Per-product store availability checker — GraphQL resolve + AJAX fetch + diff alerts (#149)
+- [x] Targeted store fetch — lat/lng proximity sorting replaces full pagination (#254)
 - ~~Filter by store availability (#150)~~ — out of scope, SAQ.com does this natively
 
 ### Phase 5c — Watch UX

--- a/scraper/src/availability.py
+++ b/scraper/src/availability.py
@@ -11,6 +11,7 @@ from .db import (
     emit_stock_event,
     get_product_availability,
     get_watched_skus,
+    get_watched_store_coords,
     upsert_product_availability,
 )
 
@@ -113,6 +114,60 @@ async def fetch_store_availability(client: httpx.AsyncClient, magento_id: int) -
     return store_qty
 
 
+async def fetch_targeted_availability(
+    client: httpx.AsyncClient,
+    magento_id: int,
+    target_stores: dict[str, tuple[float, float]],
+) -> dict[str, int]:
+    """Fetch stock for specific stores using lat/lng proximity sorting.
+
+    Each request with a store's coordinates returns that store first among 10 results.
+    Deduplicates: if store B appears in store A's response, skip store B's request.
+    Absence from results means qty 0.
+    """
+    store_qty: dict[str, int] = {}
+    found: set[str] = set()
+
+    for store_id, (lat, lng) in target_stores.items():
+        if store_id in found:
+            continue
+
+        params = {
+            "context": "product",
+            "id": str(magento_id),
+            "latitude": str(lat),
+            "longitude": str(lng),
+        }
+        try:
+            response = await client.get(
+                _STORE_AVAILABILITY_URL,
+                params=params,
+                headers={"X-Requested-With": "XMLHttpRequest"},
+            )
+            response.raise_for_status()
+            data = response.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            logger.error(
+                "Targeted availability failed (id={}, store={}): {}", magento_id, store_id, exc
+            )
+            continue
+
+        for store in data.get("list", []):
+            sid = store.get("identifier")
+            if sid and sid in target_stores:
+                store_qty[sid] = int(store.get("qty", 0))
+                found.add(sid)
+
+        await asyncio.sleep(settings.RATE_LIMIT_SECONDS)
+
+    # Target stores absent from all responses have qty 0
+    for store_id in target_stores:
+        if store_id not in store_qty:
+            store_qty[store_id] = 0
+
+    return store_qty
+
+
 async def run_availability_check(client: httpx.AsyncClient) -> int:
     """Check online + store availability for all watched SKUs.
 
@@ -133,6 +188,13 @@ async def run_availability_check(client: httpx.AsyncClient) -> int:
     unresolved = set(skus) - set(graphql_products.keys())
     if unresolved:
         logger.warning("Could not resolve {} SKUs: {}", len(unresolved), unresolved)
+
+    # Resolve which stores to check — all stores from user preferences
+    target_stores = await get_watched_store_coords()
+    if target_stores:
+        logger.info("Targeting {} preferred stores", len(target_stores))
+    else:
+        logger.info("No store preferences — online-only checks")
 
     online_restocks = 0
     online_destocks = 0
@@ -161,18 +223,22 @@ async def run_availability_check(client: httpx.AsyncClient) -> int:
                 label = "RESTOCK" if new_online else "DESTOCK"
                 logger.info("{} (online): {}", label, sku)
 
-            # Store availability — ALWAYS check, regardless of online stock_status.
+            # Store availability — targeted fetch for preferred stores only.
             # Stores can carry stock when online is OUT_OF_STOCK (verified with SKU 880500).
-            new_qty = await fetch_store_availability(client, gql.magento_id)
-            logger.info("  {} stores carrying stock", len(new_qty))
+            if target_stores:
+                new_qty = await fetch_targeted_availability(client, gql.magento_id, target_stores)
+                in_stock = sum(1 for v in new_qty.values() if v > 0)
+                logger.info("  {}/{} target stores have stock", in_stock, len(target_stores))
+            else:
+                new_qty = {}
 
             # Store diff: only emit events if we have a baseline (not first check).
             # First check establishes the snapshot — no diff to compare.
+            # Diff only target stores — stores removed from preferences are ignored.
             if is_first_check:
                 baselines += 1
-            else:
-                all_stores = set(old_qty.keys()) | set(new_qty.keys())
-                for store_id in all_stores:
+            elif target_stores:
+                for store_id in target_stores:
                     old_val = old_qty.get(store_id, 0)
                     new_val = new_qty.get(store_id, 0)
 

--- a/scraper/src/db.py
+++ b/scraper/src/db.py
@@ -8,6 +8,7 @@ from core.db.models import (
     ProductAvailability,
     StockEvent,
     Store,
+    UserStorePreference,
     Watch,
 )
 from loguru import logger
@@ -169,6 +170,25 @@ async def get_watched_skus() -> list[str]:
         stmt = select(Watch.sku).distinct()
         result = await session.execute(stmt)
         return [row[0] for row in result.all()]
+
+
+async def get_watched_store_coords() -> dict[str, tuple[float, float]]:
+    """Get coordinates for all stores in user preferences.
+
+    Returns {saq_store_id: (latitude, longitude)} for stores that have coordinates.
+    """
+    async with _SessionLocal() as session:
+        stmt = (
+            select(Store.saq_store_id, Store.latitude, Store.longitude)
+            .join(
+                UserStorePreference,
+                Store.saq_store_id == UserStorePreference.saq_store_id,
+            )
+            .where(Store.latitude.isnot(None), Store.longitude.isnot(None))
+            .distinct()
+        )
+        result = await session.execute(stmt)
+        return {row[0]: (row[1], row[2]) for row in result.all()}
 
 
 async def get_product_availability(sku: str) -> tuple[bool | None, dict[str, int]]:

--- a/scraper/tests/test_availability.py
+++ b/scraper/tests/test_availability.py
@@ -7,9 +7,13 @@ import pytest
 from src.availability import (
     GraphQLProduct,
     fetch_store_availability,
+    fetch_targeted_availability,
     resolve_graphql_products,
     run_availability_check,
 )
+
+_STORE_A = {"23009": (45.5, -73.6)}
+_TARGET_STORES = {"23009": (45.5, -73.6), "23132": (45.6, -73.7)}
 
 
 def _make_response(data: dict, status_code: int = 200) -> httpx.Response:
@@ -163,6 +167,101 @@ class TestFetchStoreAvailability:
         assert result == {"23009": 0}
 
 
+class TestFetchTargetedAvailability:
+    @pytest.mark.asyncio
+    async def test_finds_target_store(self) -> None:
+        ajax_response = {
+            "list": [
+                {"identifier": "23009", "qty": 44},
+                {"identifier": "99999", "qty": 5},
+            ]
+        }
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.get.return_value = _make_response(ajax_response)
+
+        with patch("src.availability.asyncio.sleep"):
+            result = await fetch_targeted_availability(
+                client, magento_id=42, target_stores={"23009": (45.5, -73.6)}
+            )
+
+        assert result == {"23009": 44}
+        assert client.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_nearby_stores(self) -> None:
+        """Two target stores appear in same response — second request skipped."""
+        ajax_response = {
+            "list": [
+                {"identifier": "23009", "qty": 44},
+                {"identifier": "23132", "qty": 12},
+            ]
+        }
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.get.return_value = _make_response(ajax_response)
+
+        with patch("src.availability.asyncio.sleep"):
+            result = await fetch_targeted_availability(
+                client, magento_id=42, target_stores=_TARGET_STORES
+            )
+
+        assert result == {"23009": 44, "23132": 12}
+        assert client.get.call_count == 1  # only one request needed
+
+    @pytest.mark.asyncio
+    async def test_absent_store_gets_zero(self) -> None:
+        """Target store not in AJAX response → qty 0."""
+        ajax_response = {"list": [{"identifier": "99999", "qty": 10}]}
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.get.return_value = _make_response(ajax_response)
+
+        with patch("src.availability.asyncio.sleep"):
+            result = await fetch_targeted_availability(
+                client, magento_id=42, target_stores={"23009": (45.5, -73.6)}
+            )
+
+        assert result == {"23009": 0}
+
+    @pytest.mark.asyncio
+    async def test_http_error_returns_zero(self) -> None:
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.get.side_effect = httpx.HTTPError("timeout")
+
+        result = await fetch_targeted_availability(
+            client, magento_id=42, target_stores={"23009": (45.5, -73.6)}
+        )
+
+        assert result == {"23009": 0}
+
+    @pytest.mark.asyncio
+    async def test_passes_lat_lng_params(self) -> None:
+        ajax_response = {"list": [{"identifier": "23009", "qty": 10}]}
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.get.return_value = _make_response(ajax_response)
+
+        with patch("src.availability.asyncio.sleep"):
+            await fetch_targeted_availability(
+                client, magento_id=42, target_stores={"23009": (45.5, -73.6)}
+            )
+
+        call_params = client.get.call_args[1]["params"]
+        assert call_params["latitude"] == "45.5"
+        assert call_params["longitude"] == "-73.6"
+
+    @pytest.mark.asyncio
+    async def test_rate_limits_between_requests(self) -> None:
+        """Each request is followed by a sleep, even if store was found."""
+        # Two stores far apart — need separate requests
+        resp1 = {"list": [{"identifier": "23009", "qty": 10}]}
+        resp2 = {"list": [{"identifier": "23132", "qty": 5}]}
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.get.side_effect = [_make_response(resp1), _make_response(resp2)]
+
+        with patch("src.availability.asyncio.sleep") as mock_sleep:
+            await fetch_targeted_availability(client, magento_id=42, target_stores=_TARGET_STORES)
+
+        assert mock_sleep.call_count == 2
+
+
 class TestRunAvailabilityCheck:
     @pytest.mark.asyncio
     async def test_skips_when_no_watched_skus(self) -> None:
@@ -181,8 +280,15 @@ class TestRunAvailabilityCheck:
         with (
             patch("src.availability.get_watched_skus", return_value=["15483332"]),
             patch("src.availability.resolve_graphql_products", return_value=gql),
-            patch("src.availability.fetch_store_availability", return_value={"23009": 10}),
-            patch("src.availability.get_product_availability", return_value=(True, {"23009": 0})),
+            patch("src.availability.get_watched_store_coords", return_value=_TARGET_STORES),
+            patch(
+                "src.availability.fetch_targeted_availability",
+                return_value={"23009": 10, "23132": 0},
+            ),
+            patch(
+                "src.availability.get_product_availability",
+                return_value=(True, {"23009": 0, "23132": 0}),
+            ),
             patch("src.availability.upsert_product_availability") as mock_upsert,
             patch("src.availability.emit_stock_event") as mock_emit,
             patch("src.availability.asyncio.sleep"),
@@ -192,7 +298,7 @@ class TestRunAvailabilityCheck:
         assert events == 1
         mock_emit.assert_called_once_with("15483332", available=True, saq_store_id="23009")
         mock_upsert.assert_called_once_with(
-            "15483332", online_available=True, store_qty={"23009": 10}
+            "15483332", online_available=True, store_qty={"23009": 10, "23132": 0}
         )
 
     @pytest.mark.asyncio
@@ -203,7 +309,8 @@ class TestRunAvailabilityCheck:
         with (
             patch("src.availability.get_watched_skus", return_value=["15483332"]),
             patch("src.availability.resolve_graphql_products", return_value=gql),
-            patch("src.availability.fetch_store_availability", return_value={"23009": 0}),
+            patch("src.availability.get_watched_store_coords", return_value=_STORE_A),
+            patch("src.availability.fetch_targeted_availability", return_value={"23009": 0}),
             patch("src.availability.get_product_availability", return_value=(True, {"23009": 10})),
             patch("src.availability.upsert_product_availability"),
             patch("src.availability.emit_stock_event") as mock_emit,
@@ -222,7 +329,7 @@ class TestRunAvailabilityCheck:
         with (
             patch("src.availability.get_watched_skus", return_value=["15483332"]),
             patch("src.availability.resolve_graphql_products", return_value=gql),
-            patch("src.availability.fetch_store_availability", return_value={}),
+            patch("src.availability.get_watched_store_coords", return_value={}),
             patch("src.availability.get_product_availability", return_value=(False, {})),
             patch("src.availability.upsert_product_availability"),
             patch("src.availability.emit_stock_event") as mock_emit,
@@ -241,7 +348,8 @@ class TestRunAvailabilityCheck:
         with (
             patch("src.availability.get_watched_skus", return_value=["15483332"]),
             patch("src.availability.resolve_graphql_products", return_value=gql),
-            patch("src.availability.fetch_store_availability", return_value={"23009": 10}),
+            patch("src.availability.get_watched_store_coords", return_value=_STORE_A),
+            patch("src.availability.fetch_targeted_availability", return_value={"23009": 10}),
             patch("src.availability.get_product_availability", return_value=(True, {"23009": 10})),
             patch("src.availability.upsert_product_availability") as mock_upsert,
             patch("src.availability.emit_stock_event") as mock_emit,
@@ -251,7 +359,6 @@ class TestRunAvailabilityCheck:
 
         assert events == 1
         mock_emit.assert_called_once_with("15483332", available=False)
-        # Store fetch still happens — stores can have stock when online is OUT_OF_STOCK
         mock_upsert.assert_called_once_with(
             "15483332", online_available=False, store_qty={"23009": 10}
         )
@@ -265,17 +372,18 @@ class TestRunAvailabilityCheck:
         with (
             patch("src.availability.get_watched_skus", return_value=["15483332"]),
             patch("src.availability.resolve_graphql_products", return_value=gql),
+            patch("src.availability.get_watched_store_coords", return_value=_STORE_A),
             patch("src.availability.get_product_availability", return_value=(None, {})),
             patch("src.availability.upsert_product_availability"),
             patch(
-                "src.availability.fetch_store_availability", return_value={"23009": 5}
-            ) as mock_fetch_store,
+                "src.availability.fetch_targeted_availability", return_value={"23009": 5}
+            ) as mock_fetch,
             patch("src.availability.emit_stock_event"),
             patch("src.availability.asyncio.sleep"),
         ):
             await run_availability_check(client)
 
-        mock_fetch_store.assert_called_once_with(client, 42)
+        mock_fetch.assert_called_once_with(client, 42, _STORE_A)
 
     @pytest.mark.asyncio
     async def test_no_events_when_unchanged(self) -> None:
@@ -285,7 +393,8 @@ class TestRunAvailabilityCheck:
         with (
             patch("src.availability.get_watched_skus", return_value=["15483332"]),
             patch("src.availability.resolve_graphql_products", return_value=gql),
-            patch("src.availability.fetch_store_availability", return_value={"23009": 10}),
+            patch("src.availability.get_watched_store_coords", return_value=_STORE_A),
+            patch("src.availability.fetch_targeted_availability", return_value={"23009": 10}),
             patch("src.availability.get_product_availability", return_value=(True, {"23009": 10})),
             patch("src.availability.upsert_product_availability"),
             patch("src.availability.emit_stock_event") as mock_emit,
@@ -305,8 +414,9 @@ class TestRunAvailabilityCheck:
         with (
             patch("src.availability.get_watched_skus", return_value=["15483332"]),
             patch("src.availability.resolve_graphql_products", return_value=gql),
+            patch("src.availability.get_watched_store_coords", return_value=_TARGET_STORES),
             patch(
-                "src.availability.fetch_store_availability",
+                "src.availability.fetch_targeted_availability",
                 return_value={"23009": 44, "23132": 12},
             ),
             patch("src.availability.get_product_availability", return_value=(None, {})),
@@ -333,3 +443,75 @@ class TestRunAvailabilityCheck:
             pytest.raises(RuntimeError, match="resolved 0 of 1"),
         ):
             await run_availability_check(client)
+
+    @pytest.mark.asyncio
+    async def test_online_only_when_no_store_preferences(self) -> None:
+        """No store preferences → skip store fetch, online events still fire."""
+        client = AsyncMock(spec=httpx.AsyncClient)
+        gql = {"15483332": GraphQLProduct(magento_id=42, stock_status="IN_STOCK")}
+
+        with (
+            patch("src.availability.get_watched_skus", return_value=["15483332"]),
+            patch("src.availability.resolve_graphql_products", return_value=gql),
+            patch("src.availability.get_watched_store_coords", return_value={}),
+            patch("src.availability.get_product_availability", return_value=(False, {})),
+            patch("src.availability.upsert_product_availability") as mock_upsert,
+            patch("src.availability.emit_stock_event") as mock_emit,
+            patch("src.availability.asyncio.sleep"),
+        ):
+            events = await run_availability_check(client)
+
+        assert events == 1
+        mock_emit.assert_called_once_with("15483332", available=True)
+        mock_upsert.assert_called_once_with("15483332", online_available=True, store_qty={})
+
+    @pytest.mark.asyncio
+    async def test_new_store_preference_triggers_restock(self) -> None:
+        """User adds store B between runs — B has stock → RESTOCK event."""
+        client = AsyncMock(spec=httpx.AsyncClient)
+        gql = {"15483332": GraphQLProduct(magento_id=42, stock_status="IN_STOCK")}
+
+        with (
+            patch("src.availability.get_watched_skus", return_value=["15483332"]),
+            patch("src.availability.resolve_graphql_products", return_value=gql),
+            patch("src.availability.get_watched_store_coords", return_value=_TARGET_STORES),
+            patch(
+                "src.availability.fetch_targeted_availability",
+                return_value={"23009": 10, "23132": 5},
+            ),
+            # Old snapshot only had store 23009
+            patch("src.availability.get_product_availability", return_value=(True, {"23009": 10})),
+            patch("src.availability.upsert_product_availability"),
+            patch("src.availability.emit_stock_event") as mock_emit,
+            patch("src.availability.asyncio.sleep"),
+        ):
+            events = await run_availability_check(client)
+
+        assert events == 1
+        mock_emit.assert_called_once_with("15483332", available=True, saq_store_id="23132")
+
+    @pytest.mark.asyncio
+    async def test_removed_store_preference_no_false_destock(self) -> None:
+        """User removes store B — no false DESTOCK event for B."""
+        client = AsyncMock(spec=httpx.AsyncClient)
+        gql = {"15483332": GraphQLProduct(magento_id=42, stock_status="IN_STOCK")}
+
+        with (
+            patch("src.availability.get_watched_skus", return_value=["15483332"]),
+            patch("src.availability.resolve_graphql_products", return_value=gql),
+            # Only store 23009 in preferences now (23132 removed)
+            patch("src.availability.get_watched_store_coords", return_value=_STORE_A),
+            patch("src.availability.fetch_targeted_availability", return_value={"23009": 10}),
+            # Old snapshot had both stores
+            patch(
+                "src.availability.get_product_availability",
+                return_value=(True, {"23009": 10, "23132": 5}),
+            ),
+            patch("src.availability.upsert_product_availability"),
+            patch("src.availability.emit_stock_event") as mock_emit,
+            patch("src.availability.asyncio.sleep"),
+        ):
+            events = await run_availability_check(client)
+
+        assert events == 0
+        mock_emit.assert_not_called()


### PR DESCRIPTION
## Summary

Replace full store pagination (~11 pages × 2s per product) with targeted lat/lng proximity fetches — only checks stores in user preferences. Reduces availability check time from ~3 min to ~30s for typical usage (3 stores × 6 SKUs).

## Related issue(s)

Closes #254

## Changes

- `scraper/src/db.py`: add `get_watched_store_coords()` — queries all distinct preferred stores with coordinates
- `scraper/src/availability.py`: add `fetch_targeted_availability()` — one AJAX request per target store using its lat/lng, with deduplication (nearby stores covered by one response)
- `scraper/src/availability.py`: modify `run_availability_check()` — use targeted fetch when store preferences exist, skip store fetch entirely when none; diff loop iterates only target stores to prevent false DESTOCK on removed preferences
- `scraper/tests/test_availability.py`: 6 new tests for targeted fetch, 3 new edge case tests (online-only, new store RESTOCK, removed store no false DESTOCK), all existing tests updated
- CHANGELOG + ROADMAP updated

## How to test

```bash
cd scraper && poetry run python -m pytest tests/test_availability.py -v
make lint-scraper
```