### PR TITLE
feat: wine card component — structured recommendation display in chat (#440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Wine cards in chat now show grape, vintage, availability, and bottle size (#440)
 - Chat recommendations now use multi-turn context — previous wines are excluded and curation references prior conversation (#428)
 - REST API hygiene — pagination uses `limit`/`offset` instead of `page`/`per_page`, verb-based URLs replaced with PATCH (#431)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -68,7 +68,7 @@ Wraps existing Haiku RAG pipeline for web consumption. No new AI architecture.
 
 - [x] Chat UI — message input, response display, conversation history (#426)
 - [x] Session history sidebar — list sessions, resume, rename, delete
-- [ ] Wine card component — structured recommendation display inline in chat
+- [x] Wine card component — structured recommendation display inline in chat (#440)
 
 SSE (#427) and SSE rendering are deferred — current response times (2-3s) are fine with a loading state, and streaming structured JSON (RecommendationOut) is awkward. Revisit when/if freeform conversational responses ship (Phase 10).
 

--- a/frontend/src/components/WineCard.tsx
+++ b/frontend/src/components/WineCard.tsx
@@ -1,0 +1,102 @@
+import { formatOrigin } from '@/lib/utils'
+import type { ProductOut } from '@/lib/types'
+
+interface WineCardProps {
+  product: ProductOut
+  reason?: string
+  /** Store ID → store name lookup. When provided, availability shows "At Store Name" / "In N of your stores". */
+  storeNames?: Map<string, string>
+  /** When true + storeNames provided, expands the list of matching store names below the availability line. */
+  storesExpanded?: boolean
+  /** Called when "In N of your stores" is clicked (only fires when 2+ stores match). */
+  onToggleStores?: () => void
+}
+
+function WineCard({ product, reason, storeNames, storesExpanded, onToggleStores }: WineCardProps) {
+  const origin = formatOrigin(product)
+  const details = [product.grape, origin, product.vintage].filter(Boolean).join(' · ')
+  const hasOnline = product.online_availability === true
+  const storeAvail = product.store_availability ?? []
+
+  // Cross-reference with user's saved stores when available
+  const matchingIds = storeNames ? storeAvail.filter((id) => storeNames.has(id)) : []
+  const hasStores = storeNames && storeNames.size > 0
+  const canExpand = matchingIds.length > 1 && onToggleStores
+
+  const storeText =
+    matchingIds.length === 1
+      ? `At ${storeNames?.get(matchingIds[0])}`
+      : `In ${matchingIds.length} of your stores`
+
+  const storeNode = hasStores ? (
+    matchingIds.length > 0 ? (
+      canExpand ? (
+        <button
+          type="button"
+          className="text-xs text-green-500 hover:underline underline-offset-4 cursor-pointer"
+          onClick={onToggleStores}
+        >
+          {storeText}
+        </button>
+      ) : (
+        <span className="text-xs text-green-500">{storeText}</span>
+      )
+    ) : null
+  ) : storeAvail.length > 0 ? (
+    <span className="text-xs text-green-500">
+      In {storeAvail.length} store{storeAvail.length !== 1 ? 's' : ''}
+    </span>
+  ) : null
+
+  return (
+    <div className="flex-1 min-w-0">
+      {/* Line 1: Name (links to SAQ) */}
+      <p className="font-mono font-bold text-sm line-clamp-2">
+        {product.url ? (
+          <a
+            href={product.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary"
+          >
+            {product.name}
+          </a>
+        ) : (
+          product.name
+        )}
+      </p>
+
+      {/* Line 2: Grape · Origin · Vintage */}
+      {details && <p className="text-xs text-muted-foreground mt-0.5">{details}</p>}
+
+      {/* Line 3: Price + availability */}
+      <div className="flex items-center gap-3 mt-1">
+        {product.price && (
+          <span className="text-sm">
+            {product.price} ${' '}
+            {product.size && (
+              <span className="text-muted-foreground text-xs">/ {product.size}</span>
+            )}
+          </span>
+        )}
+        {hasOnline && <span className="text-xs text-green-500">Online</span>}
+        {hasOnline && storeNode && <span className="text-xs text-muted-foreground">·</span>}
+        {storeNode}
+      </div>
+
+      {/* Expanded store list */}
+      {storesExpanded && matchingIds.length > 1 && (
+        <ul className="text-muted-foreground text-xs ml-1 mt-1">
+          {matchingIds.map((id) => (
+            <li key={id}>{storeNames?.get(id)}</li>
+          ))}
+        </ul>
+      )}
+
+      {/* Reason (chat only) */}
+      {reason && <p className="text-sm mt-2">{reason}</p>}
+    </div>
+  )
+}
+
+export default WineCard

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,14 +1,14 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { useParams, useNavigate, useOutletContext } from 'react-router'
 import { useApiClient } from '@/lib/api'
-import { formatOrigin } from '@/lib/utils'
 import type { ChatOutletContext } from '@/components/AppShell'
+import WineCard from '@/components/WineCard'
 import type {
   ChatSessionOut,
   ChatMessageOut,
   ChatSessionDetailOut,
   RecommendationOut,
-  ProductOut,
+  UserStorePreferenceOut,
 } from '@/lib/types'
 
 const MAX_MESSAGE_LENGTH = 2000
@@ -17,33 +17,17 @@ function isRecommendation(content: string | RecommendationOut): content is Recom
   return typeof content === 'object' && 'products' in content
 }
 
-function WineCard({ product, reason }: { product: ProductOut; reason: string }) {
-  const origin = formatOrigin(product)
-  return (
-    <div className="border border-border p-3">
-      {product.url ? (
-        <a
-          href={product.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="font-mono font-bold text-sm line-clamp-2 hover:text-primary"
-        >
-          {product.name}
-        </a>
-      ) : (
-        <p className="font-mono font-bold text-sm line-clamp-2">{product.name}</p>
-      )}
-      <p className="text-xs text-muted-foreground mt-0.5">
-        {[origin, product.category, product.price ? `${product.price} $` : null]
-          .filter(Boolean)
-          .join(' · ')}
-      </p>
-      <p className="text-sm mt-2">{reason}</p>
-    </div>
-  )
-}
-
-function AssistantMessage({ content }: { content: string | RecommendationOut }) {
+function AssistantMessage({
+  content,
+  storeNames,
+  expandedStores,
+  onToggleStores,
+}: {
+  content: string | RecommendationOut
+  storeNames: Map<string, string>
+  expandedStores: Set<string>
+  onToggleStores: (sku: string) => void
+}) {
   if (!isRecommendation(content)) {
     return <p className="text-sm whitespace-pre-wrap">{content}</p>
   }
@@ -52,7 +36,15 @@ function AssistantMessage({ content }: { content: string | RecommendationOut }) 
     <div className="flex flex-col gap-3">
       <p className="text-sm">{content.summary}</p>
       {content.products.map(({ product, reason }) => (
-        <WineCard key={product.sku} product={product} reason={reason} />
+        <div key={product.sku} className="border border-border p-4">
+          <WineCard
+            product={product}
+            reason={reason}
+            storeNames={storeNames}
+            storesExpanded={expandedStores.has(product.sku)}
+            onToggleStores={() => onToggleStores(product.sku)}
+          />
+        </div>
       ))}
     </div>
   )
@@ -73,9 +65,32 @@ function ChatPage() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [lastFailedInput, setLastFailedInput] = useState<string | null>(null)
+  const [storeNames, setStoreNames] = useState<Map<string, string>>(new Map())
+  const [expandedStores, setExpandedStores] = useState<Set<string>>(new Set())
+  const toggleStoreExpand = useCallback((sku: string) => {
+    setExpandedStores((prev) => {
+      const next = new Set(prev)
+      if (next.has(sku)) next.delete(sku)
+      else next.add(sku)
+      return next
+    })
+  }, [])
   const bottomRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const skipLoadRef = useRef(false)
+
+  // Fetch user's saved stores once (for availability display on wine cards)
+  useEffect(() => {
+    let cancelled = false
+    apiClient<UserStorePreferenceOut[]>('/stores/preferences')
+      .then((prefs) => {
+        if (!cancelled) setStoreNames(new Map(prefs.map((p) => [p.saq_store_id, p.store.name])))
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [apiClient])
 
   // Reset transient state when URL changes (new chat vs resume)
   useEffect(() => {
@@ -231,7 +246,12 @@ function ChatPage() {
                 {msg.role === 'user' ? (
                   <p className="text-sm whitespace-pre-wrap">{msg.content as string}</p>
                 ) : (
-                  <AssistantMessage content={msg.content} />
+                  <AssistantMessage
+                    content={msg.content}
+                    storeNames={storeNames}
+                    expandedStores={expandedStores}
+                    onToggleStores={toggleStoreExpand}
+                  />
                 )}
               </div>
             </div>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -10,7 +10,7 @@ import type {
   UserStorePreferenceOut,
 } from '@/lib/types'
 import { Button } from '@/components/ui/button'
-import { formatOrigin } from '@/lib/utils'
+import WineCard from '@/components/WineCard'
 
 const DEBOUNCE_MS = 300
 const LIMIT = 20
@@ -77,6 +77,14 @@ function SearchPage() {
   const [watchedSkus, setWatchedSkus] = useState<Set<string>>(new Set())
   const [watchingInProgress, setWatchingInProgress] = useState<string | null>(null)
   const [expandedStores, setExpandedStores] = useState<Set<string>>(new Set())
+  const toggleStoreExpand = useCallback((sku: string) => {
+    setExpandedStores((prev) => {
+      const next = new Set(prev)
+      if (next.has(sku)) next.delete(sku)
+      else next.add(sku)
+      return next
+    })
+  }, [])
 
   // Saved store IDs + names — for "In my stores" filter and availability display
   const [savedStoreIdsRaw, setSavedStoreIds] = useState<string[]>([])
@@ -612,84 +620,12 @@ function SearchPage() {
                         key={product.sku}
                         className={`border border-border p-4 flex justify-between items-start gap-4${hasAvailability ? '' : ' opacity-50'}`}
                       >
-                        <div className="flex-1 min-w-0">
-                          <p className="font-mono font-bold truncate">
-                            {product.url ? (
-                              <a
-                                href={product.url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="hover:text-primary"
-                              >
-                                {product.name}
-                              </a>
-                            ) : (
-                              product.name
-                            )}
-                          </p>
-                          <p className="text-sm text-muted-foreground mt-1">
-                            {[product.grape, formatOrigin(product), product.vintage]
-                              .filter(Boolean)
-                              .join(' · ')}
-                          </p>
-                          <div className="flex items-center gap-3 mt-1">
-                            {product.price && <span className="text-sm">{product.price} $</span>}
-                            {(() => {
-                              const canExpand = matchingIds.length > 1
-
-                              const storeText =
-                                matchingIds.length === 1
-                                  ? `At ${storeNames.get(matchingIds[0])}`
-                                  : `In ${matchingIds.length} of your stores`
-
-                              const storeNode =
-                                hasStores && matchingIds.length > 0 ? (
-                                  canExpand ? (
-                                    <button
-                                      type="button"
-                                      className="text-xs text-green-500 hover:underline underline-offset-4 cursor-pointer"
-                                      onClick={() =>
-                                        setExpandedStores((prev) => {
-                                          const next = new Set(prev)
-                                          if (next.has(product.sku)) next.delete(product.sku)
-                                          else next.add(product.sku)
-                                          return next
-                                        })
-                                      }
-                                    >
-                                      {storeText}
-                                    </button>
-                                  ) : (
-                                    <span className="text-xs text-green-500">{storeText}</span>
-                                  )
-                                ) : !hasStores && storeAvail.length > 0 ? (
-                                  <span className="text-xs text-green-500">
-                                    In {storeAvail.length} store{storeAvail.length !== 1 ? 's' : ''}
-                                  </span>
-                                ) : null
-
-                              if (!isOnline && !storeNode) return null
-                              return (
-                                <>
-                                  {isOnline && (
-                                    <span className="text-xs text-green-500">Online</span>
-                                  )}
-                                  {isOnline && storeNode && (
-                                    <span className="text-xs text-muted-foreground">·</span>
-                                  )}
-                                  {storeNode}
-                                </>
-                              )
-                            })()}
-                          </div>
-                          {expandedStores.has(product.sku) && matchingIds.length > 1 && (
-                            <ul className="text-muted-foreground text-xs ml-1 mt-1">
-                              {matchingIds.map((id) => (
-                                <li key={id}>{storeNames.get(id)}</li>
-                              ))}
-                            </ul>
-                          )}
-                        </div>
+                        <WineCard
+                          product={product}
+                          storeNames={storeNames}
+                          storesExpanded={expandedStores.has(product.sku)}
+                          onToggleStores={() => toggleStoreExpand(product.sku)}
+                        />
 
                         <button
                           type="button"


### PR DESCRIPTION
## Summary

Extract wine card rendering into a shared `WineCard` component used by both ChatPage and SearchPage. Chat wine cards now display grape, vintage, bottle size, and store availability — previously they only showed origin, category, and price.

## Related issue(s)

Closes #440

## Changes

- New `WineCard` component (`frontend/src/components/WineCard.tsx`) with props for product data, reason, store names, and store expansion toggle
- ChatPage: replaced inline WineCard with shared component, added store preferences fetch for availability display
- SearchPage: replaced ~70 lines of inline rendering with shared WineCard component
- Extracted `toggleStoreExpand` callback via `useCallback` in both pages (previously inline in SearchPage only)
- Changelog and roadmap updated