### PR TITLE
feat: JWT token middleware (#355)

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,9 +1,55 @@
-from fastapi import Header, HTTPException, status
+import jwt
+from core.db.models import User
+from fastapi import Depends, Header, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.config import backend_settings
+from backend.db import get_db
+from backend.exceptions import ForbiddenError, InvalidCredentialsError
+from backend.repositories import users as users_repo
+
+_bearer_scheme = HTTPBearer(auto_error=False)
 
 
 def verify_bot_secret(x_bot_secret: str | None = Header(default=None)) -> None:
     """Require X-Bot-Secret header when BOT_SECRET is configured. No-op when unconfigured (dev)."""
     if backend_settings.BOT_SECRET and x_bot_secret != backend_settings.BOT_SECRET:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid bot secret")
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    """Decode JWT from Authorization header and return the user."""
+    if credentials is None:
+        raise InvalidCredentialsError("Missing authentication token")
+
+    try:
+        payload = jwt.decode(
+            credentials.credentials,
+            backend_settings.JWT_SECRET_KEY,
+            algorithms=["HS256"],
+        )
+    except jwt.ExpiredSignatureError:
+        raise InvalidCredentialsError("Token has expired")
+    except jwt.InvalidTokenError:
+        raise InvalidCredentialsError("Invalid token")
+
+    user_id = payload.get("sub")
+    if user_id is None:
+        raise InvalidCredentialsError("Invalid token payload")
+
+    user = await users_repo.find_by_id(db, int(user_id))
+    if user is None:
+        raise InvalidCredentialsError("User not found")
+
+    return user
+
+
+async def get_current_active_user(user: User = Depends(get_current_user)) -> User:
+    """Require that the authenticated user is active."""
+    if not user.is_active:
+        raise ForbiddenError("Account is deactivated")
+    return user

--- a/backend/repositories/users.py
+++ b/backend/repositories/users.py
@@ -5,6 +5,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
+async def find_by_id(db: AsyncSession, user_id: int) -> User | None:
+    stmt = select(User).where(User.id == user_id)
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
 async def find_by_telegram_id(db: AsyncSession, telegram_id: int) -> User | None:
     stmt = select(User).where(User.telegram_id == telegram_id)
     result = await db.execute(stmt)

--- a/backend/tests/test_jwt_middleware.py
+++ b/backend/tests/test_jwt_middleware.py
@@ -1,0 +1,131 @@
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import jwt
+import pytest
+from core.db.models import User
+from fastapi import Depends, status
+from fastapi.testclient import TestClient
+
+from backend.app import app
+from backend.auth import get_current_active_user
+from backend.db import get_db
+
+JWT_SECRET = "test-jwt-secret-key-for-unit-tests-32b"
+
+
+def _make_token(
+    user_id: int = 1,
+    telegram_id: int = 12345,
+    role: str = "user",
+    expired: bool = False,
+) -> str:
+    now = datetime.now(UTC)
+    exp = now - timedelta(hours=1) if expired else now + timedelta(days=7)
+    payload = {
+        "sub": str(user_id),
+        "telegram_id": telegram_id,
+        "role": role,
+        "exp": exp,
+        "iat": now,
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm="HS256")
+
+
+def _mock_user(user_id: int = 1, is_active: bool = True) -> MagicMock:
+    user = MagicMock(spec=User)
+    user.id = user_id
+    user.telegram_id = 12345
+    user.role = "user"
+    user.is_active = is_active
+    return user
+
+
+@pytest.fixture()
+def protected_client():
+    """Client with a test route protected by get_current_active_user."""
+
+    @app.get("/test/protected")
+    async def protected_route(user: User = Depends(get_current_active_user)):
+        return {"user_id": user.id, "role": user.role}
+
+    session = AsyncMock()
+    app.dependency_overrides[get_db] = lambda: session
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+    # Clean up test route
+    app.routes[:] = [r for r in app.routes if getattr(r, "path", None) != "/test/protected"]
+
+
+class TestJWTMiddleware:
+    def test_valid_token_returns_user(self, protected_client: TestClient):
+        token = _make_token()
+        with (
+            patch("backend.auth.backend_settings") as mock_settings,
+            patch("backend.auth.users_repo") as mock_repo,
+        ):
+            mock_settings.JWT_SECRET_KEY = JWT_SECRET
+            mock_repo.find_by_id = AsyncMock(return_value=_mock_user())
+            resp = protected_client.get(
+                "/test/protected",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.json()["user_id"] == 1
+
+    def test_missing_token_returns_401(self, protected_client: TestClient):
+        resp = protected_client.get("/test/protected")
+        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_expired_token_returns_401(self, protected_client: TestClient):
+        token = _make_token(expired=True)
+        with patch("backend.auth.backend_settings") as mock_settings:
+            mock_settings.JWT_SECRET_KEY = JWT_SECRET
+            resp = protected_client.get(
+                "/test/protected",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+        assert "expired" in resp.json()["detail"].lower()
+
+    def test_invalid_token_returns_401(self, protected_client: TestClient):
+        with patch("backend.auth.backend_settings") as mock_settings:
+            mock_settings.JWT_SECRET_KEY = JWT_SECRET
+            resp = protected_client.get(
+                "/test/protected",
+                headers={"Authorization": "Bearer garbage.token.here"},
+            )
+
+        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_user_not_found_returns_401(self, protected_client: TestClient):
+        token = _make_token()
+        with (
+            patch("backend.auth.backend_settings") as mock_settings,
+            patch("backend.auth.users_repo") as mock_repo,
+        ):
+            mock_settings.JWT_SECRET_KEY = JWT_SECRET
+            mock_repo.find_by_id = AsyncMock(return_value=None)
+            resp = protected_client.get(
+                "/test/protected",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_inactive_user_returns_403(self, protected_client: TestClient):
+        token = _make_token()
+        with (
+            patch("backend.auth.backend_settings") as mock_settings,
+            patch("backend.auth.users_repo") as mock_repo,
+        ):
+            mock_settings.JWT_SECRET_KEY = JWT_SECRET
+            mock_repo.find_by_id = AsyncMock(return_value=_mock_user(is_active=False))
+            resp = protected_client.get(
+                "/test/protected",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert resp.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
## Summary

FastAPI dependencies for JWT authentication — `get_current_user` decodes the Bearer token and looks up the user, `get_current_active_user` adds an active check. Internal plumbing for route guarding (#356).

## Related issue(s)

Closes #355

## Changes

- `get_current_user` dependency in `backend/auth.py` — extracts JWT from `Authorization: Bearer` header, decodes with PyJWT, returns `User`
- `get_current_active_user` wrapper — rejects deactivated users with 403
- `find_by_id` added to `backend/repositories/users.py`
- 6 tests: valid token, missing token, expired, invalid, user not found, inactive user