### PR TITLE
chore: refactor Docker Compose into base/prod/dev overlay layers (#491)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,6 +3,9 @@
 services:
   backend:
     env_file: .env
+    depends_on:
+      postgres:
+        condition: service_healthy
     # Exposed on localhost for bare-metal tools (curl, browser, DBeaver).
     ports:
       - "127.0.0.1:8001:8001"
@@ -17,9 +20,15 @@ services:
 
   scraper:
     env_file: .env
+    depends_on:
+      postgres:
+        condition: service_healthy
 
   migrate:
     env_file: .env
+    depends_on:
+      postgres:
+        condition: service_healthy
 
   postgres:
     image: pgvector/pgvector:pg16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,11 +29,6 @@ services:
       start_period: 5s
     networks:
       - internal
-    depends_on:
-      postgres:
-        condition: service_healthy
-        # Not required so prod works without the dev postgres service.
-        required: false
 
   bot:
     build:
@@ -69,10 +64,6 @@ services:
         max-file: "3"
     networks:
       - internal
-    depends_on:
-      postgres:
-        condition: service_healthy
-        required: false
 
   # --- On-demand services (not started by default) ---
 
@@ -87,10 +78,6 @@ services:
     cap_drop: [ALL]
     networks:
       - internal
-    depends_on:
-      postgres:
-        condition: service_healthy
-        required: false
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary

Prevent the dev override file from accidentally loading in production and clean up the base/dev/prod compose separation. Previously `docker-compose.override.yml` was auto-loaded by any bare `docker compose up`, which caused dev port bindings and env vars to leak into prod.

## Related issue(s)

Closes #491

## Changes

- Rename `docker-compose.override.yml` → `docker-compose.dev.yml` — must now be loaded explicitly with `-f` flags
- Move postgres service definition from base → dev overlay (dev-only, prod uses `shared-postgres` from infra stack)
- Move `depends_on: postgres` from base → dev overlay (only valid where postgres service exists)
- Remove hardcoded `environment:` overrides (`DB_HOST`, `BACKEND_URL`) from base compose — now supplied via `env_file` in each overlay
- Update `BACKEND_URL` in `.env.prod.enc` to `http://backend:8001` (was `localhost`)
- Fix postgres Linux capabilities: `DAC_OVERRIDE` → `DAC_READ_SEARCH` (narrower, read-only)
- Update Makefile `start-db`/`stop-db` targets to use explicit overlay flags (no more `--profile dev`)
- Update docs (ENGINEERING.md) with new dev command

## How to test

**Dev:** `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d` — postgres starts with env vars from `.env`, backend/scraper wait for it.

**Prod:** `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d backend bot` — no postgres, no dev ports, env vars from `.env.prod`.

**Verify no auto-load:** bare `docker compose up` on VPS should NOT expose port 8001 on host or start a local postgres.