### PR TITLE
chore: add pre-deploy database backup to deploy script

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -9,6 +9,9 @@ diff -u .env.example .env || true
 echo "==> Building images..."
 make build
 
+echo "==> Pre-deploy database backup..."
+/home/victor/infra/backup/backup.sh saq_sommelier
+
 echo "==> Running migrations..."
 docker compose run --rm migrate
 


### PR DESCRIPTION
## Summary

Deploy script now runs a database backup before migrations, preventing data loss if a migration fails.

## Related issue(s)

Related to #350 (broader backup alerting)

## Changes

- Call `backup.sh saq_sommelier` from infra repo between image build and migration steps
- `set -euo pipefail` ensures deploy aborts if backup fails