### PR TITLE
fix: clear old frontend assets before SCP deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -99,6 +99,14 @@ jobs:
           yarn install --frozen-lockfile
           yarn build
 
+      - name: Clear old frontend assets
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ secrets.SSH_DEPLOY_HOST }}
+          username: ${{ secrets.SSH_DEPLOY_USER }}
+          key: ${{ secrets.SSH_DEPLOY_KEY }}
+          script: rm -rf /srv/coupette/*
+
       - name: Deploy frontend to VPS
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -108,7 +116,6 @@ jobs:
           source: "frontend/dist/*"
           target: "/srv/coupette"
           strip_components: 2
-          rm: true
 
       - name: Deploy backend to VPS
         uses: appleboy/ssh-action@v1.2.5


### PR DESCRIPTION
## Summary

Fix frontend deploy permission error — `appleboy/scp-action`'s `rm: true` tried to remove and recreate `/srv/coupette`, which failed. Instead, clear directory contents via SSH before SCP.

## Related issue(s)

None — hotfix from CD pipeline debugging.

## Changes

- `cd.yml` — replace `rm: true` with a separate SSH step that runs `rm -rf /srv/coupette/*` before SCP. Prevents stale asset accumulation without removing the directory itself.