### PR TITLE
chore: run CI on feature branch PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "feat/*"]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Add `feat/*` glob to CI pull_request trigger so PRs targeting feature branches get lint + tests
- One-line change in `.github/workflows/ci.yml`

## Motivation
Phase 6 (recommendations engine) uses a feature branch (`feat/recommendations`) with sub-branches merged into it. Without this, CI only ran on PRs to `main`.

## Test plan
- [ ] Open a PR targeting any `feat/*` branch and verify CI triggers
- [ ] Verify PRs to `main` still trigger CI as before