### PR TITLE
feat: RAG recommendation pipeline (#309, #310, #311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Daily availability refresh via Adobe Live Search (`--availability-check`) — replaces planned `--check-watches` (#289)
 - Wine attribute enrichment from Adobe (`--enrich-wines`) — backfills tasting profiles, taste tags, grape blends, and vintages for ~30k wine products
 - Intent parser — Claude Haiku extracts structured filters (category, price, country) from natural language wine queries (#155)
+- `POST /api/recommendations` — natural language wine recommendations via intent parsing + embedding similarity search (#309, #310, #311)
 
 ## [1.2.0] - 2026-03-03
 

--- a/backend/api/recommendations.py
+++ b/backend/api/recommendations.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.db import get_db
+from backend.schemas.recommendation import RecommendationIn, RecommendationOut
+from backend.services.recommendations import recommend
+
+router = APIRouter(prefix="/recommendations", tags=["recommendations"])
+
+
+@router.post("", response_model=RecommendationOut)
+async def post_recommendations(
+    body: RecommendationIn,
+    db: AsyncSession = Depends(get_db),
+) -> RecommendationOut:
+    return await recommend(db, body.query)

--- a/backend/app.py
+++ b/backend/app.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from backend.api.health import router as health_router
 from backend.api.products import router as products_router
+from backend.api.recommendations import router as recommendations_router
 from backend.api.stores import stores_router, users_router
 from backend.api.watches import router as watches_router
 from backend.config import SERVICE_NAME, backend_settings
@@ -42,3 +43,4 @@ app.include_router(products_router, prefix="/api")
 app.include_router(stores_router, prefix="/api")
 app.include_router(users_router, prefix="/api")
 app.include_router(watches_router, prefix="/api")
+app.include_router(recommendations_router, prefix="/api")

--- a/backend/config.py
+++ b/backend/config.py
@@ -15,6 +15,8 @@ DEFAULT_NEARBY_LIMIT = 5
 MAX_NEARBY_LIMIT = 20
 MAX_SAQ_STORE_ID_LENGTH = 20
 
+DEFAULT_RECOMMENDATION_LIMIT = 5
+
 
 class BackendSettings(BaseSettings):
     """Backend-specific configuration (CORS, auth, etc.)."""
@@ -25,8 +27,11 @@ class BackendSettings(BaseSettings):
         extra="ignore",
     )
 
-    # Anthropic API key for Claude recommendations.
+    # Anthropic API key for Claude intent parsing.
     ANTHROPIC_API_KEY: str = ""
+
+    # OpenAI API key for embedding queries.
+    OPENAI_API_KEY: str = ""
 
     # Shared secret for bot → backend internal calls (X-Bot-Secret header).
     # Generate with: python -c "import secrets; print(secrets.token_hex(32))"

--- a/backend/repositories/recommendations.py
+++ b/backend/repositories/recommendations.py
@@ -1,0 +1,34 @@
+from core.db.models import Product
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.config import DEFAULT_RECOMMENDATION_LIMIT
+from backend.schemas.recommendation import IntentResult
+
+
+async def find_similar(
+    db: AsyncSession,
+    intent: IntentResult,
+    query_embedding: list[float],
+    *,
+    limit: int = DEFAULT_RECOMMENDATION_LIMIT,
+) -> list[Product]:
+    """Return products matching structured filters, ranked by embedding similarity."""
+    stmt = select(Product).where(Product.delisted_at.is_(None)).where(Product.embedding.isnot(None))
+
+    if intent.categories:
+        stmt = stmt.where(Product.category.in_(intent.categories))
+    if intent.country is not None:
+        stmt = stmt.where(Product.country == intent.country)
+    if intent.min_price is not None:
+        stmt = stmt.where(Product.price >= intent.min_price)
+    if intent.max_price is not None:
+        stmt = stmt.where(Product.price <= intent.max_price)
+    if intent.available_only:
+        stmt = stmt.where(Product.online_availability.is_(True))
+
+    # Similarity ranking
+    stmt = stmt.order_by(Product.embedding.cosine_distance(query_embedding)).limit(limit)
+
+    result = await db.execute(stmt)
+    return list(result.scalars().all())

--- a/backend/schemas/recommendation.py
+++ b/backend/schemas/recommendation.py
@@ -1,6 +1,9 @@
 from decimal import Decimal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from backend.config import MAX_SEARCH_LENGTH
+from backend.schemas.product import ProductOut
 
 
 class IntentResult(BaseModel):
@@ -12,3 +15,12 @@ class IntentResult(BaseModel):
     country: str | None = None
     available_only: bool = True
     semantic_query: str = ""
+
+
+class RecommendationIn(BaseModel):
+    query: str = Field(min_length=1, max_length=MAX_SEARCH_LENGTH)
+
+
+class RecommendationOut(BaseModel):
+    products: list[ProductOut]
+    intent: IntentResult

--- a/backend/services/recommendations.py
+++ b/backend/services/recommendations.py
@@ -1,0 +1,20 @@
+from core.embedding_client import embed_query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.config import backend_settings
+from backend.repositories.recommendations import find_similar
+from backend.schemas.product import ProductOut
+from backend.schemas.recommendation import RecommendationOut
+from backend.services.intent import parse_intent
+
+
+async def recommend(db: AsyncSession, query: str) -> RecommendationOut:
+    """Full recommendation pipeline: parse intent → embed → retrieve → respond."""
+    intent = parse_intent(query)
+    vector = embed_query(intent.semantic_query, api_key=backend_settings.OPENAI_API_KEY)
+    products = await find_similar(db, intent, vector)
+
+    return RecommendationOut(
+        products=[ProductOut.model_validate(p) for p in products],
+        intent=intent,
+    )

--- a/backend/tests/test_recommendations.py
+++ b/backend/tests/test_recommendations.py
@@ -1,0 +1,116 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from core.db.models import EMBEDDING_MODEL_DIMENSIONS
+
+from backend.repositories.recommendations import find_similar
+from backend.schemas.recommendation import IntentResult, RecommendationOut
+from backend.services.recommendations import recommend
+
+
+def _fake_product() -> MagicMock:
+    """Minimal mock that passes ProductOut.model_validate."""
+    p = MagicMock()
+    p.sku = "123456"
+    p.name = "Test Wine"
+    p.category = "Vin rouge"
+    p.country = "France"
+    p.size = "750 ml"
+    p.price = 25.00
+    p.online_availability = True
+    p.rating = 4.0
+    p.review_count = 10
+    p.region = "Bordeaux"
+    p.appellation = None
+    p.designation = None
+    p.classification = None
+    p.grape = "Merlot"
+    p.alcohol = "13.5%"
+    p.sugar = None
+    p.producer = "Test Producer"
+    p.created_at = "2026-01-01T00:00:00Z"
+    p.updated_at = "2026-01-01T00:00:00Z"
+    return p
+
+
+class TestRecommend:
+    @pytest.mark.asyncio
+    @patch("backend.services.recommendations.find_similar")
+    @patch("backend.services.recommendations.embed_query")
+    @patch("backend.services.recommendations.parse_intent")
+    @patch("backend.services.recommendations.backend_settings")
+    async def test_full_pipeline(
+        self,
+        mock_settings: MagicMock,
+        mock_parse: MagicMock,
+        mock_embed: MagicMock,
+        mock_find: AsyncMock,
+    ) -> None:
+        mock_settings.OPENAI_API_KEY = "sk-test"
+        mock_parse.return_value = IntentResult(categories=["Vin rouge"], semantic_query="fruité")
+        mock_embed.return_value = [0.1] * EMBEDDING_MODEL_DIMENSIONS
+        mock_find.return_value = [_fake_product()]
+
+        db = AsyncMock()
+        result = await recommend(db, "un rouge fruité")
+
+        assert isinstance(result, RecommendationOut)
+        assert len(result.products) == 1
+        assert result.products[0].sku == "123456"
+        assert result.intent.categories == ["Vin rouge"]
+
+    @pytest.mark.asyncio
+    @patch("backend.services.recommendations.find_similar")
+    @patch("backend.services.recommendations.embed_query")
+    @patch("backend.services.recommendations.parse_intent")
+    @patch("backend.services.recommendations.backend_settings")
+    async def test_empty_results(
+        self,
+        mock_settings: MagicMock,
+        mock_parse: MagicMock,
+        mock_embed: MagicMock,
+        mock_find: AsyncMock,
+    ) -> None:
+        mock_settings.OPENAI_API_KEY = "sk-test"
+        mock_parse.return_value = IntentResult(semantic_query="rare wine")
+        mock_embed.return_value = [0.1] * EMBEDDING_MODEL_DIMENSIONS
+        mock_find.return_value = []
+
+        db = AsyncMock()
+        result = await recommend(db, "rare wine")
+
+        assert result.products == []
+        assert result.intent.semantic_query == "rare wine"
+
+
+def _fake_embedding() -> list[float]:
+    return [0.1] * EMBEDDING_MODEL_DIMENSIONS
+
+
+class TestFindSimilar:
+    @pytest.mark.asyncio
+    async def test_returns_product_list(self) -> None:
+        mock_product = MagicMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_product]
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        intent = IntentResult(semantic_query="bold red")
+        products = await find_similar(db, intent, _fake_embedding())
+
+        assert products == [mock_product]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list(self) -> None:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        intent = IntentResult(semantic_query="something rare")
+        products = await find_similar(db, intent, _fake_embedding())
+
+        assert products == []


### PR DESCRIPTION
## Summary

Wire the full recommendation pipeline: intent parsing → embedding → pgvector similarity search → structured response. Adds `POST /api/recommendations` endpoint that accepts a natural language wine query and returns ranked results with the extracted intent.

## Related issue(s)

Closes #309, closes #310, closes #311

## Changes

- `backend/repositories/recommendations.py` — hybrid retrieval: SQL pre-filters (category, country, price, availability) + pgvector cosine distance ranking
- `backend/services/recommendations.py` — orchestrates parse_intent → embed_query → find_similar
- `backend/api/recommendations.py` — `POST /api/recommendations` endpoint
- `backend/schemas/recommendation.py` — `RecommendationIn` (validated input) + `RecommendationOut` (products + intent)
- `backend/config.py` — `DEFAULT_RECOMMENDATION_LIMIT = 5`, `OPENAI_API_KEY` in BackendSettings
- `backend/tests/test_recommendations.py` — 4 tests covering service pipeline and repository behavior

## How to test

```bash
curl -s -X POST http://localhost:8001/api/recommendations \
  -H "Content-Type: application/json" \
  -d '{"query": "un vin rouge corsé à moins de 50$"}' | jq .
```