### PR TITLE
chore: harden docker-compose.yml (#348)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    security_opt: [no-new-privileges:true]
+    mem_limit: 1g
     networks:
       - internal
 
@@ -34,6 +36,14 @@ services:
     volumes:
       - ./backend:/app/backend
     command: ["uvicorn", "backend.app:app", "--reload", "--host", "0.0.0.0", "--port", "8001"]
+    read_only: true
+    security_opt: [no-new-privileges:true]
+    mem_limit: 512m
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "3"
     networks:
       - internal
     depends_on:
@@ -52,6 +62,14 @@ services:
       BACKEND_URL: http://backend:8001
     volumes:
       - ./bot/bot:/app/bot/bot
+    read_only: true
+    security_opt: [no-new-privileges:true]
+    mem_limit: 256m
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "3"
     networks:
       - internal
     depends_on:
@@ -66,6 +84,14 @@ services:
       DB_HOST: postgres
     # One-shot job — don't restart after exit. Systemd timer handles scheduling.
     restart: "no"
+    read_only: true
+    security_opt: [no-new-privileges:true]
+    mem_limit: 512m
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "3"
     networks:
       - internal
     depends_on:
@@ -82,6 +108,9 @@ services:
     environment:
       DB_HOST: postgres
     command: ["alembic", "-c", "core/alembic.ini", "upgrade", "head"]
+    read_only: true
+    security_opt: [no-new-privileges:true]
+    mem_limit: 256m
     networks:
       - internal
     depends_on:

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -1,22 +1,10 @@
 # Production
 
-Infrastructure-level state, deployment process, and outstanding work for the production VPS.
-Step-by-step setup instructions live in the infra repo (private).
+Deployment process and app-level production concerns for saq-sommelier.
+VPS-level infrastructure (firewall, SSH, TLS, networking) is documented in the [infra repo](https://github.com/vpatrin/infra/blob/main/docs/INFRASTRUCTURE.md).
 
----
-
-## Current state
-
-- **VPS**: Hetzner CX22, Debian 13 — `web-01`
-- **User**: `victor` (root SSH blocked)
-- **Auth**: SSH key only (password auth disabled)
-- **Firewall**: Hetzner network firewall + ufw — ports 22/80/443 only
-- **DNS**: `victorpatrin.dev` + wildcard `*` → VPS IP (Porkbun)
-- **Docker**: Docker CE + Compose plugin installed
-- **Swap**: 2G at `/swapfile`, swappiness=10
-- **Reverse proxy**: Caddy (SSL + routing via victorpatrin.dev subdomains)
-- **Services**: backend, bot, scraper (systemd timer), shared-postgres
 - **Deployed**: v1.2.0
+- **Services**: backend, bot, scraper (systemd timer), shared-postgres
 
 ---
 
@@ -52,32 +40,6 @@ Migrations are forward-only — never run `downgrade()` in production. Write a n
 
 ---
 
-## Security
+## Security, backups, and observability
 
-**Done:** SSH hardening (PermitRootLogin no, PasswordAuthentication no), double firewall (Hetzner + ufw, ports 22/80/443 only).
-
-**Infra repo:**
-- Fail2ban: SSH brute-force protection
-- Unattended-upgrades: automatic security patches
-
----
-
-## Backups
-
-**Not started.** Biggest production risk — no PostgreSQL backups currently.
-
-**Infra repo:**
-- `scripts/backup-db.sh`: daily `pg_dump` + 7-day local retention, systemd timer at 3am
-
----
-
-## Observability
-
-**Infra repo:**
-- Grafana: scraper health + API health dashboards — requires VPS upgrade to CX32 for RAM headroom
-
----
-
-## Staging
-
-Not needed yet. Revisit when multi-developer or when preview deploys are required.
+See [infra INFRASTRUCTURE.md](https://github.com/vpatrin/infra/blob/main/docs/INFRASTRUCTURE.md) — these are managed at the VPS level, not per-project.


### PR DESCRIPTION
## Summary

Add container security and reliability hardening to `docker-compose.yml`.

## Related issue(s)

Closes #348

## Changes

- `read_only: true` on backend, bot, scraper, migrate — prevents container filesystem writes
- `security_opt: [no-new-privileges:true]` on all 5 services — blocks privilege escalation
- `mem_limit` per service (postgres 1g, backend 512m, scraper 512m, bot 256m, migrate 256m) — guards against OOM on 4GB VPS
- Log rotation (json-file driver, 50m × 3 files) on backend, bot, scraper — prevents unbounded disk usage
- Trim `docs/PRODUCTION.md` — move infra-level content to infra repo, keep only app-level deployment concerns