### PR TITLE
feat: session history sidebar — list, resume, rename, delete (#438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Chat API — session-based chat endpoints wrapping the recommendation pipeline (`/api/chat/sessions/*`) (#425)
 - Chat UI — sommelier conversation page with message input, response display, and session persistence (#426)
+- Session history sidebar — list, resume, rename, and delete past chat sessions
 
 ### Changed
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -67,7 +67,7 @@ Wraps existing Haiku RAG pipeline for web consumption. No new AI architecture.
 ### Phase 9b — Chat Interface
 
 - [x] Chat UI — message input, response display, conversation history (#426)
-- [ ] Session history sidebar — list sessions, resume, delete
+- [x] Session history sidebar — list sessions, resume, rename, delete
 - [ ] Wine card component — structured recommendation display inline in chat
 
 SSE (#427) and SSE rendering are deferred — current response times (2-3s) are fine with a loading state, and streaming structured JSON (RecommendationOut) is awkward. Revisit when/if freeform conversational responses ship (Phase 10).
@@ -143,6 +143,7 @@ Dev tooling project — expose Coupette data to Claude Code / Claude Desktop via
 - [ ] Bilingual support — per-user language preference, static translation tables, bilingual web/bot responses (#134, #151–#153)
 - [ ] Wine tech sheets — external data enrichment beyond SAQ catalog (fiches techniques, critic notes)
 - [ ] Bot `/recommend` deprecation — remove command, bot is alerts-only (cross-cutting chore, not a product idea)
+- [ ] Data retention policy — define TTL for chat sessions, user data lifecycle, and compliance posture (GDPR-adjacent)
 
 ---
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ function App() {
       <Route element={<AuthedLayout />}>
         <Route path="/dashboard" element={<Navigate to="/chat" replace />} />
         <Route path="/chat" element={<ChatPage />} />
+        <Route path="/chat/:sessionId" element={<ChatPage />} />
         <Route path="/search" element={<SearchPage />} />
         <Route path="/watches" element={<WatchesPage />} />
         <Route path="/stores" element={<SavedStoresPage />} />

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,26 +1,106 @@
-import { useCallback } from 'react'
-import { Link, Outlet, useLocation, useNavigate } from 'react-router'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link, Outlet, useLocation, useMatch, useNavigate } from 'react-router'
 import { useAuth } from '@/contexts/AuthContext'
+import { useApiClient } from '@/lib/api'
+import { timeAgo } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import type { ChatSessionOut } from '@/lib/types'
 
 const BOT_USERNAME = import.meta.env.VITE_TELEGRAM_BOT_USERNAME as string
 
 const NAV_ITEMS = [
-  { to: '/chat', label: 'Chat' },
   { to: '/search', label: 'Search' },
   { to: '/watches', label: 'My Watches' },
   { to: '/stores', label: 'My Stores' },
 ]
 
+export interface ChatOutletContext {
+  refreshSessions: () => void
+}
+
 function AppShell() {
   const { user, logout } = useAuth()
   const location = useLocation()
   const navigate = useNavigate()
+  const apiClient = useApiClient()
+
+  const isOnChat = location.pathname.startsWith('/chat')
+  const sessionMatch = useMatch('/chat/:sessionId')
+  const activeSessionId = sessionMatch?.params.sessionId ?? null
+
+  const [sessions, setSessions] = useState<ChatSessionOut[]>([])
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [editTitle, setEditTitle] = useState('')
+  const renamingRef = useRef(false)
 
   const handleLogout = useCallback(() => {
     logout()
     navigate('/', { replace: true })
   }, [logout, navigate])
+
+  const fetchSessions = useCallback(async () => {
+    try {
+      const data = await apiClient<ChatSessionOut[]>('/chat/sessions')
+      setSessions(data)
+    } catch {
+      // Silently fail — sidebar is non-critical
+    }
+  }, [apiClient])
+
+  // Load sessions when navigating to chat
+  useEffect(() => {
+    if (!isOnChat) return
+    let cancelled = false
+    apiClient<ChatSessionOut[]>('/chat/sessions')
+      .then((data) => {
+        if (!cancelled) setSessions(data)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [isOnChat, apiClient])
+
+  const handleRename = async (id: number) => {
+    if (renamingRef.current) return
+    renamingRef.current = true
+    const trimmed = editTitle.trim()
+    if (!trimmed) {
+      setEditingId(null)
+      renamingRef.current = false
+      return
+    }
+    try {
+      const updated = await apiClient<ChatSessionOut>(`/chat/sessions/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ title: trimmed }),
+      })
+      setSessions((prev) => prev.map((s) => (s.id === id ? updated : s)))
+    } catch {
+      // Silently fail
+    }
+    setEditingId(null)
+    renamingRef.current = false
+  }
+
+  const handleDelete = async (id: number) => {
+    try {
+      await apiClient(`/chat/sessions/${id}`, { method: 'DELETE' })
+      setSessions((prev) => prev.filter((s) => s.id !== id))
+      setConfirmDeleteId(null)
+      if (activeSessionId === String(id)) {
+        navigate('/chat', { replace: true })
+      }
+    } catch {
+      // Silently fail
+    }
+  }
+
+  const outletContext = useMemo<ChatOutletContext>(
+    () => ({ refreshSessions: fetchSessions }),
+    [fetchSessions],
+  )
 
   return (
     <div className="h-screen bg-background text-foreground flex">
@@ -33,8 +113,108 @@ function AppShell() {
           </Link>
         </div>
 
+        {/* Chat section — only when on /chat */}
+        {isOnChat && (
+          <div className="flex flex-col border-b border-sidebar-border">
+            <button
+              type="button"
+              onClick={() => navigate('/chat')}
+              className="mx-2 mt-2 mb-1 px-3 py-1.5 text-sm font-mono text-left border border-border hover:bg-sidebar-accent/50"
+            >
+              + New chat
+            </button>
+            <div className="overflow-y-auto max-h-48 px-2 pb-2">
+              {sessions.length === 0 && (
+                <p className="px-3 py-1.5 text-xs text-muted-foreground">No conversations yet</p>
+              )}
+              {sessions.map((session) => {
+                const isActive = activeSessionId === String(session.id)
+                const isConfirming = confirmDeleteId === session.id
+                return (
+                  <div
+                    key={session.id}
+                    className={`group flex items-center gap-1 px-3 py-1.5 text-sm font-mono ${
+                      isActive
+                        ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+                        : 'hover:bg-sidebar-accent/50'
+                    }`}
+                  >
+                    {isConfirming ? (
+                      <div className="flex-1 flex items-center gap-2 min-w-0">
+                        <span className="text-xs text-muted-foreground truncate">Delete?</span>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(session.id)}
+                          className="text-xs text-destructive hover:text-destructive/80"
+                        >
+                          yes
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setConfirmDeleteId(null)}
+                          className="text-xs text-muted-foreground hover:text-foreground"
+                        >
+                          no
+                        </button>
+                      </div>
+                    ) : editingId === session.id ? (
+                      <input
+                        autoFocus
+                        value={editTitle}
+                        onChange={(e) => setEditTitle(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') handleRename(session.id)
+                          if (e.key === 'Escape') setEditingId(null)
+                        }}
+                        onBlur={() => handleRename(session.id)}
+                        maxLength={50}
+                        className="flex-1 min-w-0 bg-transparent border-b border-primary text-sm font-mono outline-none"
+                      />
+                    ) : (
+                      <>
+                        <Link
+                          to={`/chat/${session.id}`}
+                          className="flex-1 min-w-0 truncate"
+                          title={session.title ?? 'Untitled'}
+                          onDoubleClick={(e) => {
+                            e.preventDefault()
+                            setEditTitle(session.title ?? '')
+                            setEditingId(session.id)
+                          }}
+                        >
+                          {session.title ?? 'Untitled'}
+                        </Link>
+                        <span className="shrink-0 text-xs text-muted-foreground hidden group-hover:inline">
+                          {timeAgo(session.updated_at)}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => setConfirmDeleteId(session.id)}
+                          className="shrink-0 text-xs text-muted-foreground hover:text-destructive hidden group-hover:inline"
+                          title="Delete session"
+                        >
+                          x
+                        </button>
+                      </>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
         {/* Navigation */}
         <nav className="flex-1 p-2 flex flex-col gap-0.5">
+          {/* Chat link — only when NOT on /chat (collapsed to single link) */}
+          {!isOnChat && (
+            <Link
+              to="/chat"
+              className="block px-3 py-2 text-sm font-mono transition-colors text-sidebar-foreground hover:bg-sidebar-accent/50"
+            >
+              Chat
+            </Link>
+          )}
           {NAV_ITEMS.map(({ to, label }) => {
             const active =
               location.pathname === to ||
@@ -76,7 +256,7 @@ function AppShell() {
 
       {/* Main content */}
       <main className="flex-1 min-w-0 overflow-y-auto">
-        <Outlet />
+        <Outlet context={outletContext} />
       </main>
     </div>
   )

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -14,3 +14,15 @@ export function formatOrigin(product: ProductOut): string {
   }
   return region || product.country || ''
 }
+
+export function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000)
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  return new Date(dateStr).toLocaleDateString()
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,6 +1,8 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
+import { useParams, useNavigate, useOutletContext } from 'react-router'
 import { useApiClient } from '@/lib/api'
 import { formatOrigin } from '@/lib/utils'
+import type { ChatOutletContext } from '@/components/AppShell'
 import type {
   ChatSessionOut,
   ChatMessageOut,
@@ -58,24 +60,69 @@ function AssistantMessage({ content }: { content: string | RecommendationOut }) 
 
 function ChatPage() {
   const apiClient = useApiClient()
-  const [sessionId, setSessionId] = useState<number | null>(null)
+  const navigate = useNavigate()
+  const { sessionId: urlSessionId } = useParams<{ sessionId: string }>()
+  const { refreshSessions } = useOutletContext<ChatOutletContext>()
+
+  // Derive sessionId directly from URL — no intermediate state to get stale
+  const sessionId = urlSessionId ? Number(urlSessionId) : null
+
   const [messages, setMessages] = useState<ChatMessageOut[]>([])
   const [input, setInput] = useState('')
   const [sending, setSending] = useState(false)
+  const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [lastFailedInput, setLastFailedInput] = useState<string | null>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
+  const skipLoadRef = useRef(false)
+
+  // Reset transient state when URL changes (new chat vs resume)
+  useEffect(() => {
+    setMessages([])
+    setInput('')
+    setError(null)
+    setLastFailedInput(null)
+  }, [urlSessionId])
+
+  // Load existing session messages (skipped when submitMessage already has data)
+  useEffect(() => {
+    if (!sessionId) return
+    if (skipLoadRef.current) {
+      skipLoadRef.current = false
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    apiClient<ChatSessionDetailOut>(`/chat/sessions/${sessionId}`)
+      .then((detail) => {
+        if (!cancelled) setMessages(detail.messages)
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load session')
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+    // sessionId is derived from urlSessionId — use urlSessionId as dep to avoid
+    // re-fetching when React re-renders without a URL change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlSessionId, apiClient])
 
   // Scroll to bottom when messages change
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
 
-  // Focus input on mount
+  // Focus input on mount and when session changes
   useEffect(() => {
     inputRef.current?.focus()
-  }, [])
+  }, [urlSessionId])
 
   const submitMessage = useCallback(async () => {
     const text = input.trim()
@@ -101,14 +148,19 @@ function ChatPage() {
     try {
       let sid = sessionId
 
+      let isNewSession = false
+
       if (sid === null) {
-        // First message — create session, then send the message
+        // First message — create session (title only), then send the message below
         const session = await apiClient<ChatSessionOut>('/chat/sessions', {
           method: 'POST',
           body: JSON.stringify({ message: text }),
         })
         sid = session.id
-        setSessionId(sid)
+        isNewSession = true
+        // Skip the load effect — we'll fetch the data right below
+        skipLoadRef.current = true
+        navigate(`/chat/${sid}`, { replace: true })
       }
 
       // Send message (first or follow-up — same endpoint)
@@ -120,6 +172,9 @@ function ChatPage() {
       // Re-fetch full session to get real messages
       const detail = await apiClient<ChatSessionDetailOut>(`/chat/sessions/${sid}`)
       setMessages(detail.messages)
+
+      // Refresh sidebar only when a new session was created (title added)
+      if (isNewSession) refreshSessions()
     } catch (err) {
       // Remove optimistic message on error
       setMessages((prev) => prev.filter((m) => m.message_id !== tempUserMsg.message_id))
@@ -129,7 +184,7 @@ function ChatPage() {
       setSending(false)
       inputRef.current?.focus()
     }
-  }, [apiClient, input, sending, sessionId])
+  }, [apiClient, input, sending, sessionId, navigate, refreshSessions])
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -148,12 +203,18 @@ function ChatPage() {
       {/* Messages area */}
       <div className="flex-1 overflow-y-auto p-6">
         <div className="max-w-2xl mx-auto flex flex-col gap-6">
-          {messages.length === 0 && !sending && (
+          {messages.length === 0 && !sending && !loading && (
             <div className="flex flex-col items-center justify-center h-full min-h-[40vh] gap-2">
               <h1 className="text-2xl font-mono font-bold">What are you drinking tonight?</h1>
               <p className="text-muted-foreground text-sm">
                 Ask for a recommendation — try "A bold red under $30" or "Something for sushi"
               </p>
+            </div>
+          )}
+
+          {loading && (
+            <div className="flex flex-col items-center justify-center min-h-[20vh]">
+              <p className="text-sm text-muted-foreground font-mono">Loading...</p>
             </div>
           )}
 


### PR DESCRIPTION
## Summary

Session history sidebar in the chat interface. Users can list past conversations, resume them, rename titles inline, and delete with confirmation. Sessions are URL-routed (`/chat/:sessionId`) for shareability and browser history.

## Related issue(s)

Closes #438

## Changes

- **AppShell.tsx** — session sidebar (visible on `/chat` routes): session list, "New chat" button, inline rename (double-click title), delete with yes/no confirmation, active session highlight, relative timestamps on hover
- **ChatPage.tsx** — URL-based session routing (`useParams`), session resume (loads message history on navigate), loading state, `skipLoadRef` to avoid double-fetch after new session creation
- **App.tsx** — add `/chat/:sessionId` route
- **utils.ts** — `timeAgo()` utility for relative timestamps
- **CHANGELOG.md** — added entry under `[Unreleased]`
- **ROADMAP.md** — marked sidebar checkbox, added data retention policy idea

## How to test

1. `cd frontend && yarn dev`
2. Log in and navigate to `/chat`
3. Send a message — sidebar should show the new session
4. Click "New chat" → fresh conversation
5. Click a session in the sidebar → loads its message history
6. Double-click a session title → inline rename (Enter to save, Escape to cancel)
7. Click "x" on a session → "Delete? yes / no" confirmation → deletes
8. Navigate away from `/chat` (e.g. Search) → sidebar collapses to single "Chat" link
9. Navigate back to `/chat` → sidebar reappears with session list