### PR TITLE
fix: update deploy paths for deploy user home directory

### DIFF
--- a/deploy/deploy_backend.sh
+++ b/deploy/deploy_backend.sh
@@ -58,7 +58,7 @@ else
 fi
 
 echo "==> Pre-deploy database backup..."
-/home/victor/infra/services/postgres/backups/backup.sh saq_sommelier
+/home/deploy/infra/scripts/postgres_backup.sh saq_sommelier
 
 echo "==> Ensuring pgvector extension..."
 docker exec "$DB_HOST" psql -U postgres -d "$DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS vector;"

--- a/deploy/systemd/coupette-availability.service
+++ b/deploy/systemd/coupette-availability.service
@@ -9,4 +9,4 @@ WorkingDirectory=/opt/coupette
 EnvironmentFile=/opt/coupette/.image-tag
 EnvironmentFile=/etc/push-monitor/coupette-availability.env
 ExecStart=/usr/bin/docker compose -f docker-compose.yml -f docker-compose.prod.yml run --rm scraper python -m scraper availability
-ExecStartPost=-/home/victor/infra/scripts/push-monitor.sh ${PUSH_URL}
+ExecStartPost=-/home/deploy/infra/scripts/push-monitor.sh ${PUSH_URL}

--- a/deploy/systemd/coupette-scraper.service
+++ b/deploy/systemd/coupette-scraper.service
@@ -11,4 +11,4 @@ EnvironmentFile=/etc/push-monitor/coupette-scraper.env
 ExecStart=/usr/bin/docker compose -f docker-compose.yml -f docker-compose.prod.yml run --rm scraper python -m scraper scrape
 ExecStart=/usr/bin/docker compose -f docker-compose.yml -f docker-compose.prod.yml run --rm scraper python -m scraper enrich
 ExecStart=/usr/bin/docker compose -f docker-compose.yml -f docker-compose.prod.yml run --rm scraper python -m scraper embed
-ExecStartPost=-/home/victor/infra/scripts/push-monitor.sh ${PUSH_URL}
+ExecStartPost=-/home/deploy/infra/scripts/push-monitor.sh ${PUSH_URL}


### PR DESCRIPTION
## Summary

Fix deploy script and systemd unit paths — `/home/victor/` → `/home/deploy/` to match the CD deploy user.

## Related issue(s)

None — hotfix from first CD pipeline run.

## Changes

- `deploy/deploy_backend.sh` — backup script path updated to `/home/deploy/infra/scripts/postgres_backup.sh`
- `deploy/systemd/coupette-availability.service` — push-monitor path updated
- `deploy/systemd/coupette-scraper.service` — push-monitor path updated