### PR TITLE
chore: add .pip-audit-ignore for unfixable CVEs

### DIFF
--- a/.pip-audit-ignore
+++ b/.pip-audit-ignore
@@ -1,0 +1,6 @@
+# Known vulnerabilities with no fix available yet.
+# Remove entries once a patched version is released.
+# Format: one CVE ID per line, comments start with #.
+
+# pygments 2.19.2 — no fix version available as of 2026-03-25
+CVE-2026-4539

--- a/Makefile
+++ b/Makefile
@@ -210,21 +210,23 @@ coverage: coverage-backend coverage-scraper coverage-bot
 
 # --- Audit ---
 
+PIP_AUDIT_IGNORE := $(shell grep -v '^\#' .pip-audit-ignore 2>/dev/null | sed '/^$$/d' | sed 's/^/--ignore-vuln /')
+
 audit-core:
 	@echo "\n▶ Auditing core/"
-	cd core && poetry run pip-audit
+	cd core && poetry run pip-audit $(PIP_AUDIT_IGNORE)
 
 audit-backend:
 	@echo "\n▶ Auditing backend/"
-	cd backend && poetry run pip-audit
+	cd backend && poetry run pip-audit $(PIP_AUDIT_IGNORE)
 
 audit-scraper:
 	@echo "\n▶ Auditing scraper/"
-	cd scraper && poetry run pip-audit
+	cd scraper && poetry run pip-audit $(PIP_AUDIT_IGNORE)
 
 audit-bot:
 	@echo "\n▶ Auditing bot/"
-	cd bot && poetry run pip-audit
+	cd bot && poetry run pip-audit $(PIP_AUDIT_IGNORE)
 
 audit-frontend:
 	@echo "\n▶ Auditing frontend/"


### PR DESCRIPTION
## Summary

pip-audit blocks CI on CVEs with no upstream fix available (e.g. pygments CVE-2026-4539). Add a `.pip-audit-ignore` file (same pattern as `.trivyignore`) so unfixable CVEs can be explicitly acknowledged without breaking the pipeline.

## Changes

- Add `.pip-audit-ignore` — one CVE per line with comments explaining why it's suppressed
- Update Makefile `audit-*` targets to read from the ignore file and pass `--ignore-vuln` flags to pip-audit
- Supports multiple CVEs — each entry expands to its own `--ignore-vuln` flag

## How to test

```bash
# Verify expansion with dry run
make -n audit-scraper
# → should show: poetry run pip-audit --ignore-vuln CVE-2026-4539

# Run the actual audit
make audit-scraper
# → should pass with "No known vulnerabilities found, 1 ignored"
```