### PR TITLE
feat: log recommendation requests in service layer (#336)

### DIFF
--- a/backend/api/recommendations.py
+++ b/backend/api/recommendations.py
@@ -13,4 +13,4 @@ async def post_recommendations(
     body: RecommendationIn,
     db: AsyncSession = Depends(get_db),
 ) -> RecommendationOut:
-    return await recommend(db, body.query)
+    return await recommend(db, body.query, user_id=body.user_id)

--- a/backend/schemas/recommendation.py
+++ b/backend/schemas/recommendation.py
@@ -21,6 +21,7 @@ class IntentResult(BaseModel):
 
 class RecommendationIn(BaseModel):
     query: str = Field(min_length=1, max_length=MAX_SEARCH_LENGTH)
+    user_id: str | None = None
 
 
 class RecommendationProductOut(BaseModel):
@@ -32,3 +33,4 @@ class RecommendationOut(BaseModel):
     products: list[RecommendationProductOut]
     intent: IntentResult
     summary: str
+    log_id: int | None = None

--- a/backend/services/recommendations.py
+++ b/backend/services/recommendations.py
@@ -1,4 +1,8 @@
+import time
+
+from core.db.models import RecommendationLog
 from core.embedding_client import embed_query
+from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.config import backend_settings
@@ -19,33 +23,104 @@ _NON_WINE_MESSAGE = (
 )
 
 
+async def _write_log(
+    db: AsyncSession,
+    *,
+    user_id: str | None,
+    query: str,
+    parsed_intent: dict | None,
+    returned_skus: list[str] | None,
+    product_count: int,
+    latency_ms: dict | None,
+) -> int | None:
+    """Write a RecommendationLog row. Returns the log ID, or None on failure.
+
+    Does not commit — get_db handles session lifecycle.
+    """
+    try:
+        log = RecommendationLog(
+            user_id=user_id,
+            query=query,
+            parsed_intent=parsed_intent,
+            returned_skus=returned_skus,
+            product_count=product_count,
+            latency_ms=latency_ms,
+        )
+        db.add(log)
+        await db.flush()
+        return log.id
+    except Exception as exc:
+        logger.opt(exception=exc).warning("Failed to write recommendation log")
+        return None
+
+
+def _time_ms(start: float) -> int:
+    return int((time.monotonic() - start) * 1000)
+
+
 async def recommend(
     db: AsyncSession,
     query: str,
     *,
+    user_id: str | None = None,
     available_only: bool | None = None,
 ) -> RecommendationOut:
     """Full recommendation pipeline: parse intent → embed → retrieve → explain."""
-    intent = parse_intent(query)
+    t_start = time.monotonic()
+    latency: dict[str, int] = {}
+    intent = None
+    skus: list[str] = []
 
-    if not intent.is_wine:
-        return RecommendationOut(products=[], intent=intent, summary=_NON_WINE_MESSAGE)
+    try:
+        t0 = time.monotonic()
+        intent = parse_intent(query)
+        latency["intent"] = _time_ms(t0)
 
-    if available_only is not None:
-        intent.available_only = available_only
-    vector = embed_query(intent.semantic_query, api_key=backend_settings.OPENAI_API_KEY)
-    products = await find_similar(db, intent, vector)
+        if not intent.is_wine:
+            result = RecommendationOut(products=[], intent=intent, summary=_NON_WINE_MESSAGE)
+            return result
 
-    explanation = explain_recommendations(query, intent, products)
+        if available_only is not None:
+            intent.available_only = available_only
 
-    return RecommendationOut(
-        products=[
-            RecommendationProductOut(
-                product=ProductOut.model_validate(p),
-                reason=explanation.reasons[i],
-            )
-            for i, p in enumerate(products)
-        ],
-        intent=intent,
-        summary=explanation.summary,
+        t0 = time.monotonic()
+        vector = embed_query(intent.semantic_query, api_key=backend_settings.OPENAI_API_KEY)
+        latency["embed"] = _time_ms(t0)
+
+        t0 = time.monotonic()
+        products = await find_similar(db, intent, vector)
+        latency["search"] = _time_ms(t0)
+
+        t0 = time.monotonic()
+        explanation = explain_recommendations(query, intent, products)
+        latency["curation"] = _time_ms(t0)
+
+        skus = [p.sku for p in products]
+
+        result = RecommendationOut(
+            products=[
+                RecommendationProductOut(
+                    product=ProductOut.model_validate(p),
+                    reason=explanation.reasons[i],
+                )
+                for i, p in enumerate(products)
+            ],
+            intent=intent,
+            summary=explanation.summary,
+        )
+    except Exception as exc:
+        logger.opt(exception=exc).error("Recommendation pipeline failed")
+        raise
+
+    latency["total"] = _time_ms(t_start)
+    log_id = await _write_log(
+        db,
+        user_id=user_id,
+        query=query,
+        parsed_intent=intent.model_dump(mode="json"),
+        returned_skus=skus,
+        product_count=len(skus),
+        latency_ms=latency,
     )
+    result.log_id = log_id
+    return result

--- a/backend/tests/test_recommendations.py
+++ b/backend/tests/test_recommendations.py
@@ -52,6 +52,7 @@ def _fake_product(
 
 class TestRecommend:
     @pytest.mark.asyncio
+    @patch("backend.services.recommendations._write_log", new_callable=AsyncMock)
     @patch("backend.services.recommendations.explain_recommendations")
     @patch("backend.services.recommendations.find_similar")
     @patch("backend.services.recommendations.embed_query")
@@ -64,6 +65,7 @@ class TestRecommend:
         mock_embed: MagicMock,
         mock_find: AsyncMock,
         mock_explain: MagicMock,
+        mock_write_log: AsyncMock,
     ) -> None:
         mock_settings.OPENAI_API_KEY = "sk-test"
         mock_parse.return_value = IntentResult(categories=["Vin rouge"], semantic_query="fruité")
@@ -72,9 +74,10 @@ class TestRecommend:
         mock_explain.return_value = ExplanationResult(
             reasons=["Great fruity red"], summary="A fruity selection"
         )
+        mock_write_log.return_value = 42
 
         db = AsyncMock()
-        result = await recommend(db, "un rouge fruité")
+        result = await recommend(db, "un rouge fruité", user_id="tg:123")
 
         assert isinstance(result, RecommendationOut)
         assert len(result.products) == 1
@@ -82,8 +85,17 @@ class TestRecommend:
         assert result.products[0].reason == "Great fruity red"
         assert result.summary == "A fruity selection"
         assert result.intent.categories == ["Vin rouge"]
+        assert result.log_id == 42
+        mock_write_log.assert_called_once()
+        log_kwargs = mock_write_log.call_args.kwargs
+        assert log_kwargs["user_id"] == "tg:123"
+        assert log_kwargs["query"] == "un rouge fruité"
+        assert log_kwargs["returned_skus"] == ["123456"]
+        assert "intent" in log_kwargs["latency_ms"]
+        assert "total" in log_kwargs["latency_ms"]
 
     @pytest.mark.asyncio
+    @patch("backend.services.recommendations._write_log", new_callable=AsyncMock)
     @patch("backend.services.recommendations.explain_recommendations")
     @patch("backend.services.recommendations.find_similar")
     @patch("backend.services.recommendations.embed_query")
@@ -96,12 +108,14 @@ class TestRecommend:
         mock_embed: MagicMock,
         mock_find: AsyncMock,
         mock_explain: MagicMock,
+        mock_write_log: AsyncMock,
     ) -> None:
         mock_settings.OPENAI_API_KEY = "sk-test"
         mock_parse.return_value = IntentResult(semantic_query="rare wine")
         mock_embed.return_value = [0.1] * EMBEDDING_DIMENSIONS
         mock_find.return_value = []
         mock_explain.return_value = ExplanationResult(reasons=[], summary="")
+        mock_write_log.return_value = 1
 
         db = AsyncMock()
         result = await recommend(db, "rare wine")
@@ -109,6 +123,35 @@ class TestRecommend:
         assert result.products == []
         assert result.summary == ""
         assert result.intent.semantic_query == "rare wine"
+
+    @pytest.mark.asyncio
+    @patch("backend.services.recommendations._write_log", new_callable=AsyncMock)
+    @patch("backend.services.recommendations.parse_intent")
+    async def test_non_wine_returns_early_without_logging(
+        self,
+        mock_parse: MagicMock,
+        mock_write_log: AsyncMock,
+    ) -> None:
+        mock_parse.return_value = IntentResult(is_wine=False, semantic_query="beer")
+
+        db = AsyncMock()
+        result = await recommend(db, "give me a beer")
+
+        assert result.products == []
+        assert result.log_id is None
+        mock_write_log.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("backend.services.recommendations.parse_intent")
+    async def test_pipeline_failure_does_not_log(
+        self,
+        mock_parse: MagicMock,
+    ) -> None:
+        mock_parse.side_effect = RuntimeError("API down")
+
+        db = AsyncMock()
+        with pytest.raises(RuntimeError, match="API down"):
+            await recommend(db, "red wine")
 
 
 def _fake_embedding() -> list[float]:

--- a/bot/bot/api_client.py
+++ b/bot/bot/api_client.py
@@ -54,9 +54,12 @@ class BackendClient:
 
     # ── Recommendations ──────────────────────────────────────────
 
-    async def recommend(self, query: str) -> dict[str, Any]:
+    async def recommend(self, query: str, *, user_id: str | None = None) -> dict[str, Any]:
         """POST /api/recommendations — natural language wine recommendations."""
-        return await self._post("/recommendations", json={"query": query})
+        payload: dict[str, Any] = {"query": query}
+        if user_id is not None:
+            payload["user_id"] = user_id
+        return await self._post("/recommendations", json=payload)
 
     # ── Watches ─────────────────────────────────────────────────
 

--- a/bot/bot/handlers/recommend.py
+++ b/bot/bot/handlers/recommend.py
@@ -19,8 +19,10 @@ async def recommend_command(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     # Typing indicator while the pipeline runs (intent + embedding + search)
     await update.message.chat.send_action(ChatAction.TYPING)
 
+    user_id = f"tg:{update.effective_user.id}" if update.effective_user else None
+
     try:
-        data = await api.recommend(query)
+        data = await api.recommend(query, user_id=user_id)
     except (BackendUnavailableError, BackendAPIError) as exc:
         logger.warning("Backend unavailable during /recommend: {}", exc)
         await update.message.reply_text("Backend is currently unavailable. Try again later.")

--- a/bot/tests/test_recommend.py
+++ b/bot/tests/test_recommend.py
@@ -45,13 +45,14 @@ def update():
     mock = AsyncMock()
     mock.message.reply_text = AsyncMock()
     mock.message.chat.send_action = AsyncMock()
+    mock.effective_user.id = 12345
     return mock
 
 
 async def test_recommend_sends_results(update, context, api):
     await recommend_command(update, context)
 
-    api.recommend.assert_called_once_with("un rouge corsé")
+    api.recommend.assert_called_once_with("un rouge corsé", user_id="tg:12345")
     update.message.chat.send_action.assert_called_once()
     reply_text = update.message.reply_text.call_args[0][0]
     assert "Château Margaux" in reply_text

--- a/core/alembic/versions/de3eafa552b5_add_recommendation_logs_table.py
+++ b/core/alembic/versions/de3eafa552b5_add_recommendation_logs_table.py
@@ -57,7 +57,6 @@ def upgrade() -> None:
         sa.Column(
             "feedback", sa.String(), nullable=True, comment="User feedback: positive or negative"
         ),
-        sa.Column("error", sa.Text(), nullable=True, comment="Error type if pipeline failed"),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),

--- a/core/db/models.py
+++ b/core/db/models.py
@@ -306,7 +306,6 @@ class RecommendationLog(Base):
     product_count = Column(Integer, nullable=False, default=0, comment="Number of results returned")
     latency_ms = Column(JSONB, nullable=True, comment="Per-stage timing breakdown")
     feedback = Column(String, nullable=True, comment="User feedback: positive or negative")
-    error = Column(Text, nullable=True, comment="Error type if pipeline failed")
     created_at = Column(
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),


### PR DESCRIPTION
## Summary

Instrument the recommendation pipeline to write a `RecommendationLog` row on each successful `/recommend` call, capturing query, parsed intent, returned SKUs, and per-stage latency breakdown. Pass `user_id` from bot through to backend for attribution.

Part 2/3 of #294 (recommendation logging + feedback buttons).

## Related issue(s)

Closes #336

## Changes

- **`backend/services/recommendations.py`** — time each pipeline stage (intent, embed, search, curation), write log via `_write_log()` on success. Errors are logged via loguru only (DB row would be rolled back by `get_db`). Non-wine queries return early without logging.
- **`backend/schemas/recommendation.py`** — add `user_id` to `RecommendationIn`, `log_id` to `RecommendationOut`
- **`backend/api/recommendations.py`** — pass `user_id` through to service
- **`bot/bot/handlers/recommend.py`** — pass `tg:{user_id}` to API call
- **`bot/bot/api_client.py`** — accept optional `user_id` in `recommend()`
- **`core/db/models.py`** + migration — drop unused `error` column from `RecommendationLog`
- 4 new test cases: full pipeline with log verification, empty results, non-wine skip, pipeline failure

## How to test

```bash
curl -X POST http://localhost:8001/api/recommendations \
  -H 'Content-Type: application/json' \
  -d '{"query": "un rouge fruité", "user_id": "tg:123"}'
```

Response should include `"log_id": <int>`. Verify row in DB:

```sql
SELECT id, user_id, query, product_count, latency_ms FROM recommendation_logs;
```