### PR TITLE
feat: group stock notifications by product and include online status (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Group stock notifications by product — one message per wine listing all affected stores, with online availability hint (#256)
 - Targeted store availability fetch — checks only preferred stores via lat/lng proximity instead of paginating all ~400 stores (#254)
 - HTTP 404s logged as warnings instead of errors, counted separately in run summary (#197)
 - Flat wine type filter keyboard (Rouge/Blanc/Rosé/Bulles) replaces two-level family hierarchy (#167)

--- a/backend/schemas/watch.py
+++ b/backend/schemas/watch.py
@@ -31,7 +31,7 @@ class WatchWithProduct(BaseModel):
 
 
 class PendingNotification(BaseModel):
-    """One user×event pair — the bot sends one Telegram message per item."""
+    """One user×event pair — grouped by (user, sku) on the bot side for sending."""
 
     event_id: int
     sku: str
@@ -42,6 +42,8 @@ class PendingNotification(BaseModel):
     # NULL = online event, non-NULL = in-store event
     saq_store_id: str | None = None
     store_name: str | None = None
+    # Current online availability from products table (independent of event type)
+    online_available: bool | None = None
 
 
 class AckRequest(BaseModel):

--- a/backend/services/watches.py
+++ b/backend/services/watches.py
@@ -60,6 +60,7 @@ async def list_pending_notifications(db: AsyncSession) -> list[PendingNotificati
             detected_at=event.detected_at,
             saq_store_id=event.saq_store_id,
             store_name=store.name if store else None,
+            online_available=product.availability if product else None,
         )
         for event, watch, product, store in rows
     ]

--- a/backend/tests/test_watches.py
+++ b/backend/tests/test_watches.py
@@ -268,6 +268,7 @@ def test_pending_notifications_success():
     assert data[0]["user_id"] == "tg:123"
     assert data[0]["available"] is True
     assert data[0]["product_name"] == "Château Test"
+    assert data[0]["online_available"] is True
     assert "detected_at" in data[0]
 
 
@@ -299,6 +300,7 @@ def test_pending_notifications_product_missing():
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data[0]["product_name"] is None
+    assert data[0]["online_available"] is None
 
 
 def test_pending_notifications_destock_event():

--- a/bot/bot/formatters.py
+++ b/bot/bot/formatters.py
@@ -78,26 +78,52 @@ def format_watch_list(watches: list[dict[str, Any]]) -> str:
     return f"{header}\n\n{'\n\n'.join(lines)}"
 
 
-def format_restock_notification(notification: dict[str, Any]) -> str:
-    """Format a proactive restock alert sent by the bot."""
-    sku = notification["sku"]
-    name = notification.get("product_name") or sku
+def format_stock_notification(notifications: list[dict[str, Any]]) -> str:
+    """Format a grouped stock alert — one message per (user, product, direction)."""
+    first = notifications[0]
+    sku = first["sku"]
+    name = first.get("product_name") or sku
     url = f"{SAQ_BASE_URL}/{sku}"
-    store_name = notification.get("store_name")
-    if store_name:
-        return f"\U0001f377 Back in stock at *{store_name}*: [{name}]({url})"
-    return f"\U0001f377 Back in stock: [{name}]({url})"
+    is_restock = first["available"]
+    online_available = first.get("online_available")
+
+    stores: list[str] = []
+    has_online_event = False
+    for n in notifications:
+        loc = _event_location(n)
+        if loc:
+            stores.append(loc)
+        else:
+            has_online_event = True
+
+    # Online-only — no bullet list
+    if not stores and has_online_event:
+        verb = "Back in stock online" if is_restock else "Out of stock online"
+        emoji = "\U0001f377" if is_restock else "\U0001f4e6"
+        return f"{emoji} {verb}: [{name}]({url})"
+
+    emoji = "\U0001f377" if is_restock else "\U0001f4e6"
+    verb = "Back in stock" if is_restock else "Out of stock"
+    lines = [f"{emoji} {verb}: [{name}]({url})"]
+
+    if has_online_event:
+        lines.append("  \u2022 Online")
+    for loc in stores:
+        lines.append(f"  \u2022 {loc}")
+
+    # Online availability hint when no online event in the group
+    if not has_online_event and online_available is True:
+        hint = "Also available online" if is_restock else "Still available online"
+        lines.append(f"\U0001f310 {hint}")
+
+    return "\n".join(lines)
 
 
-def format_destock_notification(notification: dict[str, Any]) -> str:
-    """Format a proactive destock alert sent by the bot."""
-    sku = notification["sku"]
-    name = notification.get("product_name") or sku
-    url = f"{SAQ_BASE_URL}/{sku}"
-    store_name = notification.get("store_name")
-    if store_name:
-        return f"\U0001f4e6 Out of stock at *{store_name}*: [{name}]({url})"
-    return f"\U0001f4e6 Out of stock: [{name}]({url})"
+def _event_location(n: dict[str, Any]) -> str | None:
+    """Return store name for store events, None for online events."""
+    if n.get("saq_store_id") is None:
+        return None
+    return n.get("store_name") or n["saq_store_id"]
 
 
 # ── Stores ────────────────────────────────────────────────────

--- a/bot/bot/handlers/notifications.py
+++ b/bot/bot/handlers/notifications.py
@@ -1,9 +1,11 @@
+from collections import defaultdict
+
 from loguru import logger
 from telegram.ext import ContextTypes
 
 from bot.api_client import BackendAPIError, BackendClient, BackendUnavailableError
 from bot.config import USER_ID_PREFIX
-from bot.formatters import format_destock_notification, format_restock_notification
+from bot.formatters import format_stock_notification
 
 
 def _parse_user_id(user_id: str) -> int | None:
@@ -15,7 +17,7 @@ def _parse_user_id(user_id: str) -> int | None:
 
 
 async def _process_batch(api: BackendClient, context: ContextTypes.DEFAULT_TYPE) -> bool:
-    """Fetch one batch of notifications, send messages, ack. Returns True if batch was non-empty."""
+    """Fetch one batch of notifications, group by product, send messages, ack."""
     try:
         notifications = await api.get_pending_notifications()
     except (BackendUnavailableError, BackendAPIError):
@@ -26,15 +28,19 @@ async def _process_batch(api: BackendClient, context: ContextTypes.DEFAULT_TYPE)
         return False
 
     acked_ids: list[int] = []
+
+    # Group by (chat_id, sku, available) — one message per product per direction
+    groups: dict[tuple[int, str, bool], list[dict]] = defaultdict(list)
     for notif in notifications:
         chat_id = _parse_user_id(notif["user_id"])
         if chat_id is None:
             logger.warning("Skipping notification with unknown user_id: {}", notif["user_id"])
-            acked_ids.append(notif["event_id"])  # ack to prevent infinite re-fetch
+            acked_ids.append(notif["event_id"])
             continue
-        fmt = format_restock_notification if notif["available"] else format_destock_notification
-        text = fmt(notif)
+        groups[(chat_id, notif["sku"], notif["available"])].append(notif)
 
+    for (chat_id, _sku, _available), group in groups.items():
+        text = format_stock_notification(group)
         try:
             await context.bot.send_message(
                 chat_id=chat_id, text=text, parse_mode="Markdown", disable_web_page_preview=True
@@ -43,7 +49,7 @@ async def _process_batch(api: BackendClient, context: ContextTypes.DEFAULT_TYPE)
             logger.warning("Failed to send notification to chat_id={}", chat_id)
 
         # Ack regardless — if send failed (user blocked bot), retrying forever is worse
-        acked_ids.append(notif["event_id"])
+        acked_ids.extend(n["event_id"] for n in group)
 
     if acked_ids:
         try:
@@ -51,7 +57,7 @@ async def _process_batch(api: BackendClient, context: ContextTypes.DEFAULT_TYPE)
             logger.info("Acked {} event(s)", len(acked_ids))
         except (BackendUnavailableError, BackendAPIError):
             logger.warning("Failed to ack {} events — will retry next poll", len(acked_ids))
-            return False  # stop draining — ack failed, next batch would re-fetch same events
+            return False
 
     return True
 

--- a/bot/tests/test_formatters.py
+++ b/bot/tests/test_formatters.py
@@ -1,8 +1,7 @@
 from bot.formatters import (
-    format_destock_notification,
     format_product_line,
     format_product_list,
-    format_restock_notification,
+    format_stock_notification,
     format_watch_list,
 )
 
@@ -156,59 +155,94 @@ class TestFormatWatchList:
         assert "since Jan 1" in result
 
 
-class TestFormatRestockNotification:
-    def test_with_product_name(self):
-        notif = {"sku": "10327701", "product_name": "Mouton Cadet"}
-        result = format_restock_notification(notif)
+def _notif(**overrides):
+    defaults = {
+        "sku": "10327701",
+        "product_name": "Mouton Cadet",
+        "available": True,
+        "saq_store_id": None,
+        "store_name": None,
+        "online_available": True,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+class TestFormatStockNotification:
+    def test_single_store_restock(self):
+        notifs = [_notif(saq_store_id="23009", store_name="Du Parc")]
+        result = format_stock_notification(notifs)
         assert "Back in stock" in result
         assert "[Mouton Cadet](https://www.saq.com/fr/10327701)" in result
+        assert "\u2022 Du Parc" in result
 
-    def test_without_product_name(self):
-        notif = {"sku": "10327701", "product_name": None}
-        result = format_restock_notification(notif)
+    def test_multiple_stores_restock(self):
+        notifs = [
+            _notif(saq_store_id="23009", store_name="Du Parc"),
+            _notif(saq_store_id="23010", store_name="Atwater"),
+        ]
+        result = format_stock_notification(notifs)
+        assert "Back in stock" in result
+        assert "\u2022 Du Parc" in result
+        assert "\u2022 Atwater" in result
+
+    def test_online_only_restock(self):
+        notifs = [_notif()]
+        result = format_stock_notification(notifs)
+        assert "Back in stock online" in result
+        assert "[Mouton Cadet]" in result
+        assert "\u2022" not in result
+
+    def test_online_only_destock(self):
+        notifs = [_notif(available=False)]
+        result = format_stock_notification(notifs)
+        assert "Out of stock online" in result
+
+    def test_store_restock_with_online_available(self):
+        notifs = [_notif(saq_store_id="23009", store_name="Du Parc", online_available=True)]
+        result = format_stock_notification(notifs)
+        assert "Also available online" in result
+
+    def test_store_destock_with_online_available(self):
+        notifs = [
+            _notif(
+                saq_store_id="23009",
+                store_name="Du Parc",
+                available=False,
+                online_available=True,
+            )
+        ]
+        result = format_stock_notification(notifs)
+        assert "Out of stock" in result
+        assert "Still available online" in result
+
+    def test_store_events_online_not_available(self):
+        notifs = [_notif(saq_store_id="23009", store_name="Du Parc", online_available=False)]
+        result = format_stock_notification(notifs)
+        assert "available online" not in result.lower()
+
+    def test_store_events_online_unknown(self):
+        notifs = [_notif(saq_store_id="23009", store_name="Du Parc", online_available=None)]
+        result = format_stock_notification(notifs)
+        assert "available online" not in result.lower()
+
+    def test_mixed_online_and_store(self):
+        notifs = [
+            _notif(),  # online event
+            _notif(saq_store_id="23009", store_name="Du Parc"),
+        ]
+        result = format_stock_notification(notifs)
+        assert "\u2022 Online" in result
+        assert "\u2022 Du Parc" in result
+        # No addendum — "Online" already in bullet list
+        assert "Also available online" not in result
+
+    def test_no_product_name_uses_sku(self):
+        notifs = [_notif(product_name=None)]
+        result = format_stock_notification(notifs)
         assert "10327701" in result
 
-    def test_with_store_name(self):
-        notif = {
-            "sku": "10327701",
-            "product_name": "Mouton Cadet",
-            "store_name": "Du Parc - Fairmount Ouest",
-        }
-        result = format_restock_notification(notif)
-        assert "Back in stock at *Du Parc - Fairmount Ouest*" in result
-        assert "[Mouton Cadet](https://www.saq.com/fr/10327701)" in result
-
-    def test_online_event_no_store(self):
-        notif = {"sku": "10327701", "product_name": "Mouton Cadet", "store_name": None}
-        result = format_restock_notification(notif)
-        assert "Back in stock:" in result
-        assert "at *" not in result
-
-
-class TestFormatDestockNotification:
-    def test_with_product_name(self):
-        notif = {"sku": "10327701", "product_name": "Mouton Cadet"}
-        result = format_destock_notification(notif)
-        assert "Out of stock" in result
-        assert "[Mouton Cadet](https://www.saq.com/fr/10327701)" in result
-
-    def test_without_product_name(self):
-        notif = {"sku": "10327701", "product_name": None}
-        result = format_destock_notification(notif)
-        assert "Out of stock" in result
-        assert "10327701" in result
-
-    def test_with_store_name(self):
-        notif = {
-            "sku": "10327701",
-            "product_name": "Mouton Cadet",
-            "store_name": "Marché Atwater",
-        }
-        result = format_destock_notification(notif)
-        assert "Out of stock at *Marché Atwater*" in result
-
-    def test_online_event_no_store(self):
-        notif = {"sku": "10327701", "product_name": "Mouton Cadet", "store_name": None}
-        result = format_destock_notification(notif)
-        assert "Out of stock:" in result
-        assert "at *" not in result
+    def test_store_name_fallback_to_store_id(self):
+        notifs = [_notif(saq_store_id="23009", store_name=None)]
+        result = format_stock_notification(notifs)
+        assert "\u2022 23009" in result

--- a/bot/tests/test_notifications.py
+++ b/bot/tests/test_notifications.py
@@ -14,6 +14,9 @@ def _notif(**overrides):
         "available": True,
         "product_name": "Mouton Cadet",
         "detected_at": "2026-01-01T00:00:00",
+        "saq_store_id": None,
+        "store_name": None,
+        "online_available": True,
     }
     defaults.update(overrides)
     return defaults
@@ -93,7 +96,7 @@ async def test_poll_restock_sends_back_in_stock(context, api):
     await poll_notifications(context)
 
     text = context.bot.send_message.call_args[1]["text"]
-    assert "Back in stock" in text
+    assert "Back in stock online" in text
     assert "Mouton Cadet" in text
 
 
@@ -103,8 +106,28 @@ async def test_poll_destock_sends_out_of_stock(context, api):
     await poll_notifications(context)
 
     text = context.bot.send_message.call_args[1]["text"]
-    assert "Out of stock" in text
+    assert "Out of stock online" in text
     assert "Mouton Cadet" in text
+
+
+# ── Grouping ─────────────────────────────────────────────────
+
+
+async def test_poll_groups_same_product(context, api):
+    """Two store events for same user+sku produce one message, both acked."""
+    batch = [
+        _notif(event_id=1, saq_store_id="23009", store_name="Du Parc"),
+        _notif(event_id=2, saq_store_id="23010", store_name="Atwater"),
+    ]
+    api.get_pending_notifications.side_effect = [batch, []]
+
+    await poll_notifications(context)
+
+    context.bot.send_message.assert_called_once()
+    text = context.bot.send_message.call_args[1]["text"]
+    assert "Du Parc" in text
+    assert "Atwater" in text
+    api.ack_notifications.assert_called_once_with([1, 2])
 
 
 # ── Product name missing ─────────────────────────────────────

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -76,7 +76,7 @@ Backend endpoints driven by Telegram bot needs. See [specs/TELEGRAM_BOT.md](spec
 - [x] Paginated results with next/previous buttons (#167)
 - [x] Auto-recap watch list after /watch and /unwatch (#183)
 
-### Phase 5b — Store Availability
+### Phase 5b — Store Availability ✅
 
 See [specs/STORE_AVAILABILITY.md](specs/STORE_AVAILABILITY.md) for API reference and engineering plan.
 


### PR DESCRIPTION
## Summary

Stock notifications now group events by product instead of sending one message per store. A single restock/destock affecting 3 stores produces one message with a bullet list, not 3 separate messages. Online availability is included as context when only store events fired.

## Related issue(s)

Closes #256

## Changes

- **`backend/schemas/watch.py`** — add `online_available` field to `PendingNotification`
- **`backend/services/watches.py`** — populate `online_available` from `product.availability`
- **`bot/formatters.py`** — replace separate `format_restock_notification` / `format_destock_notification` with unified `format_stock_notification` that accepts a list of grouped notifications
- **`bot/handlers/notifications.py`** — group notifications by `(chat_id, sku, available)` before sending; ack all event IDs in the group together
- **`docs/ROADMAP.md`** — mark Phase 5b ✅
- **Tests** — updated formatter and notification tests for grouped format, added grouping and edge-case coverage

## How to test

```bash
cd backend && poetry run pytest tests/test_watches.py -v
cd bot && poetry run pytest tests/ -v
```