### PR TITLE
feat: sommelier service — direct Claude response for wine chat (#472)

### DIFF
--- a/.github/badges/coverage.svg
+++ b/.github/badges/coverage.svg
@@ -8,7 +8,7 @@
   </mask>
   <g mask="url(#a)">
     <rect width="62.0" height="20" fill="#555"/>
-    <rect x="62.0" width="83.5" height="20" fill="#a3c51c"/>
+    <rect x="62.0" width="83.5" height="20" fill="#4c1"/>
     <rect x="145.5" width="83.5" height="20" fill="#dfb317"/>
     <rect x="229.0" width="57.5" height="20" fill="#4c1"/>
     <rect width="286.5" height="20" fill="url(#b)"/>
@@ -16,8 +16,8 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="31.0" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="31.0" y="14">coverage</text>
-    <text x="103.75" y="15" fill="#010101" fill-opacity=".3">backend 84%</text>
-    <text x="103.75" y="14">backend 84%</text>
+    <text x="103.75" y="15" fill="#010101" fill-opacity=".3">backend 85%</text>
+    <text x="103.75" y="14">backend 85%</text>
     <text x="187.25" y="15" fill="#010101" fill-opacity=".3">scraper 78%</text>
     <text x="187.25" y="14">scraper 78%</text>
     <text x="257.75" y="15" fill="#010101" fill-opacity=".3">bot 94%</text>

--- a/backend/services/sommelier.py
+++ b/backend/services/sommelier.py
@@ -1,0 +1,80 @@
+import anthropic
+from loguru import logger
+
+from backend.config import backend_settings
+from backend.services._anthropic import get_anthropic_client
+
+_MODEL = "claude-haiku-4-5-20251001"
+
+_MAX_TOKENS = 512
+
+_FALLBACK_MESSAGE = "I'm having trouble connecting right now — try again in a moment."
+
+_SYSTEM_PROMPT = """\
+You are a knowledgeable wine sommelier. You help users learn about wine — \
+grape varieties, regions, food pairings, tasting technique, winemaking, \
+comparisons, and general wine culture.
+
+## Rules
+1. Write in the same language as the user (French or English).
+2. Be conversational and warm, but concise — prefer 2-4 short paragraphs over walls of text.
+3. When comparing wines, use concrete attributes (tannin, acidity, body, aroma) not vague praise.
+4. You may reference SAQ as a source of wines available in Québec, but do NOT recommend \
+specific products by name or SKU — the recommendation system handles that separately. \
+If the user asks for a specific product suggestion, tell them to ask for a recommendation instead.
+5. For food pairings, explain WHY the pairing works \
+(acidity cuts fat, tannin matches protein, etc.).
+6. If the question is not about wine, politely redirect — you're a wine specialist."""
+
+
+def _build_messages(
+    query: str,
+    *,
+    conversation_history: str | None = None,
+) -> list[dict[str, str]]:
+    messages: list[dict[str, str]] = []
+    if conversation_history:
+        messages.append(
+            {
+                "role": "user",
+                "content": (
+                    f"Previous conversation:\n{conversation_history}\n\nNew question: {query}"
+                ),
+            }
+        )
+    else:
+        messages.append({"role": "user", "content": query})
+    return messages
+
+
+async def sommelier_chat(
+    query: str,
+    *,
+    conversation_history: str | None = None,
+) -> str:
+    """Answer a freeform wine question via Claude. Returns plain text."""
+    if not backend_settings.ANTHROPIC_API_KEY:
+        logger.warning("ANTHROPIC_API_KEY not set — returning fallback")
+        return _FALLBACK_MESSAGE
+
+    client = get_anthropic_client()
+
+    try:
+        response = await client.messages.create(
+            model=_MODEL,
+            max_tokens=_MAX_TOKENS,
+            temperature=backend_settings.HAIKU_TEMPERATURE,
+            system=_SYSTEM_PROMPT,
+            messages=_build_messages(query, conversation_history=conversation_history),
+        )
+    except anthropic.APIError as exc:
+        logger.opt(exception=exc).warning("Sommelier chat call failed — returning fallback")
+        return _FALLBACK_MESSAGE
+
+    # Extract text from response blocks
+    parts = [block.text for block in response.content if block.type == "text"]
+    if not parts:
+        logger.warning("Sommelier response had no text blocks — returning fallback")
+        return _FALLBACK_MESSAGE
+
+    return "\n\n".join(parts)

--- a/backend/tests/test_sommelier.py
+++ b/backend/tests/test_sommelier.py
@@ -1,0 +1,113 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import anthropic
+import pytest
+
+from backend.services.sommelier import _FALLBACK_MESSAGE, _build_messages, sommelier_chat
+
+
+class TestBuildMessages:
+    def test_without_history(self) -> None:
+        msgs = _build_messages("What pairs with lamb?")
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"] == "What pairs with lamb?"
+
+    def test_with_history(self) -> None:
+        history = "User: Tell me about Burgundy\nAssistant: Burgundy is a region..."
+        msgs = _build_messages("What about the whites?", conversation_history=history)
+        assert len(msgs) == 1
+        assert "Previous conversation:" in msgs[0]["content"]
+        assert "Tell me about Burgundy" in msgs[0]["content"]
+        assert "New question: What about the whites?" in msgs[0]["content"]
+
+
+class TestSommelierChat:
+    @pytest.mark.asyncio
+    @patch("backend.services.sommelier.get_anthropic_client")
+    @patch("backend.services.sommelier.backend_settings")
+    async def test_successful_response(
+        self, mock_settings: MagicMock, mock_get_client: MagicMock
+    ) -> None:
+        mock_settings.ANTHROPIC_API_KEY = "sk-test"
+        mock_settings.HAIKU_TEMPERATURE = 0.3
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = "Lamb pairs beautifully with Syrah."
+        mock_response = MagicMock()
+        mock_response.content = [text_block]
+        mock_client.messages.create.return_value = mock_response
+
+        result = await sommelier_chat("What pairs with lamb?")
+        assert result == "Lamb pairs beautifully with Syrah."
+        mock_client.messages.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("backend.services.sommelier.backend_settings")
+    async def test_no_api_key_returns_fallback(self, mock_settings: MagicMock) -> None:
+        mock_settings.ANTHROPIC_API_KEY = ""
+        result = await sommelier_chat("Tell me about Bordeaux")
+        assert result == _FALLBACK_MESSAGE
+
+    @pytest.mark.asyncio
+    @patch("backend.services.sommelier.get_anthropic_client")
+    @patch("backend.services.sommelier.backend_settings")
+    async def test_api_error_returns_fallback(
+        self, mock_settings: MagicMock, mock_get_client: MagicMock
+    ) -> None:
+        mock_settings.ANTHROPIC_API_KEY = "sk-test"
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+        mock_client.messages.create.side_effect = anthropic.APIError(
+            message="fail", request=MagicMock(), body=None
+        )
+
+        result = await sommelier_chat("What is tannin?")
+        assert result == _FALLBACK_MESSAGE
+
+    @pytest.mark.asyncio
+    @patch("backend.services.sommelier.get_anthropic_client")
+    @patch("backend.services.sommelier.backend_settings")
+    async def test_no_text_blocks_returns_fallback(
+        self, mock_settings: MagicMock, mock_get_client: MagicMock
+    ) -> None:
+        mock_settings.ANTHROPIC_API_KEY = "sk-test"
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.content = []
+        mock_client.messages.create.return_value = mock_response
+
+        result = await sommelier_chat("Hello")
+        assert result == _FALLBACK_MESSAGE
+
+    @pytest.mark.asyncio
+    @patch("backend.services.sommelier.get_anthropic_client")
+    @patch("backend.services.sommelier.backend_settings")
+    async def test_passes_conversation_history(
+        self, mock_settings: MagicMock, mock_get_client: MagicMock
+    ) -> None:
+        mock_settings.ANTHROPIC_API_KEY = "sk-test"
+        mock_settings.HAIKU_TEMPERATURE = 0.3
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = "The whites from Burgundy are Chardonnay-based."
+        mock_response = MagicMock()
+        mock_response.content = [text_block]
+        mock_client.messages.create.return_value = mock_response
+
+        history = "User: Tell me about Burgundy\nAssistant: Burgundy is famous for Pinot Noir."
+        result = await sommelier_chat("What about the whites?", conversation_history=history)
+
+        assert "Chardonnay" in result
+        call_kwargs = mock_client.messages.create.call_args.kwargs
+        user_msg = call_kwargs["messages"][0]["content"]
+        assert "Previous conversation:" in user_msg
+        assert "New question: What about the whites?" in user_msg


### PR DESCRIPTION
## Summary

New `sommelier_chat()` service function that answers freeform wine questions via Claude Haiku. Foundation for Phase 10 intent routing — non-recommendation queries (food pairings, region info, comparisons) will be routed here instead of through the RAG pipeline.

## Related issue(s)

Closes #472

## Changes

- New `backend/services/sommelier.py` — async `sommelier_chat(query, conversation_history)` returning plain text
- System prompt: wine-focused sommelier persona, bilingual (FR/EN), aware of SAQ context but scoped to general wine knowledge (specific product recs deferred to RAG pipeline)
- Graceful fallback on missing API key or Claude API errors
- Conversation history support for multi-turn coherence
- 7 tests covering happy path, API failure, missing key, empty response, and history passthrough