### PR TITLE
docs: add deployment procedure to PRODUCTION.md (#227)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for database setup options and fu
 - [Architecture](docs/ARCHITECTURE.md) — system design, schema boundaries, key decisions
 - [Development](docs/DEVELOPMENT.md) — local setup, workflows, migrations
 - [Operations](docs/OPERATIONS.md) — production scheduling, scraper ops, failure recovery
-- [Production](docs/PRODUCTION.md) — VPS state, backups, security hardening, observability infra
+- [Production](docs/PRODUCTION.md) — VPS state, deployment, backups, security hardening
 - [Engineering](docs/ENGINEERING.md) — testing, security, observability, SRE, platform, ML/MLOps
 - [Roadmap](docs/ROADMAP.md) — product phases and timeline
 - [Changelog](CHANGELOG.md) — release history

--- a/docs/ENGINEERING.md
+++ b/docs/ENGINEERING.md
@@ -49,7 +49,7 @@ Infrastructure-level production targets (VPS hardening, backups, Grafana) tracke
 **Done:** Makefile (per-service and combined targets for install, dev, lint, format, test, coverage, audit, build, run). Docker Compose (dev profile for postgres, production for backend + bot). CI/CD (lint + test + audit per service, Hadolint, coverage enforcement, concurrency cancel-in-progress). Systemd timers for production scheduling. Scoped git hooks (pre-commit lints changed services, pre-push tests changed services + checks lock files + migration coverage).
 
 **Next:**
-- `docs/DEPLOYMENT.md` (#227): deploy flow, migration order, rollback procedure, initial VPS bootstrap — production is live but the process is only in your head
+- ~~`docs/DEPLOYMENT.md`~~: folded into [PRODUCTION.md](PRODUCTION.md#deploying) (#227)
 - CD pipeline: push to main → build image → push to GHCR → SSH deploy to VPS — currently manual and undocumented
 - Image tagging: `:latest` for production, `:YYYYMMDD-HHMMSS` for rollback archive — enables one-command rollback
 - `docker-compose.prod.yml`: explicit resource limits, restart policies, health checks, no debug ports — current compose mixes dev and prod concerns

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -1,7 +1,6 @@
 # Production
 
-Infrastructure-level state and outstanding work for the production VPS.
-Application deployment process documented in [DEPLOYMENT.md](DEPLOYMENT.md) (#227, not yet written).
+Infrastructure-level state, deployment process, and outstanding work for the production VPS.
 Step-by-step setup instructions live in the infra repo (private).
 
 ---
@@ -18,6 +17,41 @@ Step-by-step setup instructions live in the infra repo (private).
 - **Reverse proxy**: Caddy (SSL + routing via victorpatrin.dev subdomains)
 - **Services**: backend, bot, scraper (systemd timer), shared-postgres
 - **Deployed**: v1.1.0
+
+---
+
+## Deploying
+
+Tag on main first (see [CHANGELOG.md](../CHANGELOG.md)), then deploy the tag on the VPS.
+
+```bash
+git fetch --tags && git checkout vX.Y.Z
+diff .env.example .env            # check for new/changed vars
+make build                        # rebuild service images (including scraper for next scheduled run)
+make migrate                      # apply pending migrations (idempotent, always safe to run)
+docker compose up -d backend bot  # restart services
+```
+
+If `deploy/` unit files changed (or first deploy):
+
+```bash
+sudo cp deploy/saq-scraper.{service,timer} deploy/saq-watches.{service,timer} /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now saq-scraper.timer saq-watches.timer
+```
+
+Verify:
+
+```bash
+curl -s localhost:8001/health     # backend responds
+# message the bot on Telegram    # bot responds
+systemctl status saq-scraper.timer   # timer active, next run scheduled
+systemctl status saq-watches.timer   # timer active, next run scheduled
+```
+
+Rollback: `git checkout vX.Y.Z && make build && docker compose up -d backend bot`
+
+Migrations are forward-only — never run `downgrade()` in production. Write a new migration to fix mistakes. See [OPERATIONS.md](OPERATIONS.md#forward-only-in-production).
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the VPS deployment flow in PRODUCTION.md instead of a standalone DEPLOYMENT.md — keeps deploy steps next to the infrastructure state they describe.

Closes #227

## Changes

- **PRODUCTION.md**: added Deploying section — tag-based deploy flow, env diff check, systemd unit install, verification checklist, rollback, migration note
- **ENGINEERING.md**: marked `docs/DEPLOYMENT.md` as folded into PRODUCTION.md
- **README.md**: updated Production doc description to include "deployment"