### PR TITLE
docs: restructure ROADMAP.md for phases 7-10 (#352)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -101,20 +101,18 @@ Upgrade path from Haiku RAG to Claude with direct tool access. Either as MCP ser
 
 **CI hardening:**
 
-- [ ] Container security scan — Trivy on built images (catches OS-level CVEs that pip-audit misses)
-- [ ] Alembic migration smoke test — `upgrade head && check` against test DB (part of integration tests)
+- [ ] Container security scan — Trivy on built images, catches OS-level CVEs that pip-audit misses (#360)
+- [ ] Alembic migration smoke test — `upgrade head && check` against test DB (#316)
 
 **CD pipeline:**
 
-- [ ] ghcr.io image registry — CI builds and pushes images on merge to main, tagged by git SHA
-- [ ] Deploy workflow — tag push triggers: build → push → SSH → pre-deploy backup → migrate → restart → health check
-- [ ] Health check gate + auto-rollback — deploy fails gracefully if /health doesn't respond
+- [ ] Build + Trivy + push + deploy on tag push (#362)
+- [ ] Deploy key — dedicated SSH key for CI → VPS access (#361)
 - [ ] docker-compose.prod.yml — resource limits, restart policies, no dev volumes
-- [ ] Deploy key — dedicated SSH key for CI → VPS access (not personal key)
 
 **Observability:**
 
-- [ ] Request correlation — X-Request-ID middleware across bot → backend → DB
+- [ ] Request correlation — X-Request-ID middleware across bot → backend → DB (#315)
 
 **Secrets management:**
 


### PR DESCRIPTION
## Summary

Restructure ROADMAP.md to reflect current project state: collapse completed phases into one-liner summaries with issue refs and spec links, add new phases 7–10, update cross-cutting DevOps section with issue refs, freeze RAG Eval, remove stale timeline estimate.

## Related issue(s)

Closes #352

## Changes

- Collapsed Phases 0–6 to one-liner summaries with issue refs and spec cross-references
- Added Phase 7 (Auth & Security), Phase 8 (Chat Endpoint), Phase 9 (React Frontend), Phase 10 (MCP Server)
- Moved bilingual support to Ideas with original issue refs (#134, #151–#153)
- Frozen RAG Eval + MLOps section
- Updated DevOps section:
  - Backup marked ✅ (#351)
  - Added issue refs: cron alerts (#350), Trivy (#360), migration smoke test (#316), CD pipeline (#362), deploy key (#361), request correlation (#315)
  - Consolidated CD pipeline items (ghcr + deploy + health check → single #362)
- Removed stale timeline estimate