### PR TITLE
chore: scraper code quality and schema naming standardization (#251, #250, #238)

### DIFF
--- a/backend/api/products.py
+++ b/backend/api/products.py
@@ -12,13 +12,13 @@ from backend.config import (
     MAX_SKU_LENGTH,
 )
 from backend.db import get_db
-from backend.schemas.product import FacetsResponse, PaginatedResponse, ProductResponse
+from backend.schemas.product import FacetsOut, PaginatedOut, ProductOut
 from backend.services.products import get_facets, get_product, get_random_product, list_products
 
 router = APIRouter(prefix="/products", tags=["products"])
 
 
-@router.get("", response_model=PaginatedResponse)
+@router.get("", response_model=PaginatedOut)
 async def get_products(
     page: int = Query(default=1, ge=1),
     per_page: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
@@ -33,7 +33,7 @@ async def get_products(
     max_price: Decimal | None = Query(default=None, ge=0),
     available: bool | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
-) -> PaginatedResponse:
+) -> PaginatedOut:
     """List products with offset-based pagination and optional filters and sorting options."""
     return await list_products(
         db,
@@ -50,15 +50,15 @@ async def get_products(
     )
 
 
-@router.get("/facets", response_model=FacetsResponse)
+@router.get("/facets", response_model=FacetsOut)
 async def get_product_facets(
     db: AsyncSession = Depends(get_db),
-) -> FacetsResponse:
+) -> FacetsOut:
     """Return distinct filter values and price range for the catalog."""
     return await get_facets(db)
 
 
-@router.get("/random", response_model=ProductResponse)
+@router.get("/random", response_model=ProductOut)
 async def get_random(
     category: list[Annotated[str, Query(max_length=MAX_FILTER_LENGTH)]] | None = Query(
         default=None
@@ -69,7 +69,7 @@ async def get_random(
     max_price: Decimal | None = Query(default=None, ge=0),
     available: bool | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
-) -> ProductResponse:
+) -> ProductOut:
     """Return a single random product matching the given filters."""
     return await get_random_product(
         db,
@@ -82,10 +82,10 @@ async def get_random(
     )
 
 
-@router.get("/{sku}", response_model=ProductResponse)
+@router.get("/{sku}", response_model=ProductOut)
 async def get_product_detail(
     sku: str = Path(max_length=MAX_SKU_LENGTH),
     db: AsyncSession = Depends(get_db),
-) -> ProductResponse:
+) -> ProductOut:
     """Get a single product by SKU."""
     return await get_product(db, sku)

--- a/backend/api/stores.py
+++ b/backend/api/stores.py
@@ -8,7 +8,7 @@ from backend.config import (
     MAX_USER_ID_LENGTH,
 )
 from backend.db import get_db
-from backend.schemas.store import AddStorePreference, StoreWithDistance, UserStorePreferenceOut
+from backend.schemas.store import StoreWithDistance, UserStorePreferenceIn, UserStorePreferenceOut
 from backend.services.stores import (
     add_user_store,
     get_nearby_stores,
@@ -46,7 +46,7 @@ async def list_user_stores(
     status_code=status.HTTP_201_CREATED,
 )
 async def add_store_preference(
-    body: AddStorePreference,
+    body: UserStorePreferenceIn,
     user_id: str = Path(min_length=1, max_length=MAX_USER_ID_LENGTH),
     db: AsyncSession = Depends(get_db),
 ) -> UserStorePreferenceOut:

--- a/backend/api/watches.py
+++ b/backend/api/watches.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.config import MAX_SKU_LENGTH, MAX_USER_ID_LENGTH
 from backend.db import get_db
-from backend.schemas.watch import AckRequest, PendingNotification, WatchCreate, WatchWithProduct
+from backend.schemas.watch import AckIn, PendingNotification, WatchIn, WatchWithProduct
 from backend.services.watches import (
     ack_notifications,
     create_watch,
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/watches", tags=["watches"])
 
 @router.post("", response_model=WatchWithProduct, status_code=status.HTTP_201_CREATED)
 async def post_watch(
-    body: WatchCreate,
+    body: WatchIn,
     db: AsyncSession = Depends(get_db),
 ) -> WatchWithProduct:
     """Create a watch on a product for a user."""
@@ -43,7 +43,7 @@ async def get_pending_notifications(
 
 @router.post("/notifications/ack", status_code=status.HTTP_204_NO_CONTENT)
 async def ack_notifications_endpoint(
-    body: AckRequest,
+    body: AckIn,
     db: AsyncSession = Depends(get_db),
 ) -> None:
     """Acknowledge processed notifications (mark as sent)."""

--- a/backend/schemas/product.py
+++ b/backend/schemas/product.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from pydantic import BaseModel, ConfigDict, Field
 
 
-class ProductResponse(BaseModel):
+class ProductOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     sku: str
@@ -30,8 +30,8 @@ class ProductResponse(BaseModel):
     updated_at: datetime
 
 
-class PaginatedResponse(BaseModel):
-    products: list[ProductResponse]
+class PaginatedOut(BaseModel):
+    products: list[ProductOut]
     total: int
     page: int
     per_page: int
@@ -43,7 +43,7 @@ class PriceRange(BaseModel):
     max: Decimal
 
 
-class FacetsResponse(BaseModel):
+class FacetsOut(BaseModel):
     categories: list[str]
     countries: list[str]
     regions: list[str]

--- a/backend/schemas/store.py
+++ b/backend/schemas/store.py
@@ -26,7 +26,7 @@ class StoreWithDistance(StoreOut):
     distance_km: float
 
 
-class AddStorePreference(BaseModel):
+class UserStorePreferenceIn(BaseModel):
     saq_store_id: str = Field(min_length=1, max_length=MAX_SAQ_STORE_ID_LENGTH)
 
 

--- a/backend/schemas/watch.py
+++ b/backend/schemas/watch.py
@@ -3,17 +3,17 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field
 
 from backend.config import MAX_ACK_BATCH_SIZE, MAX_SKU_LENGTH, MAX_USER_ID_LENGTH
-from backend.schemas.product import ProductResponse
+from backend.schemas.product import ProductOut
 
 
 # input validation for POST /watches
-class WatchCreate(BaseModel):
+class WatchIn(BaseModel):
     user_id: str = Field(min_length=1, max_length=MAX_USER_ID_LENGTH)
     sku: str = Field(min_length=1, max_length=MAX_SKU_LENGTH)
 
 
 # Output resource validation for a single watch
-class WatchResponse(BaseModel):
+class WatchOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
@@ -22,12 +22,12 @@ class WatchResponse(BaseModel):
     created_at: datetime
 
 
-# Wraps a WatchResponse + the joined ProductResponse
+# Wraps a WatchOut + the joined ProductOut
 class WatchWithProduct(BaseModel):
     """Watch with embedded product info — for the GET /watches list."""
 
-    watch: WatchResponse
-    product: ProductResponse | None
+    watch: WatchOut
+    product: ProductOut | None
 
 
 class PendingNotification(BaseModel):
@@ -46,5 +46,5 @@ class PendingNotification(BaseModel):
     online_available: bool | None = None
 
 
-class AckRequest(BaseModel):
+class AckIn(BaseModel):
     event_ids: list[int] = Field(min_length=1, max_length=MAX_ACK_BATCH_SIZE)

--- a/backend/services/products.py
+++ b/backend/services/products.py
@@ -14,19 +14,19 @@ from backend.repositories.products import (
     get_price_range,
 )
 from backend.schemas.product import (
-    FacetsResponse,
-    PaginatedResponse,
+    FacetsOut,
+    PaginatedOut,
     PriceRange,
-    ProductResponse,
+    ProductOut,
 )
 
 
-async def get_product(db: AsyncSession, sku: str) -> ProductResponse:
+async def get_product(db: AsyncSession, sku: str) -> ProductOut:
     """Fetch a single product by SKU. Raises NotFoundError if not found."""
     product = await find_by_sku(db, sku)
     if product is None:
         raise NotFoundError("Product", sku)
-    return ProductResponse.model_validate(product)
+    return ProductOut.model_validate(product)
 
 
 async def list_products(
@@ -42,7 +42,7 @@ async def list_products(
     min_price: Decimal | None = None,
     max_price: Decimal | None = None,
     available: bool | None = None,
-) -> PaginatedResponse:
+) -> PaginatedOut:
     """Fetch a paginated list of products, optionally filtered and sorted."""
     filters = dict(
         q=q,
@@ -58,8 +58,8 @@ async def list_products(
     offset = (page - 1) * per_page
     rows = await find_page(db, offset, per_page, sort=sort, **filters)
 
-    return PaginatedResponse(
-        products=[ProductResponse.model_validate(r) for r in rows],
+    return PaginatedOut(
+        products=[ProductOut.model_validate(r) for r in rows],
         total=total,
         page=page,
         per_page=per_page,
@@ -76,7 +76,7 @@ async def get_random_product(
     min_price: Decimal | None = None,
     max_price: Decimal | None = None,
     available: bool | None = None,
-) -> ProductResponse:
+) -> ProductOut:
     """Fetch a single random product matching filters. Raises NotFoundError if none."""
     product = await find_random(
         db,
@@ -89,10 +89,10 @@ async def get_random_product(
     )
     if product is None:
         raise NotFoundError("Product", "no product matches the given filters")
-    return ProductResponse.model_validate(product)
+    return ProductOut.model_validate(product)
 
 
-async def get_facets(db: AsyncSession) -> FacetsResponse:
+async def get_facets(db: AsyncSession) -> FacetsOut:
     """Fetch distinct filter values and price range for active products."""
     categories = await get_distinct_values(db, Product.category)
     countries = await get_distinct_values(db, Product.country)
@@ -100,7 +100,7 @@ async def get_facets(db: AsyncSession) -> FacetsResponse:
     grapes = await get_distinct_values(db, Product.grape)
     price_result = await get_price_range(db)
 
-    return FacetsResponse(
+    return FacetsOut(
         categories=categories,
         countries=countries,
         regions=regions,

--- a/backend/services/watches.py
+++ b/backend/services/watches.py
@@ -5,8 +5,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.exceptions import ConflictError, NotFoundError
 from backend.repositories import products as products_repo
 from backend.repositories import watches as repo
-from backend.schemas.product import ProductResponse
-from backend.schemas.watch import PendingNotification, WatchResponse, WatchWithProduct
+from backend.schemas.product import ProductOut
+from backend.schemas.watch import PendingNotification, WatchOut, WatchWithProduct
 
 
 async def create_watch(db: AsyncSession, user_id: str, sku: str) -> WatchWithProduct:
@@ -28,8 +28,8 @@ async def create_watch(db: AsyncSession, user_id: str, sku: str) -> WatchWithPro
         raise NotFoundError("Product", sku) from exc
     product = await products_repo.find_by_sku(db, sku)
     return WatchWithProduct(
-        watch=WatchResponse.model_validate(watch),
-        product=ProductResponse.model_validate(product) if product else None,
+        watch=WatchOut.model_validate(watch),
+        product=ProductOut.model_validate(product) if product else None,
     )
 
 
@@ -38,8 +38,8 @@ async def list_watches(db: AsyncSession, user_id: str) -> list[WatchWithProduct]
     rows = await repo.find_by_user(db, user_id)
     return [
         WatchWithProduct(
-            watch=WatchResponse.model_validate(watch),
-            product=ProductResponse.model_validate(product) if product else None,
+            watch=WatchOut.model_validate(watch),
+            product=ProductOut.model_validate(product) if product else None,
         )
         for watch, product in rows
     ]

--- a/backend/tests/test_products.py
+++ b/backend/tests/test_products.py
@@ -18,11 +18,11 @@ from backend.repositories.products import (
     find_random,
     get_distinct_values,
 )
-from backend.schemas.product import ProductResponse
+from backend.schemas.product import ProductOut
 
 NOW = datetime(2025, 1, 1, tzinfo=UTC)
 
-EXPECTED_FIELDS = set(ProductResponse.model_fields.keys())
+EXPECTED_FIELDS = set(ProductOut.model_fields.keys())
 
 # One dummy value per type — used to auto-populate _fake_product defaults
 _DUMMY_VALUES: dict[type, object] = {
@@ -37,7 +37,7 @@ _DUMMY_VALUES: dict[type, object] = {
 def _fake_product(**overrides):
     """Build a fake Product object. Raises AttributeError on unknown attrs."""
     defaults = {}
-    for name, field_info in ProductResponse.model_fields.items():
+    for name, field_info in ProductOut.model_fields.items():
         annotation = field_info.annotation
         # Unwrap Optional (str | None → str)
         if isinstance(annotation, UnionType):
@@ -221,15 +221,15 @@ def test_list_products_per_page_too_large():
 
 
 def test_product_response_fields_exist_on_model():
-    """Every ProductResponse field must map to a Product column.
+    """Every ProductOut field must map to a Product column.
 
     Catches renames in the ORM model that silently break the API
     (from_attributes=True returns None instead of raising).
     """
     model_columns = set(Product.__table__.columns.keys())
-    response_fields = set(ProductResponse.model_fields.keys())
+    response_fields = set(ProductOut.model_fields.keys())
     missing = response_fields - model_columns
-    assert not missing, f"ProductResponse fields not in Product model: {missing}"
+    assert not missing, f"ProductOut fields not in Product model: {missing}"
 
 
 def test_list_products_excludes_sensitive_fields():

--- a/scraper/src/__main__.py
+++ b/scraper/src/__main__.py
@@ -2,6 +2,7 @@ import asyncio
 import sys
 import time
 import urllib.error
+from dataclasses import dataclass
 from datetime import date, datetime
 from http import HTTPStatus
 
@@ -57,6 +58,158 @@ def _needs_scrape(entry: SitemapEntry, updated_dates: dict[str, date]) -> bool:
     return datetime.fromisoformat(entry.lastmod).date() > updated_dates[entry.sku]
 
 
+async def _bootstrap_stores(client: httpx.AsyncClient) -> None:
+    """Bootstrap store directory on first run. Logs and continues on failure."""
+    if not await stores_populated():
+        logger.info("Stores table empty — bootstrapping store directory...")
+        try:
+            stores = await fetch_stores(client)
+            await upsert_stores(stores)
+            logger.info("Store bootstrap complete: {} stores loaded", len(stores))
+        except (httpx.HTTPError, SQLAlchemyError, ValueError, KeyError) as exc:
+            logger.warning("Store bootstrap failed — continuing without store data: {}", exc)
+
+
+async def _load_and_filter_entries(
+    client: httpx.AsyncClient,
+) -> list[SitemapEntry] | None:
+    """Fetch sitemaps, apply robots.txt and product filters.
+
+    Returns filtered entries, or None if robots.txt fetch fails (caller should abort).
+    """
+    logger.info("Fetching sitemap index...")
+    sub_sitemap_urls = await fetch_sitemap_index(client)
+    logger.info("Found {} sub-sitemaps", len(sub_sitemap_urls))
+
+    entries: list[SitemapEntry] = []
+    for j, sub_url in enumerate(sub_sitemap_urls, 1):
+        await asyncio.sleep(settings.RATE_LIMIT_SECONDS)
+        logger.info("[{}/{}] Fetching sub-sitemap...", j, len(sub_sitemap_urls))
+        entries.extend(await fetch_sub_sitemap(client, sub_url))
+
+    # Load robots.txt rules (one sync HTTP call, fail-fast for compliance)
+    try:
+        rp = load_robots(settings.ROBOTS_URL)
+    except urllib.error.URLError as exc:
+        logger.opt(exception=exc).error("Cannot fetch robots.txt — aborting to ensure compliance")
+        return None
+
+    before_robots = len(entries)
+    entries = [e for e in entries if is_allowed(rp, e.url, settings.USER_AGENT)]
+    skipped_robots = before_robots - len(entries)
+
+    # Filter non-product URLs (recipes, accessories have slug SKUs, not numeric)
+    total_sitemap = len(entries)
+    entries = [e for e in entries if e.sku.isdigit()]
+    skipped_non_products = total_sitemap - len(entries)
+
+    logger.info(
+        "Found {} product URLs across {} sub-sitemaps"
+        " ({} blocked by robots.txt, {} non-products skipped)",
+        len(entries),
+        len(sub_sitemap_urls),
+        skipped_robots,
+        skipped_non_products,
+    )
+
+    return entries
+
+
+@dataclass
+class _ScrapeStats:
+    saved: int = 0
+    inserted: int = 0
+    updated: int = 0
+    restocked: int = 0
+    destocked: int = 0
+    not_found: int = 0
+    errors: int = 0
+
+
+async def _scrape_products(
+    client: httpx.AsyncClient,
+    entries: list[SitemapEntry],
+    updated_dates: dict[str, date],
+    availability_map: dict[str, bool],
+) -> _ScrapeStats:
+    """Download, parse, and upsert each product entry. Returns run stats."""
+    stats = _ScrapeStats()
+
+    for i, entry in enumerate(entries, 1):
+        # Ethical rate limiter
+        await asyncio.sleep(settings.RATE_LIMIT_SECONDS)
+
+        try:
+            logger.info("[{}/{}] Fetching {} ...", i, len(entries), entry.url)
+            response = await client.get(entry.url)
+            response.raise_for_status()
+
+            product = parse_product(response.content, url=entry.url)
+            await upsert_product(product)
+            stats.saved += 1
+            if entry.sku in updated_dates:
+                stats.updated += 1
+            else:
+                stats.inserted += 1
+
+            # Detect availability transitions
+            old_avail = availability_map.get(entry.sku)
+            if old_avail is False and product.availability:
+                await emit_stock_event(entry.sku, available=True)
+                stats.restocked += 1
+                logger.info("Restock detected for SKU {}", entry.sku)
+            elif old_avail is True and not product.availability:
+                await emit_stock_event(entry.sku, available=False)
+                stats.destocked += 1
+                logger.info("Destock detected for SKU {}", entry.sku)
+
+            logger.success("Saved {} - {}", product.sku or "unknown", product.name or "no name")
+
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == HTTPStatus.NOT_FOUND:
+                stats.not_found += 1
+                logger.warning("Not found (stale sitemap entry): {}", entry.url)
+            else:
+                stats.errors += 1
+                logger.error("HTTP error for {}: {}", entry.url, e)
+        except httpx.HTTPError as e:
+            stats.errors += 1
+            logger.error("HTTP error for {}: {}", entry.url, e)
+        except SQLAlchemyError as exc:
+            stats.errors += 1
+            logger.error("DB error for {}: {}", entry.url, exc)
+        except Exception:
+            stats.errors += 1
+            logger.exception("Unexpected error for {}", entry.url)
+
+    return stats
+
+
+async def _detect_delists(sitemap_skus: set[str], db_skus: set[str]) -> tuple[int, int]:
+    """Compare sitemap vs DB SKUs and mark/clear delisted products.
+
+    Returns (delisted, relisted). Best-effort — logs and returns (0, 0) on error.
+    """
+    # Delist detection: compare sitemap SKUs vs DB SKUs
+    # Best-effort — if it fails, next run catches up
+    try:
+        to_delist = db_skus - sitemap_skus
+        delisted = await mark_delisted(to_delist)
+        if delisted:
+            logger.info("Marked {} products as delisted", delisted)
+
+        currently_delisted = await get_delisted_skus()
+        to_relist = currently_delisted & sitemap_skus
+        relisted = await clear_delisted(to_relist)
+        if relisted:
+            logger.info("Relisted {} products (back in sitemap)", relisted)
+
+        return delisted, relisted
+    except SQLAlchemyError as exc:
+        logger.opt(exception=exc).warning("Delist detection failed, skipping")
+        return 0, 0
+
+
 async def main() -> int:
     """Fetch sitemap, scrape products, write to database. Returns exit code."""
     # monotonic is immune to system clock changes
@@ -69,56 +222,11 @@ async def main() -> int:
     ) as client:
         # Bootstrap store directory on first run — stores are physical locations,
         # rarely change. Re-populate by clearing the stores table and re-running.
-        if not await stores_populated():
-            logger.info("Stores table empty — bootstrapping store directory...")
-            try:
-                stores = await fetch_stores(client)
-                await upsert_stores(stores)
-                logger.info("Store bootstrap complete: {} stores loaded", len(stores))
-            except (httpx.HTTPError, SQLAlchemyError, ValueError, KeyError) as exc:
-                logger.warning("Store bootstrap failed — continuing without store data: {}", exc)
+        await _bootstrap_stores(client)
 
-        logger.info("Fetching sitemap index...")
-        sub_sitemap_urls = await fetch_sitemap_index(client)
-        logger.info("Found {} sub-sitemaps", len(sub_sitemap_urls))
-
-        # Fetch all sub-sitemaps, collecting entries into one list
-        entries = []
-        for j, sub_url in enumerate(sub_sitemap_urls, 1):
-            await asyncio.sleep(settings.RATE_LIMIT_SECONDS)
-            logger.info("[{}/{}] Fetching sub-sitemap...", j, len(sub_sitemap_urls))
-            entries.extend(await fetch_sub_sitemap(client, sub_url))
-
-        # Load robots.txt rules (one sync HTTP call, fail-fast for compliance)
-        try:
-            rp = load_robots(settings.ROBOTS_URL)
-        except urllib.error.URLError as exc:
-            logger.opt(exception=exc).error(
-                "Cannot fetch robots.txt — aborting to ensure compliance"
-            )
+        entries = await _load_and_filter_entries(client)
+        if entries is None:
             return EXIT_FATAL
-
-        # Filter URLs disallowed by robots.txt
-        before_robots = len(entries)
-        entries = [e for e in entries if is_allowed(rp, e.url, settings.USER_AGENT)]
-        skipped_robots = before_robots - len(entries)
-
-        # Filter non-product URLs (recipes, accessories have slug SKUs, not numeric)
-        total_sitemap = len(entries)
-        entries = [e for e in entries if e.sku.isdigit()]
-        skipped_non_products = total_sitemap - len(entries)
-
-        logger.info(
-            "Found {} product URLs across {} sub-sitemaps"
-            " ({} blocked by robots.txt, {} non-products skipped)",
-            len(entries),
-            len(sub_sitemap_urls),
-            skipped_robots,
-            skipped_non_products,
-        )
-
-        limit = settings.SCRAPE_LIMIT
-        products_to_scrape = entries[:limit] if limit else entries
 
         # Loads {sku: last_updated_date} from DB, then O(1) dict lookup per entry
         try:
@@ -129,95 +237,22 @@ async def main() -> int:
             return EXIT_FATAL
 
         # Incremental scraping: skip products unchanged since last scrape
+        limit = settings.SCRAPE_LIMIT
+        products_to_scrape = entries[:limit] if limit else entries
         total_before = len(products_to_scrape)
         products_to_scrape = [e for e in products_to_scrape if _needs_scrape(e, updated_dates)]
         skipped = total_before - len(products_to_scrape)
-
         logger.info(
             "Incremental filter: {} to scrape, {} skipped (unchanged)",
             len(products_to_scrape),
             skipped,
         )
 
-        # Main scrape loop
-        saved = 0
-        inserted = 0
-        updated = 0
-        restocked = 0
-        destocked = 0
-        not_found = 0
-        errors = 0
-        for i, entry in enumerate(products_to_scrape, 1):
-            # Ethical rate limiter
-            await asyncio.sleep(settings.RATE_LIMIT_SECONDS)
+        stats = await _scrape_products(client, products_to_scrape, updated_dates, availability_map)
 
-            try:
-                # Download HTML
-                logger.info("[{}/{}] Fetching {} ...", i, len(products_to_scrape), entry.url)
-                response = await client.get(entry.url)
-                response.raise_for_status()
-
-                # Parse HTML and create a ProductData instance
-                product = parse_product(response.content, url=entry.url)
-
-                # Saves to DB (upsert)
-                await upsert_product(product)
-                saved += 1
-                if entry.sku in updated_dates:
-                    updated += 1
-                else:
-                    inserted += 1
-
-                # Detect availability transitions
-                old_avail = availability_map.get(entry.sku)
-                if old_avail is False and product.availability:
-                    await emit_stock_event(entry.sku, available=True)
-                    restocked += 1
-                    logger.info("Restock detected for SKU {}", entry.sku)
-                elif old_avail is True and not product.availability:
-                    await emit_stock_event(entry.sku, available=False)
-                    destocked += 1
-                    logger.info("Destock detected for SKU {}", entry.sku)
-
-                logger.success("Saved {} - {}", product.sku or "unknown", product.name or "no name")
-
-            except httpx.HTTPStatusError as e:
-                if e.response.status_code == HTTPStatus.NOT_FOUND:
-                    not_found += 1
-                    logger.warning("Not found (stale sitemap entry): {}", entry.url)
-                else:
-                    errors += 1
-                    logger.error("HTTP error for {}: {}", entry.url, e)
-            except httpx.HTTPError as e:
-                errors += 1
-                logger.error("HTTP error for {}: {}", entry.url, e)
-            except SQLAlchemyError as exc:
-                errors += 1
-                logger.error("DB error for {}: {}", entry.url, exc)
-            except Exception:
-                errors += 1
-                logger.exception("Unexpected error for {}", entry.url)
-
-    # Delist detection: compare sitemap SKUs vs DB SKUs
-    # Best-effort — if it fails, next run catches up
-    delisted = 0
-    relisted = 0
     sitemap_skus = {e.sku for e in entries}
     db_skus = set(updated_dates.keys())
-
-    try:
-        to_delist = db_skus - sitemap_skus
-        delisted = await mark_delisted(to_delist)
-        if delisted:
-            logger.info("Marked {} products as delisted", delisted)
-
-        currently_delisted = await get_delisted_skus()
-        to_relist = currently_delisted & sitemap_skus
-        relisted = await clear_delisted(to_relist)
-        if relisted:
-            logger.info("Relisted {} products (back in sitemap)", relisted)
-    except SQLAlchemyError as exc:
-        logger.opt(exception=exc).warning("Delist detection failed, skipping")
+    delisted, relisted = await _detect_delists(sitemap_skus, db_skus)
 
     # Housekeeping: purge old stock events
     await delete_old_stock_events(days=settings.STOCK_EVENT_RETENTION_DAYS)
@@ -231,7 +266,6 @@ async def main() -> int:
         "Scraper run complete:\n"
         "  Duration: {}h {}m {}s\n"
         "  Sitemap URLs: {}\n"
-        "  Skipped (robots.txt): {}\n"
         "  Fetched: {}\n"
         "  Inserted: {}\n"
         "  Updated: {}\n"
@@ -246,20 +280,19 @@ async def main() -> int:
         minutes,
         seconds,
         len(entries),
-        skipped_robots,
-        saved,
-        inserted,
-        updated,
-        restocked,
-        destocked,
-        not_found,
-        errors,
+        stats.saved,
+        stats.inserted,
+        stats.updated,
+        stats.restocked,
+        stats.destocked,
+        stats.not_found,
+        stats.errors,
         skipped,
         delisted,
         relisted,
     )
 
-    return _exit_code(saved, errors)
+    return _exit_code(stats.saved, stats.errors)
 
 
 async def check_watches() -> int:

--- a/scraper/src/availability.py
+++ b/scraper/src/availability.py
@@ -19,6 +19,7 @@ _GRAPHQL_URL = "https://www.saq.com/graphql"
 _STORE_AVAILABILITY_URL = "https://www.saq.com/fr/store/locator/ajaxlist"
 _GRAPHQL_BATCH_SIZE = 20  # tested safe; TODO: test upper limit for Phase 6 (12k SKUs)
 _MAX_PAGES = 50  # safety valve: 500 stores max (SAQ has ~400)
+_SAQ_PAGE_SIZE = 10  # server-enforced, not configurable
 
 
 @dataclass
@@ -37,9 +38,8 @@ async def resolve_graphql_products(
         batch = skus[i : i + _GRAPHQL_BATCH_SIZE]
         sku_filter = json.dumps(batch)
         query = (
-            "{ products(filter: { sku: { in: "
-            + sku_filter
-            + " } }) { items { id sku stock_status } }}"
+            f"{{ products(filter: {{ sku: {{ in: {sku_filter} }}"
+            " }) { items { id sku stock_status } }}"
         )
 
         try:
@@ -76,8 +76,6 @@ async def fetch_store_availability(client: httpx.AsyncClient, magento_id: int) -
     offset = 0
     is_last_page = False
     page = 0
-    SAQ_PAGE_SIZE = 10
-
     while not is_last_page and page < _MAX_PAGES:
         page += 1
         params = {
@@ -108,7 +106,7 @@ async def fetch_store_availability(client: httpx.AsyncClient, magento_id: int) -
         is_last_page = data.get("is_last_page", True)
 
         if not is_last_page:
-            offset += SAQ_PAGE_SIZE  # SAQ page size is server-enforced, not configurable
+            offset += _SAQ_PAGE_SIZE
             await asyncio.sleep(settings.RATE_LIMIT_SECONDS)
 
     if page >= _MAX_PAGES:

--- a/scraper/src/db.py
+++ b/scraper/src/db.py
@@ -141,14 +141,15 @@ async def upsert_product(product_data: ProductData) -> None:
     """
     async with _SessionLocal() as session:
         product_dict = asdict(product_data)
-        product_dict["created_at"] = datetime.now(UTC)
-        product_dict["updated_at"] = datetime.now(UTC)
+        now = datetime.now(UTC)
+        product_dict["created_at"] = now
+        product_dict["updated_at"] = now
 
         stmt = pg_insert(Product).values(product_dict)
 
         # On conflict (SKU already exists), update all fields except sku and created_at
         update_dict = {k: v for k, v in product_dict.items() if k not in ["sku", "created_at"]}
-        update_dict["updated_at"] = datetime.now(UTC)
+        update_dict["updated_at"] = now
 
         stmt = stmt.on_conflict_do_update(
             index_elements=list(Product.__table__.primary_key),


### PR DESCRIPTION
## Summary

Three code quality issues addressed in one pass: scraper nits, `main()` decomposition, and schema naming convention cleanup.

## Related issue(s)

Closes #251
Closes #250
Closes #238

## Changes

**#251 — Scraper code quality nits** (`scraper/`)
- `db.py`: Single `now = datetime.now(UTC)` call in `upsert_product` — guarantees consistent timestamps and avoids three separate clock reads
- `availability.py`: Promote local `SAQ_PAGE_SIZE = 10` to module-level `_SAQ_PAGE_SIZE` alongside the other private constants; replace string concatenation with f-string for the GraphQL query

**#250 — Extract sub-functions from `main()`** (`scraper/src/__main__.py`)
- `_bootstrap_stores(client)` — store directory bootstrap (first run)
- `_load_and_filter_entries(client) -> list | None` — sitemap fetch + robots.txt + product filter; returns `None` as abort sentinel on robots.txt failure
- `_ScrapeStats` dataclass — replaces 7 bare counter variables in the loop
- `_scrape_products(client, entries, updated_dates, availability_map) -> _ScrapeStats` — full scrape loop with error handling
- `_detect_delists(sitemap_skus, db_skus) -> tuple[int, int]` — best-effort delist detection; encapsulates `SQLAlchemyError` handling and returns `(0, 0)` on error
- `main()` reduced from ~130 lines to ~40 lines

**#238 — Standardize schema naming** (`backend/`)
- `ProductResponse` → `ProductOut`, `PaginatedResponse` → `PaginatedOut`, `FacetsResponse` → `FacetsOut`
- `WatchCreate` → `WatchIn`, `WatchResponse` → `WatchOut`, `AckRequest` → `AckIn`
- `AddStorePreference` → `UserStorePreferenceIn`
- Updated across all API handlers, service layer, and tests