### PR TITLE
feat: inline unwatch buttons and unified watch UX (#240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `/alerts` shows inline remove buttons per wine — tap to unwatch without typing `/unwatch` (#240)
+- `/watch` and `/unwatch` now show the updated watch list keyboard directly, with no separate confirmation message (#240)
 - Group stock notifications by product — one message per wine listing all affected stores, with online availability hint (#256)
 - Targeted store availability fetch — checks only preferred stores via lat/lng proximity instead of paginating all ~400 stores (#254)
 - HTTP 404s logged as warnings instead of errors, counted separately in run summary (#197)

--- a/bot/bot/app.py
+++ b/bot/bot/app.py
@@ -17,6 +17,7 @@ from bot.config import (
     CALLBACK_PREFIX,
     CALLBACK_STORE_DONE,
     CALLBACK_STORE_PREFIX,
+    CALLBACK_WATCH_PREFIX,
     CMD_ALERTS,
     CMD_HELP,
     CMD_MYSTORES,
@@ -45,7 +46,7 @@ from bot.handlers.new import new_command
 from bot.handlers.notifications import poll_notifications
 from bot.handlers.random import random_command
 from bot.handlers.start import help_command, start
-from bot.handlers.watch import alerts_command, unwatch_command, watch_command
+from bot.handlers.watch import alerts_command, unwatch_command, watch_command, watch_remove_callback
 from bot.middleware import allowlist_gate, rate_limit_gate
 
 
@@ -115,7 +116,10 @@ def create_app() -> Application:
     app.add_handler(MessageHandler(filters.Text([MENU_STORES]), mystores_command))
     app.add_handler(MessageHandler(filters.Text([MENU_HELP]), help_command))
     app.add_handler(MessageHandler(filters.Text(["\u2190 Back"]), back_handler))
-    # Inline button callbacks — store selection ("s:") and product filters ("f:")
+    # Inline button callbacks — watch removal ("w:"), store selection ("s:"), product filters ("f:")
+    app.add_handler(
+        CallbackQueryHandler(watch_remove_callback, pattern=rf"^{CALLBACK_WATCH_PREFIX}rm:")
+    )
     app.add_handler(
         CallbackQueryHandler(store_toggle_callback, pattern=rf"^{CALLBACK_STORE_PREFIX}toggle:")
     )

--- a/bot/bot/config.py
+++ b/bot/bot/config.py
@@ -78,6 +78,10 @@ CALLBACK_STORE_TOGGLE = f"{CALLBACK_STORE_PREFIX}toggle:"
 CALLBACK_STORE_REMOVE = f"{CALLBACK_STORE_PREFIX}rm:"
 CALLBACK_STORE_DONE = f"{CALLBACK_STORE_PREFIX}done"
 
+# Watch removal callbacks — shared between keyboards.py and watch handler
+CALLBACK_WATCH_PREFIX = "w:"
+CALLBACK_WATCH_REMOVE = f"{CALLBACK_WATCH_PREFIX}rm:"
+
 
 class PriceBucket(NamedTuple):
     min_price: int | None

--- a/bot/bot/handlers/watch.py
+++ b/bot/bot/handlers/watch.py
@@ -1,12 +1,14 @@
 from http import HTTPStatus
+from typing import Any
 
 from loguru import logger
 from telegram import Update
 from telegram.ext import ContextTypes
 
 from bot.api_client import BackendAPIError, BackendClient, BackendUnavailableError
-from bot.config import SAQ_BASE_URL, USER_ID_PREFIX
-from bot.formatters import format_product_line, format_watch_list
+from bot.config import CALLBACK_WATCH_REMOVE, SAQ_BASE_URL, USER_ID_PREFIX
+from bot.formatters import format_watch_list
+from bot.keyboards import build_watch_keyboard
 
 
 def _user_id(update: Update) -> str:
@@ -24,16 +26,31 @@ def _parse_sku(context: ContextTypes.DEFAULT_TYPE) -> str | None:
     return arg
 
 
-async def _send_watch_recap(update: Update, api: BackendClient, user_id: str) -> None:
-    """Fetch and send the current watch list as a follow-up message."""
+def _watch_list_header(count: int) -> str:
+    plural = "s" if count != 1 else ""
+    return f"\U0001f440 *{count} watched wine{plural}*\n\n\U0001f446 Tap to remove."
+
+
+async def _render_watch_list(update: Update, watches: list[dict[str, Any]]) -> None:
+    """Render the watch list — keyboard with remove buttons if non-empty, text otherwise."""
+    keyboard = build_watch_keyboard(watches)
+    if keyboard:
+        await update.message.reply_text(
+            _watch_list_header(len(watches)), parse_mode="Markdown", reply_markup=keyboard
+        )
+    else:
+        text = format_watch_list(watches)
+        await update.message.reply_text(text, parse_mode="Markdown", disable_web_page_preview=True)
+
+
+async def _send_watch_list(update: Update, api: BackendClient, user_id: str) -> None:
+    """Fetch and render the watch list — silently skips on backend error."""
     try:
         watches = await api.list_watches(user_id)
     except (BackendUnavailableError, BackendAPIError) as exc:
-        logger.debug("Skipping watch recap — backend unavailable: {}", exc)
+        logger.debug("Skipping watch list — backend unavailable: {}", exc)
         return
-    if watches:
-        text = format_watch_list(watches)
-        await update.message.reply_text(text, parse_mode="Markdown", disable_web_page_preview=True)
+    await _render_watch_list(update, watches)
 
 
 async def watch_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -47,7 +64,7 @@ async def watch_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     user_id = _user_id(update)
 
     try:
-        data = await api.create_watch(user_id, sku)
+        await api.create_watch(user_id, sku)
     except BackendAPIError as exc:
         if exc.status_code == HTTPStatus.NOT_FOUND:
             await update.message.reply_text(f"Product `{sku}` not found.", parse_mode="Markdown")
@@ -65,14 +82,7 @@ async def watch_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         await update.message.reply_text("Backend is currently unavailable. Try again later.")
         return
 
-    product = data.get("product")
-    if product:
-        line = format_product_line(product, 0).removeprefix("0. ")
-        text = f"Now watching {line}"
-    else:
-        text = f"Watching `{sku}` — you'll get alerts when availability changes."
-    await update.message.reply_text(text, parse_mode="Markdown", disable_web_page_preview=True)
-    await _send_watch_recap(update, api, user_id)
+    await _send_watch_list(update, api, user_id)
 
 
 async def unwatch_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -99,20 +109,52 @@ async def unwatch_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         await update.message.reply_text("Backend is currently unavailable. Try again later.")
         return
 
-    await update.message.reply_text(f"Stopped watching `{sku}`.", parse_mode="Markdown")
-    await _send_watch_recap(update, api, user_id)
+    await _send_watch_list(update, api, user_id)
 
 
 async def alerts_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Handle /alerts — list all watched products."""
+    """Handle /alerts — list watched products with inline remove buttons."""
     api: BackendClient = context.bot_data["api"]
+    user_id = _user_id(update)
 
     try:
-        watches = await api.list_watches(_user_id(update))
+        watches = await api.list_watches(user_id)
     except (BackendUnavailableError, BackendAPIError) as exc:
         logger.warning("Backend unavailable during /alerts: {}", exc)
         await update.message.reply_text("Backend is currently unavailable. Try again later.")
         return
 
-    text = format_watch_list(watches)
-    await update.message.reply_text(text, parse_mode="Markdown", disable_web_page_preview=True)
+    await _render_watch_list(update, watches)
+
+
+async def watch_remove_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle inline remove button from /alerts list."""
+    query = update.callback_query
+    await query.answer()
+
+    sku = query.data.removeprefix(CALLBACK_WATCH_REMOVE)
+    api: BackendClient = context.bot_data["api"]
+    user_id = _user_id(update)
+
+    try:
+        await api.delete_watch(user_id, sku)
+    except BackendAPIError as exc:
+        # 404 = already removed — treat as success
+        if exc.status_code != HTTPStatus.NOT_FOUND:
+            logger.warning("Backend error during watch remove: {}", exc)
+            await query.answer("Something went wrong.", show_alert=True)
+            return
+    except BackendUnavailableError as exc:
+        logger.warning("Backend unavailable during watch remove (user={}): {}", user_id, exc)
+        await query.answer("Backend unavailable.", show_alert=True)
+        return
+
+    try:
+        watches = await api.list_watches(user_id)
+    except (BackendUnavailableError, BackendAPIError) as exc:
+        logger.warning("Failed to refresh watches after remove (user={}): {}", user_id, exc)
+        watches = []
+
+    keyboard = build_watch_keyboard(watches)
+    text = _watch_list_header(len(watches)) if watches else format_watch_list([])
+    await query.edit_message_text(text, parse_mode="Markdown", reply_markup=keyboard)

--- a/bot/bot/keyboards.py
+++ b/bot/bot/keyboards.py
@@ -11,6 +11,7 @@ from bot.config import (
     CALLBACK_STORE_DONE,
     CALLBACK_STORE_REMOVE,
     CALLBACK_STORE_TOGGLE,
+    CALLBACK_WATCH_REMOVE,
     MENU_ALERTS,
     MENU_HELP,
     MENU_NEW,
@@ -144,5 +145,21 @@ def build_saved_stores_keyboard(stores: list[dict[str, Any]]) -> InlineKeyboardM
         label = f"\u2716 {name} — {city}" if city else f"\u2716 {name}"
         rows.append(
             [InlineKeyboardButton(label, callback_data=f"{CALLBACK_STORE_REMOVE}{store_id}")]
+        )
+    return InlineKeyboardMarkup(rows)
+
+
+def build_watch_keyboard(watches: list[dict[str, Any]]) -> InlineKeyboardMarkup | None:
+    """Build inline keyboard with remove buttons for watched wines. None if empty."""
+    if not watches:
+        return None
+    rows: list[list[InlineKeyboardButton]] = []
+    for entry in watches:
+        watch = entry["watch"]
+        product = entry.get("product")
+        sku = watch["sku"]
+        name = (product or {}).get("name") or sku
+        rows.append(
+            [InlineKeyboardButton(f"\u2716 {name}", callback_data=f"{CALLBACK_WATCH_REMOVE}{sku}")]
         )
     return InlineKeyboardMarkup(rows)

--- a/bot/tests/test_app.py
+++ b/bot/tests/test_app.py
@@ -10,5 +10,5 @@ def test_create_app_returns_application() -> None:
 
 def test_create_app_registers_handlers() -> None:
     app = create_app()
-    # 8 commands + 1 location + 6 menu buttons + 4 callbacks = 19
-    assert len(app.handlers[0]) == 19
+    # 8 commands + 1 location + 6 menu buttons + 5 callbacks = 20
+    assert len(app.handlers[0]) == 20

--- a/bot/tests/test_watches.py
+++ b/bot/tests/test_watches.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from bot.api_client import BackendAPIError, BackendUnavailableError
-from bot.handlers.watch import alerts_command, unwatch_command, watch_command
+from bot.handlers.watch import alerts_command, unwatch_command, watch_command, watch_remove_callback
 
 
 @pytest.fixture
@@ -27,18 +27,23 @@ def update():
     return mock
 
 
+@pytest.fixture
+def callback_query():
+    mock = AsyncMock()
+    mock.data = "w:rm:10327701"
+    return mock
+
+
+@pytest.fixture
+def callback_update(callback_query):
+    mock = AsyncMock()
+    mock.effective_user.id = 42
+    mock.callback_query = callback_query
+    return mock
+
+
 # ── /watch ───────────────────────────────────────────────────
 
-
-_WATCH_RESPONSE = {
-    "watch": {"id": 1, "user_id": "tg:42", "sku": "10327701", "created_at": "2026-01-01"},
-    "product": {
-        "name": "Mouton Cadet",
-        "price": "16.95",
-        "availability": True,
-        "sku": "10327701",
-    },
-}
 
 _WATCH_LIST = [
     {
@@ -55,24 +60,20 @@ _WATCH_LIST = [
 
 async def test_watch_creates_watch(update, context, api):
     context.args = ["10327701"]
-    api.create_watch.return_value = _WATCH_RESPONSE
     api.list_watches.return_value = _WATCH_LIST
 
     await watch_command(update, context)
 
     api.create_watch.assert_called_once_with("tg:42", "10327701")
-    # First reply: confirmation, second: recap
-    assert update.message.reply_text.call_count == 2
-    text = update.message.reply_text.call_args_list[0][0][0]
-    assert "Mouton Cadet" in text
-    assert "watching" in text.lower()
-    recap = update.message.reply_text.call_args_list[1][0][0]
-    assert "1 watched wine" in recap
+    # Single reply: the watch list keyboard
+    assert update.message.reply_text.call_count == 1
+    text = update.message.reply_text.call_args[0][0]
+    assert "👀" in text
+    assert "1 watched wine" in text
 
 
 async def test_watch_accepts_saq_url(update, context, api):
     context.args = ["https://www.saq.com/fr/10327701"]
-    api.create_watch.return_value = _WATCH_RESPONSE
     api.list_watches.return_value = _WATCH_LIST
 
     await watch_command(update, context)
@@ -82,21 +83,11 @@ async def test_watch_accepts_saq_url(update, context, api):
 
 async def test_watch_accepts_saq_url_with_trailing_slash(update, context, api):
     context.args = ["https://www.saq.com/fr/10327701/"]
-    api.create_watch.return_value = _WATCH_RESPONSE
     api.list_watches.return_value = _WATCH_LIST
 
     await watch_command(update, context)
 
     api.create_watch.assert_called_once_with("tg:42", "10327701")
-
-
-async def test_unwatch_accepts_saq_url(update, context, api):
-    context.args = ["https://www.saq.com/fr/10327701"]
-    api.list_watches.return_value = []
-
-    await unwatch_command(update, context)
-
-    api.delete_watch.assert_called_once_with("tg:42", "10327701")
 
 
 async def test_watch_no_sku(update, context):
@@ -151,37 +142,37 @@ async def test_watch_generic_api_error(update, context, api):
 # ── /unwatch ─────────────────────────────────────────────────
 
 
-async def test_unwatch_deletes_watch(update, context, api):
-    context.args = ["10327701"]
+async def test_unwatch_accepts_saq_url(update, context, api):
+    context.args = ["https://www.saq.com/fr/10327701"]
     api.list_watches.return_value = []
 
     await unwatch_command(update, context)
 
     api.delete_watch.assert_called_once_with("tg:42", "10327701")
-    text = update.message.reply_text.call_args_list[0][0][0]
-    assert "stopped" in text.lower()
 
 
-async def test_unwatch_sends_recap(update, context, api):
+async def test_unwatch_deletes_watch(update, context, api):
     context.args = ["10327701"]
     api.list_watches.return_value = _WATCH_LIST
 
     await unwatch_command(update, context)
 
-    # First reply: confirmation, second: recap
-    assert update.message.reply_text.call_count == 2
-    recap = update.message.reply_text.call_args_list[1][0][0]
-    assert "1 watched wine" in recap
+    api.delete_watch.assert_called_once_with("tg:42", "10327701")
+    # Single reply: updated watch list keyboard (no preamble — symmetric with /watch)
+    assert update.message.reply_text.call_count == 1
+    text = update.message.reply_text.call_args[0][0]
+    assert "1 watched wine" in text
 
 
-async def test_unwatch_no_recap_when_empty(update, context, api):
+async def test_unwatch_shows_empty_state(update, context, api):
     context.args = ["10327701"]
     api.list_watches.return_value = []
 
     await unwatch_command(update, context)
 
-    # Only confirmation, no recap for empty list
     assert update.message.reply_text.call_count == 1
+    text = update.message.reply_text.call_args[0][0]
+    assert "not watching" in text.lower()
 
 
 async def test_unwatch_no_sku(update, context):
@@ -233,8 +224,12 @@ async def test_alerts_shows_watches(update, context, api):
 
     api.list_watches.assert_called_once_with("tg:42")
     text = update.message.reply_text.call_args[0][0]
-    assert "Mouton Cadet" in text
+    assert "👀" in text
     assert "1 watched wine" in text
+    # Product name is in the inline keyboard button, not the message text
+    keyboard = update.message.reply_text.call_args[1]["reply_markup"]
+    assert keyboard is not None
+    assert "Mouton Cadet" in keyboard.inline_keyboard[0][0].text
 
 
 async def test_alerts_empty(update, context, api):
@@ -262,8 +257,10 @@ async def test_alerts_with_delisted_product(update, context, api):
     await alerts_command(update, context)
 
     text = update.message.reply_text.call_args[0][0]
-    assert "GONE123" in text
-    assert "no longer available" in text
+    assert "1 watched wine" in text
+    # Delisted product: button shows SKU as fallback
+    keyboard = update.message.reply_text.call_args[1]["reply_markup"]
+    assert "GONE123" in keyboard.inline_keyboard[0][0].text
 
 
 async def test_alerts_backend_unavailable(update, context, api):
@@ -273,3 +270,60 @@ async def test_alerts_backend_unavailable(update, context, api):
 
     text = update.message.reply_text.call_args[0][0]
     assert "unavailable" in text.lower()
+
+
+# ── watch_remove_callback (#240) ─────────────────────────────
+
+
+async def test_watch_remove_success(callback_update, callback_query, context, api):
+    api.list_watches.return_value = []
+
+    await watch_remove_callback(callback_update, context)
+
+    api.delete_watch.assert_called_once_with("tg:42", "10327701")
+    callback_query.edit_message_text.assert_called_once()
+    text = callback_query.edit_message_text.call_args[0][0]
+    assert "not watching" in text.lower()
+
+
+async def test_watch_remove_already_gone_treated_as_success(
+    callback_update, callback_query, context, api
+):
+    api.delete_watch.side_effect = BackendAPIError(404, "Not Found")
+    api.list_watches.return_value = []
+
+    await watch_remove_callback(callback_update, context)
+
+    # 404 = already removed — treated as success, list still refreshed
+    callback_query.edit_message_text.assert_called_once()
+
+
+async def test_watch_remove_remaining_watches_show_keyboard(
+    callback_update, callback_query, context, api
+):
+    api.list_watches.return_value = _WATCH_LIST
+
+    await watch_remove_callback(callback_update, context)
+
+    text = callback_query.edit_message_text.call_args[0][0]
+    assert "1 watched wine" in text
+    kwargs = callback_query.edit_message_text.call_args[1]
+    assert kwargs["reply_markup"] is not None
+
+
+async def test_watch_remove_backend_error(callback_update, callback_query, context, api):
+    api.delete_watch.side_effect = BackendAPIError(500, "Internal Server Error")
+
+    await watch_remove_callback(callback_update, context)
+
+    callback_query.answer.assert_called_with("Something went wrong.", show_alert=True)
+    callback_query.edit_message_text.assert_not_called()
+
+
+async def test_watch_remove_backend_unavailable(callback_update, callback_query, context, api):
+    api.delete_watch.side_effect = BackendUnavailableError("down")
+
+    await watch_remove_callback(callback_update, context)
+
+    callback_query.answer.assert_called_with("Backend unavailable.", show_alert=True)
+    callback_query.edit_message_text.assert_not_called()

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -93,7 +93,7 @@ See [specs/STORE_AVAILABILITY.md](specs/STORE_AVAILABILITY.md) for API reference
 ### Phase 5c — Watch UX
 
 - [ ] Auto-detect pasted SAQ URLs — prompt "Watch this?" without `/watch` command
-- [ ] Inline unwatch buttons on `/alerts` list (#240)
+- [x] Inline unwatch buttons on `/alerts` list (#240)
 - [ ] Deep links — `t.me/bot?start=watch_{sku}` for external watch triggers
 
 ### Phase 5d — Bilingual Support


### PR DESCRIPTION
## Summary

Adds inline ✖ remove buttons to \`/alerts\` so users can unwatch wines without typing \`/unwatch\`. Also unifies the UX: \`/watch\`, \`/unwatch\`, and the inline button all now respond with the same watch list keyboard — no separate confirmation messages.

## Related issue(s)

Closes #240
Refs #242 — nudge decided against; \`/start\` is the right place for onboarding, not watch commands.

## Changes

- \`config.py\` — \`CALLBACK_WATCH_PREFIX\` + \`CALLBACK_WATCH_REMOVE\` constants
- \`keyboards.py\` — \`build_watch_keyboard()\` (mirrors \`build_saved_stores_keyboard\` pattern)
- \`handlers/watch.py\` — \`_watch_list_header()\`, \`_render_watch_list()\`, \`_send_watch_list()\` helpers; \`alerts_command\` sends inline keyboard; \`watch_remove_callback\` added; \`/watch\` and \`/unwatch\` unified to show keyboard with no preamble
- \`app.py\` — registers \`watch_remove_callback\` on \`^w:rm:\` pattern
- \`test_watches.py\` — updated existing tests, added 5 tests for \`watch_remove_callback\`

## How to test

```
/watch 10327701        # should show 👀 keyboard, no "Now watching" message
/alerts                # should show same 👀 keyboard with ✖ buttons
# tap ✖ button        # should remove wine and refresh keyboard inline
/unwatch 10327701      # should show updated keyboard, no "Stopped watching" message
```