### PR TITLE
refactor: drop /api/v1 prefix, use /api (#236)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -38,7 +38,7 @@ app.add_middleware(
 
 register_exception_handlers(app)
 app.include_router(health_router)
-app.include_router(products_router, prefix="/api/v1")
-app.include_router(stores_router, prefix="/api/v1")
-app.include_router(users_router, prefix="/api/v1")
-app.include_router(watches_router, prefix="/api/v1")
+app.include_router(products_router, prefix="/api")
+app.include_router(stores_router, prefix="/api")
+app.include_router(users_router, prefix="/api")
+app.include_router(watches_router, prefix="/api")

--- a/backend/tests/test_products.py
+++ b/backend/tests/test_products.py
@@ -86,7 +86,7 @@ def test_get_product_found():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products/ABC123")
+    resp = client.get("/api/products/ABC123")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["sku"] == "ABC123"
@@ -98,7 +98,7 @@ def test_get_product_not_found():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products/NOPE")
+    resp = client.get("/api/products/NOPE")
     assert resp.status_code == status.HTTP_404_NOT_FOUND
     assert "NOPE" in resp.json()["detail"]
 
@@ -110,7 +110,7 @@ def test_get_product_response_shape():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products/test")
+    resp = client.get("/api/products/test")
     assert set(resp.json().keys()) == EXPECTED_FIELDS
 
 
@@ -123,7 +123,7 @@ def test_get_product_excludes_sensitive_fields():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products/test")
+    resp = client.get("/api/products/test")
     for field in ("description", "url", "image"):
         assert field not in resp.json(), f"{field} should not be exposed in API"
 
@@ -137,7 +137,7 @@ def test_list_products_default_pagination():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products")
+    resp = client.get("/api/products")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["total"] == 3
@@ -155,7 +155,7 @@ def test_list_products_response_shape():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products")
+    resp = client.get("/api/products")
     product = resp.json()["products"][0]
     assert set(product.keys()) == EXPECTED_FIELDS
 
@@ -167,7 +167,7 @@ def test_list_products_price_serialization():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products")
+    resp = client.get("/api/products")
     assert resp.json()["products"][0]["price"] == "15.99"
 
 
@@ -177,7 +177,7 @@ def test_list_products_custom_pagination():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products?page=2&per_page=10")
+    resp = client.get("/api/products?page=2&per_page=10")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["total"] == 25
@@ -192,7 +192,7 @@ def test_list_products_empty():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products")
+    resp = client.get("/api/products")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["total"] == 0
@@ -206,7 +206,7 @@ def test_list_products_invalid_page():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products?page=0")
+    resp = client.get("/api/products?page=0")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
@@ -216,7 +216,7 @@ def test_list_products_per_page_too_large():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products?per_page=101")
+    resp = client.get("/api/products?per_page=101")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
@@ -243,7 +243,7 @@ def test_list_products_excludes_sensitive_fields():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products")
+    resp = client.get("/api/products")
     product = resp.json()["products"][0]
     # ! We decided to exclude SAQ proprietary data
     for field in ("description", "url", "image"):
@@ -260,7 +260,7 @@ def test_search_by_name():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products?q=margaux")
+    resp = client.get("/api/products?q=margaux")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["total"] == 1
@@ -273,7 +273,7 @@ def test_filter_by_category():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products?category=Vin+rouge")
+    resp = client.get("/api/products?category=Vin+rouge")
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total"] == 1
 
@@ -294,7 +294,7 @@ def test_filter_by_price_range():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products?min_price=15&max_price=30")
+    resp = client.get("/api/products?min_price=15&max_price=30")
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total"] == 1
 
@@ -306,7 +306,7 @@ def test_combined_filters_with_pagination():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products?country=France&min_price=10&page=2&per_page=10")
+    resp = client.get("/api/products?country=France&min_price=10&page=2&per_page=10")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["total"] == 15
@@ -320,7 +320,7 @@ def test_filter_no_results():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products?country=Atlantis")
+    resp = client.get("/api/products?country=Atlantis")
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total"] == 0
     assert resp.json()["products"] == []
@@ -332,7 +332,7 @@ def test_search_q_empty_string_rejected():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products?q=")
+    resp = client.get("/api/products?q=")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
@@ -342,7 +342,7 @@ def test_filter_negative_price_rejected():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products?min_price=-5")
+    resp = client.get("/api/products?min_price=-5")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
@@ -352,7 +352,7 @@ def test_search_q_too_long_rejected():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get(f"/api/v1/products?q={'x' * (MAX_SEARCH_LENGTH + 1)}")
+    resp = client.get(f"/api/products?q={'x' * (MAX_SEARCH_LENGTH + 1)}")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
@@ -362,7 +362,7 @@ def test_filter_category_too_long_rejected():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get(f"/api/v1/products?category={'x' * (MAX_FILTER_LENGTH + 1)}")
+    resp = client.get(f"/api/products?category={'x' * (MAX_FILTER_LENGTH + 1)}")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
@@ -372,7 +372,7 @@ def test_sku_too_long_rejected():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get(f"/api/v1/products/{'x' * (MAX_SKU_LENGTH + 1)}")
+    resp = client.get(f"/api/products/{'x' * (MAX_SKU_LENGTH + 1)}")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
@@ -477,7 +477,7 @@ def test_facets_response_shape():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products/facets")
+    resp = client.get("/api/products/facets")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["categories"] == ["Vin blanc", "Vin rouge"]
@@ -499,7 +499,7 @@ def test_facets_empty_catalog():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products/facets")
+    resp = client.get("/api/products/facets")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["categories"] == []
@@ -521,7 +521,7 @@ def test_facets_no_prices():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products/facets")
+    resp = client.get("/api/products/facets")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert len(data["categories"]) == 1
@@ -555,7 +555,7 @@ def test_sort_recent_returns_200():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products?sort=recent")
+    resp = client.get("/api/products?sort=recent")
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total"] == 1
 
@@ -566,7 +566,7 @@ def test_sort_invalid_rejected():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products?sort=bogus")
+    resp = client.get("/api/products?sort=bogus")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
@@ -593,7 +593,7 @@ def test_sort_price_asc_returns_200():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products?sort=price_asc")
+    resp = client.get("/api/products?sort=price_asc")
     assert resp.status_code == status.HTTP_200_OK
 
 
@@ -604,7 +604,7 @@ def test_sort_price_desc_returns_200():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products?sort=price_desc")
+    resp = client.get("/api/products?sort=price_desc")
     assert resp.status_code == status.HTTP_200_OK
 
 
@@ -634,7 +634,7 @@ def test_random_product_found():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products/random")
+    resp = client.get("/api/products/random")
     assert resp.status_code == status.HTTP_200_OK
     assert set(resp.json().keys()) == EXPECTED_FIELDS
 
@@ -645,7 +645,7 @@ def test_random_product_not_found():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products/random")
+    resp = client.get("/api/products/random")
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -656,7 +656,7 @@ def test_random_with_filters():
 
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/products/random?category=Vin+rouge&min_price=10")
+    resp = client.get("/api/products/random?category=Vin+rouge&min_price=10")
     assert resp.status_code == status.HTTP_200_OK
 
 

--- a/backend/tests/test_stores.py
+++ b/backend/tests/test_stores.py
@@ -49,7 +49,7 @@ def test_nearby_returns_stores_sorted_by_distance():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/stores/nearby?lat=45.52&lng=-73.60")
+        resp = client.get("/api/stores/nearby?lat=45.52&lng=-73.60")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -68,7 +68,7 @@ def test_nearby_limit_respected():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/stores/nearby?lat=45.52&lng=-73.60&limit=3")
+        resp = client.get("/api/stores/nearby?lat=45.52&lng=-73.60&limit=3")
 
     assert resp.status_code == status.HTTP_200_OK
     assert len(resp.json()) == 3
@@ -84,7 +84,7 @@ def test_nearby_excludes_stores_without_coordinates():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/stores/nearby?lat=45.52&lng=-73.60")
+        resp = client.get("/api/stores/nearby?lat=45.52&lng=-73.60")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -103,7 +103,7 @@ def test_nearby_excludes_non_consumer_store_types():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/stores/nearby?lat=45.52&lng=-73.60")
+        resp = client.get("/api/stores/nearby?lat=45.52&lng=-73.60")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -118,7 +118,7 @@ def test_nearby_empty_db():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/stores/nearby?lat=45.52&lng=-73.60")
+        resp = client.get("/api/stores/nearby?lat=45.52&lng=-73.60")
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == []
@@ -137,7 +137,7 @@ def test_get_user_stores_success():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/users/tg:123/stores")
+        resp = client.get("/api/users/tg:123/stores")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -153,7 +153,7 @@ def test_get_user_stores_empty():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/users/tg:123/stores")
+        resp = client.get("/api/users/tg:123/stores")
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == []
@@ -173,7 +173,7 @@ def test_add_user_store_success():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.post("/api/v1/users/tg:123/stores", json={"saq_store_id": "23009"})
+        resp = client.post("/api/users/tg:123/stores", json={"saq_store_id": "23009"})
 
     assert resp.status_code == status.HTTP_201_CREATED
     data = resp.json()
@@ -188,7 +188,7 @@ def test_add_user_store_store_not_found():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.post("/api/v1/users/tg:123/stores", json={"saq_store_id": "99999"})
+        resp = client.post("/api/users/tg:123/stores", json={"saq_store_id": "99999"})
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
@@ -203,7 +203,7 @@ def test_add_user_store_duplicate():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.post("/api/v1/users/tg:123/stores", json={"saq_store_id": "23009"})
+        resp = client.post("/api/users/tg:123/stores", json={"saq_store_id": "23009"})
 
     assert resp.status_code == status.HTTP_409_CONFLICT
 
@@ -218,7 +218,7 @@ def test_remove_user_store_success():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.delete("/api/v1/users/tg:123/stores/23009")
+        resp = client.delete("/api/users/tg:123/stores/23009")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
 
@@ -230,6 +230,6 @@ def test_remove_user_store_not_found():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.delete("/api/v1/users/tg:123/stores/99999")
+        resp = client.delete("/api/users/tg:123/stores/99999")
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/tests/test_watches.py
+++ b/backend/tests/test_watches.py
@@ -71,7 +71,7 @@ def test_create_watch_success():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.post("/api/v1/watches", json={"user_id": "tg:123", "sku": "SKU001"})
+        resp = client.post("/api/watches", json={"user_id": "tg:123", "sku": "SKU001"})
 
     assert resp.status_code == status.HTTP_201_CREATED
     data = resp.json()
@@ -92,7 +92,7 @@ def test_create_watch_duplicate():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.post("/api/v1/watches", json={"user_id": "tg:123", "sku": "SKU001"})
+        resp = client.post("/api/watches", json={"user_id": "tg:123", "sku": "SKU001"})
 
     assert resp.status_code == status.HTTP_409_CONFLICT
     assert "already watches" in resp.json()["detail"]
@@ -108,7 +108,7 @@ def test_create_watch_invalid_sku():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.post("/api/v1/watches", json={"user_id": "tg:123", "sku": "NOPE"})
+        resp = client.post("/api/watches", json={"user_id": "tg:123", "sku": "NOPE"})
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
     assert "NOPE" in resp.json()["detail"]
@@ -119,7 +119,7 @@ def test_create_watch_empty_user_id_rejected():
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.post("/api/v1/watches", json={"user_id": "", "sku": "SKU001"})
+    resp = client.post("/api/watches", json={"user_id": "", "sku": "SKU001"})
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
@@ -128,7 +128,7 @@ def test_create_watch_empty_sku_rejected():
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.post("/api/v1/watches", json={"user_id": "tg:123", "sku": ""})
+    resp = client.post("/api/watches", json={"user_id": "tg:123", "sku": ""})
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
@@ -137,7 +137,7 @@ def test_create_watch_missing_body():
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.post("/api/v1/watches")
+    resp = client.post("/api/watches")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
@@ -154,7 +154,7 @@ def test_list_watches_with_product():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/watches?user_id=tg:123")
+        resp = client.get("/api/watches?user_id=tg:123")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -172,7 +172,7 @@ def test_list_watches_product_missing():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/watches?user_id=tg:123")
+        resp = client.get("/api/watches?user_id=tg:123")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -187,7 +187,7 @@ def test_list_watches_empty():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/watches?user_id=tg:999")
+        resp = client.get("/api/watches?user_id=tg:999")
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == []
@@ -198,7 +198,7 @@ def test_list_watches_missing_user_id():
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.get("/api/v1/watches")
+    resp = client.get("/api/watches")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
@@ -215,7 +215,7 @@ def test_delete_watch_success():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.delete("/api/v1/watches/SKU001?user_id=tg:123")
+        resp = client.delete("/api/watches/SKU001?user_id=tg:123")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
 
@@ -227,7 +227,7 @@ def test_delete_watch_not_found():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.delete("/api/v1/watches/NOPE?user_id=tg:123")
+        resp = client.delete("/api/watches/NOPE?user_id=tg:123")
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
     assert "NOPE" in resp.json()["detail"]
@@ -238,7 +238,7 @@ def test_delete_watch_missing_user_id():
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.delete("/api/v1/watches/SKU001")
+    resp = client.delete("/api/watches/SKU001")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
@@ -258,7 +258,7 @@ def test_pending_notifications_success():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/watches/notifications")
+        resp = client.get("/api/watches/notifications")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -279,7 +279,7 @@ def test_pending_notifications_empty():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/watches/notifications")
+        resp = client.get("/api/watches/notifications")
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == []
@@ -295,7 +295,7 @@ def test_pending_notifications_product_missing():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/watches/notifications")
+        resp = client.get("/api/watches/notifications")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -316,7 +316,7 @@ def test_pending_notifications_destock_event():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/watches/notifications")
+        resp = client.get("/api/watches/notifications")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -339,7 +339,7 @@ def test_pending_notifications_store_event():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/watches/notifications")
+        resp = client.get("/api/watches/notifications")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -360,7 +360,7 @@ def test_pending_notifications_online_event_has_null_store():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
-        resp = client.get("/api/v1/watches/notifications")
+        resp = client.get("/api/watches/notifications")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -379,7 +379,7 @@ def test_ack_notifications_success():
         app.dependency_overrides[get_db] = lambda: session
         client = TestClient(app)
         resp = client.post(
-            "/api/v1/watches/notifications/ack",
+            "/api/watches/notifications/ack",
             json={"event_ids": [1, 2]},
         )
 
@@ -392,7 +392,7 @@ def test_ack_notifications_empty_list_rejected():
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
     resp = client.post(
-        "/api/v1/watches/notifications/ack",
+        "/api/watches/notifications/ack",
         json={"event_ids": []},
     )
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
@@ -403,5 +403,5 @@ def test_ack_notifications_missing_body():
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
     client = TestClient(app)
-    resp = client.post("/api/v1/watches/notifications/ack")
+    resp = client.post("/api/watches/notifications/ack")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT

--- a/bot/bot/api_client.py
+++ b/bot/bot/api_client.py
@@ -35,7 +35,7 @@ class BackendClient:
 
     async def open(self) -> None:
         self._client = httpx.AsyncClient(
-            base_url=f"{self._base_url}/api/v1",
+            base_url=f"{self._base_url}/api",
             timeout=self._timeout,
         )
 
@@ -47,61 +47,61 @@ class BackendClient:
     # ── Products ────────────────────────────────────────────────
 
     async def list_products(self, **params: Any) -> dict[str, Any]:
-        """GET /api/v1/products with optional query params."""
+        """GET /api/products with optional query params."""
         return await self._get("/products", params=params)
 
     async def get_product(self, sku: str) -> dict[str, Any] | None:
-        """GET /api/v1/products/{sku}. Returns None if 404."""
+        """GET /api/products/{sku}. Returns None if 404."""
         return await self._get_or_none(f"/products/{sku}")
 
     async def get_random_product(self, **params: Any) -> dict[str, Any] | None:
-        """GET /api/v1/products/random. Returns None if 404 (empty catalog)."""
+        """GET /api/products/random. Returns None if 404 (empty catalog)."""
         return await self._get_or_none("/products/random", params=params)
 
     async def get_facets(self) -> dict[str, Any]:
-        """GET /api/v1/products/facets."""
+        """GET /api/products/facets."""
         return await self._get("/products/facets")
 
     # ── Watches ─────────────────────────────────────────────────
 
     async def create_watch(self, user_id: str, sku: str) -> dict[str, Any]:
-        """POST /api/v1/watches."""
+        """POST /api/watches."""
         return await self._post("/watches", json={"user_id": user_id, "sku": sku})
 
     async def list_watches(self, user_id: str) -> list[dict[str, Any]]:
-        """GET /api/v1/watches?user_id=..."""
+        """GET /api/watches?user_id=..."""
         return await self._get("/watches", params={"user_id": user_id})
 
     async def delete_watch(self, user_id: str, sku: str) -> None:
-        """DELETE /api/v1/watches/{sku}?user_id=..."""
+        """DELETE /api/watches/{sku}?user_id=..."""
         await self._delete(f"/watches/{sku}", params={"user_id": user_id})
 
     # ── Stores ───────────────────────────────────────────────────
 
     async def get_nearby_stores(self, lat: float, lng: float) -> list[dict[str, Any]]:
-        """GET /api/v1/stores/nearby — stores sorted by distance from coordinates."""
+        """GET /api/stores/nearby — stores sorted by distance from coordinates."""
         return await self._get("/stores/nearby", params={"lat": lat, "lng": lng})
 
     async def list_user_stores(self, user_id: str) -> list[dict[str, Any]]:
-        """GET /api/v1/users/{user_id}/stores — user's preferred stores."""
+        """GET /api/users/{user_id}/stores — user's preferred stores."""
         return await self._get(f"/users/{user_id}/stores")
 
     async def add_user_store(self, user_id: str, saq_store_id: str) -> dict[str, Any]:
-        """POST /api/v1/users/{user_id}/stores — add a store to preferences."""
+        """POST /api/users/{user_id}/stores — add a store to preferences."""
         return await self._post(f"/users/{user_id}/stores", json={"saq_store_id": saq_store_id})
 
     async def remove_user_store(self, user_id: str, saq_store_id: str) -> None:
-        """DELETE /api/v1/users/{user_id}/stores/{saq_store_id}."""
+        """DELETE /api/users/{user_id}/stores/{saq_store_id}."""
         await self._delete(f"/users/{user_id}/stores/{saq_store_id}")
 
     # ── Notifications ────────────────────────────────────────────
 
     async def get_pending_notifications(self) -> list[dict[str, Any]]:
-        """GET /api/v1/watches/notifications — pending stock event alerts."""
+        """GET /api/watches/notifications — pending stock event alerts."""
         return await self._get("/watches/notifications")
 
     async def ack_notifications(self, event_ids: list[int]) -> None:
-        """POST /api/v1/watches/notifications/ack — mark events as sent."""
+        """POST /api/watches/notifications/ack — mark events as sent."""
         await self._post("/watches/notifications/ack", json={"event_ids": event_ids})
 
     # ── Transport ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Drop the `/v1` version segment from all API routes. This is an internal API with no public consumers — the only clients are the bot and the future frontend, both deployed by the same team. URL versioning adds maintenance overhead with no benefit when you control both sides of the contract.

## Related issue(s)

Closes #236

## Changes

- `backend/app.py`: `prefix="/api/v1"` → `prefix="/api"` on all 4 `include_router` calls
- `bot/bot/api_client.py`: updated `base_url` construction and all docstring path references
- `backend/tests/test_products.py`, `test_watches.py`, `test_stores.py`: updated all test URLs (66 occurrences, mechanical replace)