### PR TITLE
fix: use Docker healthcheck instead of curl in deploy script

### DIFF
--- a/deploy/deploy_backend.sh
+++ b/deploy/deploy_backend.sh
@@ -75,12 +75,13 @@ echo "==> Restarting services..."
 echo "==> Health check..."
 healthy=false
 for i in 1 2 3 4 5 6; do
-  curl -sf localhost:8001/health > /dev/null && healthy=true && break
+  status=$(docker inspect --format='{{.State.Health.Status}}' coupette-backend 2>/dev/null || echo "unknown")
+  [[ "$status" == "healthy" ]] && healthy=true && break
   sleep 2
 done
 
 if ! $healthy; then
-  echo "ERROR: backend health check failed after 12s"
+  echo "ERROR: backend health check failed after 12s (status: $status)"
   exit 1
 fi
 echo "OK: backend healthy"


### PR DESCRIPTION
## Summary

After removing the dev port binding from prod (#491), `curl localhost:8001/health` no longer works since the backend port isn't exposed on the host. Replace with `docker inspect` which uses the container's built-in healthcheck.

## Related issue(s)

Follow-up to #491

## Changes

- Replace `curl -sf localhost:8001/health` with `docker inspect --format='{{.State.Health.Status}}' coupette-backend`
- Include health status in error message for easier debugging