### PR TITLE
feat: public landing page + login page redesign (#536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Public landing page — bilingual hero, RAG pipeline walkthrough, changelog timeline, open source section with live GitHub commits
+
+### Changed
+
+- Login route moved to `/login`; `/` now serves the public landing page
+- "Watchlist" renamed to "Favoris" throughout the French UI
+
 ## [1.5.2] - 2026-03-24
 
 ### Added

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,7 +15,7 @@ Scaffolding, scraping, data layer, API, Telegram bot, AI layer (RAG + Claude), a
 Premium warm theme replacing the brutalist/terminal aesthetic. Cross-cutting UX effort before Phase 11.
 
 - [x] Theme foundation — tokens, fonts, sidebar (#534)
-- [ ] Landing page + login restyle + age gate (#536, #535)
+- [x] Landing page + login restyle (#536, #535)
 - [ ] Chat page + wine card restyle (#537)
 - [ ] Search, watchlist, stores restyle + empty states (#538)
 - [ ] Wine detail slide panel (#539)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🥂</text></svg>">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><defs><linearGradient id='g' x1='0' y1='0' x2='1' y2='1'><stop offset='0%25' stop-color='%23d4a04a55'/><stop offset='100%25' stop-color='%23d4a04a22'/></linearGradient></defs><rect width='32' height='32' rx='8' fill='url(%23g)'/><text x='16' y='22' text-anchor='middle' font-family='system-ui,sans-serif' font-size='17' font-weight='600' fill='%23d4a04a'>C</text></svg>">
     <title>Coupette</title>
     <script defer src="https://analytics.victorpatrin.dev/script.js" data-website-id="b9760e2c-0c83-4dc2-8790-a8b76cc63aec"></script>
   </head>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate } from 'react-router'
 import { ProtectedRoute } from '@/components/ProtectedRoute'
 import AppShell from '@/components/AppShell'
+import LandingPage from '@/pages/LandingPage'
 import LoginPage from '@/pages/LoginPage'
 import ChatPage from '@/pages/ChatPage'
 import SearchPage from '@/pages/SearchPage'
@@ -19,7 +20,8 @@ function AuthedLayout() {
 function App() {
   return (
     <Routes>
-      <Route path="/" element={<LoginPage />} />
+      <Route path="/" element={<LandingPage />} />
+      <Route path="/login" element={<LoginPage />} />
       <Route path="/invite/:code" element={<LoginPage />} />
       <Route element={<AuthedLayout />}>
         <Route path="/dashboard" element={<Navigate to="/chat" replace />} />
@@ -30,7 +32,7 @@ function App() {
         <Route path="/stores" element={<SavedStoresPage />} />
         <Route path="/stores/nearby" element={<NearbyStoresPage />} />
       </Route>
-      <Route path="*" element={<LoginPage />} />
+      <Route path="*" element={<LandingPage />} />
     </Routes>
   )
 }

--- a/frontend/src/components/TelegramLoginButton.tsx
+++ b/frontend/src/components/TelegramLoginButton.tsx
@@ -12,9 +12,10 @@ export interface TelegramLoginData {
 interface TelegramLoginButtonProps {
   botUsername: string
   onAuth: (data: TelegramLoginData) => void
+  lang?: string
 }
 
-export function TelegramLoginButton({ botUsername, onAuth }: TelegramLoginButtonProps) {
+export function TelegramLoginButton({ botUsername, onAuth, lang }: TelegramLoginButtonProps) {
   const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -31,6 +32,7 @@ export function TelegramLoginButton({ botUsername, onAuth }: TelegramLoginButton
     script.setAttribute('data-size', 'large')
     script.setAttribute('data-onauth', `${callbackName}(user)`)
     script.setAttribute('data-request-access', 'write')
+    if (lang) script.setAttribute('data-lang', lang)
 
     const container = containerRef.current
     container?.appendChild(script)
@@ -41,7 +43,7 @@ export function TelegramLoginButton({ botUsername, onAuth }: TelegramLoginButton
         container.innerHTML = ''
       }
     }
-  }, [botUsername, onAuth])
+  }, [botUsername, onAuth, lang])
 
   return <div ref={containerRef} />
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -134,6 +134,67 @@
   --spacing-sidebar-x: 1.125rem; /* 18px */
 }
 
+/* RAG pipeline — animated gradient border cards */
+@keyframes border-rotate {
+  from {
+    --border-angle: 0deg;
+  }
+  to {
+    --border-angle: 360deg;
+  }
+}
+
+@property --border-angle {
+  syntax: '<angle>';
+  initial-value: 0deg;
+  inherits: false;
+}
+
+.rag-card {
+  position: relative;
+  border-radius: var(--radius-2xl);
+  background: oklch(0.15 0.005 280);
+  isolation: isolate;
+}
+
+.rag-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: conic-gradient(
+    from var(--border-angle),
+    oklch(1 0 0 / 4%) 0%,
+    oklch(0.7 0.13 65 / 30%) 25%,
+    oklch(1 0 0 / 4%) 50%,
+    oklch(0.7 0.13 65 / 12%) 75%,
+    oklch(1 0 0 / 4%) 100%
+  );
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  animation: border-rotate 6s linear infinite;
+}
+
+.rag-card:hover::before {
+  background: conic-gradient(
+    from var(--border-angle),
+    oklch(1 0 0 / 6%) 0%,
+    oklch(0.7 0.13 65 / 50%) 25%,
+    oklch(1 0 0 / 6%) 50%,
+    oklch(0.7 0.13 65 / 25%) 75%,
+    oklch(1 0 0 / 6%) 100%
+  );
+}
+
+/* RAG pipeline — SVG flow arrows */
+.rag-arrow {
+  color: oklch(0.7 0.13 65 / 70%);
+  filter: drop-shadow(0 0 6px oklch(0.7 0.13 65 / 35%));
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,11 +1,117 @@
 {
   "brand": "Coupette",
+  "landing": {
+    "mailto": {
+      "subject": "Coupette — Access request",
+      "body": "Hi!\n\nI'd like to try Coupette.\n\nThanks!"
+    },
+    "nav": {
+      "login": "Sign in",
+      "requestAccess": "Request access"
+    },
+    "hero": {
+      "title": {
+        "before": "Your",
+        "accent": "personal sommelier",
+        "afterBefore": "for the",
+        "afterBold": "SAQ",
+        "afterEnd": "."
+      },
+      "subtitle": "Tell it what you're cooking, your budget, your mood — it combs 14,000+ SAQ wines and surfaces the right bottle.",
+      "cta": "Request access",
+      "signin": "Already have access? Sign in",
+      "betaNote": "Closed beta — invite only"
+    },
+    "preview": {
+      "userMsg": "A red for pasta tonight, max $25, something a bit spicy",
+      "botIntro": "A Rhône blend with peppery Syrah — enough character to match the dish without overpowering it.",
+      "tastingNote": "Black cherry and garrigue on the nose. Medium body, supple tannins, nice acidity and a peppery finish.",
+      "placeholder": "What are we drinking tonight?"
+    },
+    "stats": {
+      "wines": "SAQ products indexed",
+      "stores": "stores covered",
+      "llm": "LLM curation",
+      "sync": "catalog sync"
+    },
+    "features": {
+      "title": "Curious. Methodical. Passionate.",
+      "subtitle": "The catalog to explore. The journal to remember.\nThe rest to go further.",
+      "catalog": {
+        "title": "Catalog",
+        "desc": "Browse 14,000+ SAQ wines. Filter by type, price, region, grape."
+      },
+      "watchlist": {
+        "title": "Watchlist",
+        "desc": "Save wines you want. Get availability alerts at your stores."
+      },
+      "journal": {
+        "title": "Journal",
+        "desc": "Your tasting notes. The sommelier learns your palate."
+      },
+      "cellar": {
+        "title": "Cellar",
+        "desc": "Your digital wine cellar. By region, vintage, or tonight's mood."
+      }
+    },
+    "rag": {
+      "title": { "before": "Under the", "bold": "hood." },
+      "subtitle": "Your sommelier did its homework.",
+      "step1": {
+        "title": "Intent analysis",
+        "detail": "Claude classifies the query: food pairing, discovery, budget, region…",
+        "code": "intent_route: pairing"
+      },
+      "step2": {
+        "title": "SQL filters on the catalog",
+        "detail": "Price, color, grape, region — narrows 14,000 products to ~200 candidates",
+        "code": "WHERE price ≤ 25 AND color = 'rouge'"
+      },
+      "step3": {
+        "title": "pgvector semantic search",
+        "detail": "Cosine similarity on tasting note embeddings",
+        "code": "cosine_similarity(query_vec, note_vec) → top 8"
+      },
+      "step4": {
+        "title": "MMR diversification",
+        "detail": "Maximal Marginal Relevance — so you don't end up with 5 identical Côtes-du-Rhône",
+        "code": "mmr_rerank(λ=0.7) → 3 diversified candidates"
+      },
+      "step5": {
+        "title": "Claude Haiku curation",
+        "detail": "The LLM picks the best match, writes the note, and explains the pairing",
+        "code": ""
+      },
+      "step6": {
+        "title": "Structured response",
+        "detail": "The wine, tasting note, and pairing explanation",
+        "code": "stream(wine_card + tasting_note + pairing)"
+      }
+    },
+    "changelog": {
+      "title": { "before": "Shipping", "bold": "constantly" },
+      "subtitle": "Every release is tagged, documented, and ships automatically.",
+      "v152": "Bilingual web app — French and English",
+      "v151": "Prometheus metrics, facets 3.5× faster, CD pipeline",
+      "v150": "Chat UI, session history, intent routing, automated deploys",
+      "v140": "React frontend, search with filters, wine cards",
+      "seeAll": "Full changelog"
+    },
+    "dev": {
+      "title": { "before": "Built in", "bold": "public" },
+      "subtitle": "Two repos. All the code, all the decisions.",
+      "deployed": "In production",
+      "viewRepo": "View repo"
+    },
+    "footer": {
+      "legal": "18+ only · Drink responsibly · Data from the public saq.com catalog · Not affiliated with SAQ"
+    }
+  },
   "login": {
-    "tagline": "Wine discovery for the curious.",
-    "invited": "You've been invited",
+    "invited": "Invitation accepted",
     "authFailed": "Authentication failed",
-    "madeWith": "Made with ❤️",
-    "sourceOnGithub": "Source on GitHub"
+    "backToLanding": "Home",
+    "legal": "18+ only · Drink responsibly"
   },
   "chat": {
     "welcome": "What are you drinking tonight?",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -1,11 +1,117 @@
 {
   "brand": "Coupette",
+  "landing": {
+    "mailto": {
+      "subject": "Coupette — Demande d'accès",
+      "body": "Salut !\n\nJ'aimerais essayer Coupette.\n\nMerci !"
+    },
+    "nav": {
+      "login": "Se connecter",
+      "requestAccess": "Demander un accès"
+    },
+    "hero": {
+      "title": {
+        "before": "Ton",
+        "accent": "sommelier personnel",
+        "afterBefore": "pour la",
+        "afterBold": "SAQ",
+        "afterEnd": "."
+      },
+      "subtitle": "Dis-lui ce que tu manges, ton budget, l'envie du moment — il passe au crible 14 000+ vins de la SAQ et te sort le bon.",
+      "cta": "Demander un accès",
+      "signin": "Déjà un accès ? Connecte-toi",
+      "betaNote": "Bêta fermée — accès sur invitation"
+    },
+    "preview": {
+      "userMsg": "Un rouge pour les pâtes ce soir, max 25 $, j'aimerais ça un peu épicé",
+      "botIntro": "Un assemblage du Rhône avec de la Syrah poivrée — assez de caractère pour accompagner le plat sans le dominer.",
+      "tastingNote": "Cerise noire et garrigue au nez. Corps moyen, tanins souples, belle acidité et une finale poivrée.",
+      "placeholder": "Qu'est-ce qu'on boit ce soir ?"
+    },
+    "stats": {
+      "wines": "produits SAQ indexés",
+      "stores": "succursales couvertes",
+      "llm": "curation LLM",
+      "sync": "synchronisation catalogue"
+    },
+    "features": {
+      "title": "Curieux. Méthodique. Passionné.",
+      "subtitle": "Le catalogue pour explorer. Le journal pour se souvenir.\nLe reste pour aller plus loin.",
+      "catalog": {
+        "title": "Catalogue",
+        "desc": "Explore les 14 000+ vins de la SAQ. Filtre par type, prix, région, cépage."
+      },
+      "watchlist": {
+        "title": "Favoris",
+        "desc": "Garde tes bouteilles de côté. Alertes de disponibilité dans tes succursales."
+      },
+      "journal": {
+        "title": "Journal",
+        "desc": "Tes notes de dégustation. Le sommelier s'ajuste à ton palais."
+      },
+      "cellar": {
+        "title": "Cellier",
+        "desc": "Ta cave numérisée. Par région, millésime ou envie du moment."
+      }
+    },
+    "rag": {
+      "title": { "before": "Sous le", "bold": "capot." },
+      "subtitle": "Ton sommelier a fait ses devoirs.",
+      "step1": {
+        "title": "Analyse de l'intention",
+        "detail": "Claude classifie la requête : accord mets-vin, découverte, budget, région…",
+        "code": "intent_route: pairing"
+      },
+      "step2": {
+        "title": "Filtres SQL sur le catalogue",
+        "detail": "Prix, couleur, cépage, région — réduit 14 000 produits à ~200 candidats",
+        "code": "WHERE price ≤ 25 AND color = 'rouge'"
+      },
+      "step3": {
+        "title": "Recherche vectorielle pgvector",
+        "detail": "Similarité cosinus sur les embeddings de notes de dégustation",
+        "code": "cosine_similarity(query_vec, note_vec) → top 8"
+      },
+      "step4": {
+        "title": "Diversification MMR",
+        "detail": "Maximal Marginal Relevance — pour ne pas finir avec 5 Côtes-du-Rhône identiques",
+        "code": "mmr_rerank(λ=0.7) → 3 candidats diversifiés"
+      },
+      "step5": {
+        "title": "Curation Claude Haiku",
+        "detail": "Le LLM choisit le meilleur match, rédige la note et explique l'accord",
+        "code": ""
+      },
+      "step6": {
+        "title": "Réponse structurée",
+        "detail": "Le vin, la note de dégustation et l'explication de l'accord",
+        "code": "stream(wine_card + tasting_note + pairing)"
+      }
+    },
+    "changelog": {
+      "title": { "before": "Livré", "bold": "en continu" },
+      "subtitle": "Chaque version est taguée, documentée et déployée en continu.",
+      "v152": "App web bilingue — français et anglais",
+      "v151": "Métriques Prometheus, facettes 3.5× plus rapides, pipeline CD",
+      "v150": "Chat UI, historique de sessions, routage d'intention, déploiements automatisés",
+      "v140": "Frontend React, recherche avec filtres, cartes de vin",
+      "seeAll": "Changelog complet"
+    },
+    "dev": {
+      "title": { "before": "Construit en", "bold": "public" },
+      "subtitle": "Deux repos. Tout le code, toutes les décisions.",
+      "deployed": "En production",
+      "viewRepo": "Voir le repo"
+    },
+    "footer": {
+      "legal": "Réservé aux 18 ans et plus · La modération a bien meilleur goût · Données du catalogue public saq.com · Non affilié à la SAQ"
+    }
+  },
   "login": {
-    "tagline": "La découverte du vin pour les curieux.",
-    "invited": "Vous avez été invité",
+    "invited": "Invitation validée",
     "authFailed": "Échec de l'authentification",
-    "madeWith": "Fait avec ❤️",
-    "sourceOnGithub": "Code source sur GitHub"
+    "backToLanding": "Accueil",
+    "legal": "Réservé aux 18 ans et plus · La modération a bien meilleur goût"
   },
   "chat": {
     "welcome": "Qu'est-ce qu'on boit ce soir ?",
@@ -44,28 +150,28 @@
     "sortPriceDesc": "Prix : décroissant",
     "sortAlpha": "Alphabétique",
     "noResults": "Aucun vin ne correspond à vos filtres.",
-    "watch": "Suivre",
-    "watching": "Suivi",
+    "watch": "Favoris",
+    "watching": "En favoris",
     "first": "Début",
     "prev": "Préc.",
     "next": "Suiv.",
     "last": "Fin",
     "failedToSearch": "Impossible de rechercher des produits",
-    "failedToAddWatch": "Impossible d'ajouter le suivi",
-    "failedToRemoveWatch": "Impossible de retirer le suivi",
+    "failedToAddWatch": "Impossible d'ajouter aux favoris",
+    "failedToRemoveWatch": "Impossible de retirer des favoris",
     "minPrice": "Prix minimum",
     "maxPrice": "Prix maximum",
     "retry": "réessayer"
   },
   "watches": {
-    "title": "Mes suivis",
-    "loading": "Chargement des suivis...",
-    "empty": "Aucun suivi pour l'instant. Recherchez des vins et ajoutez-les à votre liste.",
+    "title": "Mes favoris",
+    "loading": "Chargement des favoris...",
+    "empty": "Aucun favori pour l'instant. Recherchez des vins et ajoutez-les à vos favoris.",
     "remove": "Retirer",
     "removing": "Retrait...",
     "delisted": "Produit retiré (SKU : {{sku}})",
-    "failedToLoad": "Impossible de charger les suivis",
-    "failedToRemove": "Impossible de retirer le suivi"
+    "failedToLoad": "Impossible de charger les favoris",
+    "failedToRemove": "Impossible de retirer le favori"
   },
   "stores": {
     "title": "Mes succursales",
@@ -94,7 +200,7 @@
   "nav": {
     "chat": "Discussion",
     "search": "Recherche",
-    "myWatches": "Mes suivis",
+    "myWatches": "Mes favoris",
     "myStores": "Mes succursales",
     "newChat": "+ Nouvelle discussion",
     "history": "Historique",

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,0 +1,676 @@
+import { Link } from 'react-router'
+import { useTranslation } from 'react-i18next'
+import { useAuth } from '@/contexts/AuthContext'
+import { Navigate } from 'react-router'
+import { Fragment, useEffect, useState } from 'react'
+import {
+  MagnifyingGlassIcon,
+  EyeIcon,
+  BookOpenIcon,
+  HouseIcon,
+  GithubLogoIcon,
+} from '@phosphor-icons/react'
+
+const CONTACT_EMAIL = 'victor.patrin@protonmail.com'
+
+const STATS = [
+  { value: '14 000+', labelKey: 'landing.stats.wines' },
+  { value: '400+', labelKey: 'landing.stats.stores' },
+  { value: '~2s', labelKey: 'landing.stats.llm' },
+  { value: '24h', labelKey: 'landing.stats.sync' },
+] as const
+
+const FEATURES = [
+  {
+    icon: MagnifyingGlassIcon,
+    titleKey: 'landing.features.catalog.title',
+    descKey: 'landing.features.catalog.desc',
+  },
+  {
+    icon: EyeIcon,
+    titleKey: 'landing.features.watchlist.title',
+    descKey: 'landing.features.watchlist.desc',
+  },
+  {
+    icon: BookOpenIcon,
+    titleKey: 'landing.features.journal.title',
+    descKey: 'landing.features.journal.desc',
+  },
+  {
+    icon: HouseIcon,
+    titleKey: 'landing.features.cellar.title',
+    descKey: 'landing.features.cellar.desc',
+  },
+] as const
+
+const RAG_STEPS = [
+  {
+    num: '01',
+    titleKey: 'landing.rag.step1.title',
+    detailKey: 'landing.rag.step1.detail',
+    codeKey: 'landing.rag.step1.code',
+  },
+  {
+    num: '02',
+    titleKey: 'landing.rag.step2.title',
+    detailKey: 'landing.rag.step2.detail',
+    codeKey: 'landing.rag.step2.code',
+  },
+  {
+    num: '03',
+    titleKey: 'landing.rag.step3.title',
+    detailKey: 'landing.rag.step3.detail',
+    codeKey: 'landing.rag.step3.code',
+  },
+  {
+    num: '04',
+    titleKey: 'landing.rag.step4.title',
+    detailKey: 'landing.rag.step4.detail',
+    codeKey: 'landing.rag.step4.code',
+  },
+  {
+    num: '05',
+    titleKey: 'landing.rag.step5.title',
+    detailKey: 'landing.rag.step5.detail',
+    codeKey: 'landing.rag.step5.code',
+    result: '✓ Château Pesquié Terrasses 2022 — 18,95 $ · 1.8s',
+  },
+  {
+    num: '06',
+    titleKey: 'landing.rag.step6.title',
+    detailKey: 'landing.rag.step6.detail',
+    codeKey: 'landing.rag.step6.code',
+  },
+] as const
+
+interface GitHubCommit {
+  sha: string
+  commit: { message: string; author: { date: string } }
+}
+
+interface RepoData {
+  commits: { message: string; timeAgo: string }[]
+  loading: boolean
+}
+
+interface DeployInfo {
+  version: string
+  timeAgo: string
+}
+
+const GH_API = 'https://api.github.com'
+const CHANGELOG = [
+  { version: '1.5.2', date: '2026-03-24', titleKey: 'landing.changelog.v152' },
+  { version: '1.5.1', date: '2026-03-21', titleKey: 'landing.changelog.v151' },
+  { version: '1.5.0', date: '2026-03-19', titleKey: 'landing.changelog.v150' },
+  { version: '1.4.0', date: '2026-03-12', titleKey: 'landing.changelog.v140' },
+] as const
+
+const REPOS = [
+  { owner: 'vpatrin', name: 'coupette', desc: 'FastAPI · React · RAG · Telegram bot' },
+  { owner: 'vpatrin', name: 'infra', desc: 'Caddy · Docker · Monitoring · Hardening' },
+] as const
+
+function formatTimeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000)
+  if (seconds < 60) return '<1min'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}min`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h`
+  const days = Math.floor(hours / 24)
+  return `${days}d`
+}
+
+const INITIAL_REPOS: Record<string, RepoData> = Object.fromEntries(
+  REPOS.map((repo) => [`${repo.owner}/${repo.name}`, { commits: [], loading: true }]),
+)
+
+function useGitHubData() {
+  const [repos, setRepos] = useState<Record<string, RepoData>>(INITIAL_REPOS)
+  const [deploy, setDeploy] = useState<DeployInfo | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    fetch(`${GH_API}/repos/vpatrin/coupette/tags?per_page=1`)
+      .then((r) => (r.ok ? r.json() : []))
+      .then(async (tags: { name: string; commit: { url: string } }[]) => {
+        if (cancelled || !tags.length) return
+        const commitRes = await fetch(tags[0].commit.url)
+        if (!commitRes.ok) return
+        const commitData = await commitRes.json()
+        const date = commitData.commit?.author?.date
+        if (!cancelled && date) {
+          setDeploy({ version: tags[0].name, timeAgo: formatTimeAgo(date) })
+        }
+      })
+      .catch(() => {})
+
+    for (const repo of REPOS) {
+      const key = `${repo.owner}/${repo.name}`
+
+      fetch(`${GH_API}/repos/${repo.owner}/${repo.name}/commits?per_page=4`)
+        .then((r) => (r.ok ? r.json() : []))
+        .then((commits: GitHubCommit[]) => {
+          if (cancelled) return
+          setRepos((prev) => ({
+            ...prev,
+            [key]: {
+              loading: false,
+              commits: commits.map((c) => ({
+                message: c.commit.message.split('\n')[0],
+                timeAgo: formatTimeAgo(c.commit.author.date),
+              })),
+            },
+          }))
+        })
+        .catch(() => {
+          if (!cancelled) setRepos((prev) => ({ ...prev, [key]: { commits: [], loading: false } }))
+        })
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return { repos, deploy }
+}
+
+/* Content width — matches nav container for alignment */
+const SECTION = 'max-w-6xl mx-auto w-full px-8'
+
+function LandingPage() {
+  const { t, i18n } = useTranslation()
+  const { token } = useAuth()
+  const { repos, deploy } = useGitHubData()
+  const toggleLang = () => {
+    i18n.changeLanguage(i18n.resolvedLanguage === 'fr' ? 'en' : 'fr')
+  }
+
+  if (token) return <Navigate to="/chat" replace />
+
+  const mailtoHref = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(t('landing.mailto.subject'))}&body=${encodeURIComponent(t('landing.mailto.body'))}`
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      {/* Nav */}
+      <nav className="fixed top-0 inset-x-0 z-50 bg-background/60 backdrop-blur-xl border-b border-border">
+        <div className="max-w-6xl mx-auto w-full px-8 flex items-center justify-between py-3.5">
+          <Link to="/" className="flex items-center gap-2.5">
+            <div className="w-7.5 h-7.5 rounded-lg bg-gradient-to-br from-primary/35 to-primary/15 flex items-center justify-center text-sm font-semibold text-primary">
+              C
+            </div>
+            <span className="text-base font-medium">{t('brand')}</span>
+          </Link>
+          <div className="flex items-center gap-4">
+            <button
+              type="button"
+              onClick={toggleLang}
+              className="w-8 text-center text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {i18n.resolvedLanguage === 'fr' ? 'EN' : 'FR'}
+            </button>
+            <Link
+              to="/login"
+              className="min-w-24 text-center text-[length:var(--text-sidebar)] text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {t('landing.nav.login')}
+            </Link>
+            <a
+              href={mailtoHref}
+              className="min-w-44 text-center px-4 py-2 rounded-xl bg-primary/15 border border-primary/20 text-primary text-sm font-medium hover:bg-primary/25 transition-colors"
+            >
+              {t('landing.nav.requestAccess')}
+            </a>
+          </div>
+        </div>
+      </nav>
+
+      {/* Hero */}
+      <section className="pt-44 pb-28">
+        <div className={`${SECTION}`}>
+          <h1 className="text-5xl md:text-7xl font-extralight leading-[1.08] tracking-tight mb-6 max-w-3xl">
+            {t('landing.hero.title.before')}{' '}
+            <span className="text-primary font-light">{t('landing.hero.title.accent')}</span>
+            <br />
+            {t('landing.hero.title.afterBefore')}{' '}
+            <strong className="font-semibold">{t('landing.hero.title.afterBold')}</strong>
+            {t('landing.hero.title.afterEnd')}
+          </h1>
+
+          <p className="text-base font-light text-foreground/80 max-w-lg leading-relaxed mb-10">
+            {t('landing.hero.subtitle')}
+          </p>
+
+          {/* CTA */}
+          <div className="flex items-center gap-6 mb-3">
+            <a
+              href={mailtoHref}
+              className="px-6 py-3 rounded-xl bg-primary/15 border border-primary/20 text-primary text-sm font-medium hover:bg-primary/25 transition-colors"
+            >
+              {t('landing.hero.cta')}
+            </a>
+            <Link
+              to="/login"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {t('landing.hero.signin')}
+            </Link>
+          </div>
+          <p className="text-xs text-muted-foreground mb-12">{t('landing.hero.betaNote')}</p>
+        </div>
+
+        {/* Chat preview — flush with content, bottom fade */}
+        <div className={`${SECTION} relative`}>
+          <div className="rounded-2xl border border-border/50 bg-card/30 overflow-hidden">
+            {/* Browser chrome */}
+            <div className="h-9 flex items-center px-3.5 gap-1.5 bg-surface-hover border-b border-border/50">
+              <span className="w-2.5 h-2.5 rounded-full bg-[rgba(255,255,255,0.08)]" />
+              <span className="w-2.5 h-2.5 rounded-full bg-[rgba(255,255,255,0.08)]" />
+              <span className="w-2.5 h-2.5 rounded-full bg-[rgba(255,255,255,0.08)]" />
+              <span className="flex-1 text-center font-mono text-[length:var(--text-sidebar-xs)] text-muted-foreground">
+                coupette.club
+              </span>
+            </div>
+
+            <div className="p-5 md:p-6 flex flex-col gap-3.5">
+              {/* User message */}
+              <div className="flex flex-col items-end">
+                <div className="max-w-[75%] px-4 py-2.5 rounded-2xl rounded-br-sm bg-primary/10 border border-primary/12 text-[length:var(--text-sidebar)] leading-relaxed">
+                  {t('landing.preview.userMsg')}
+                </div>
+              </div>
+
+              {/* Bot response */}
+              <div className="flex flex-col items-start">
+                <div className="max-w-[88%] px-4 py-3.5 rounded-2xl rounded-tl-sm bg-card/50 border border-border/50 text-[length:var(--text-sidebar)] font-light leading-relaxed text-muted-foreground">
+                  {/* SSE pipeline trace */}
+                  <div className="font-mono text-[length:var(--text-sidebar-xs)] leading-relaxed mb-3 px-3 py-2.5 rounded-lg bg-[rgba(0,0,0,0.3)] border border-[rgba(255,255,255,0.03)]">
+                    <div>
+                      <span className="text-primary">›</span> query: rouge, ≤25$, pâtes, épicé
+                    </div>
+                    <div> intent_route: pairing → sql_filter</div>
+                    <div> pgvector: cosine_sim top_k=8 → mmr_rerank</div>
+                    <div>
+                      <span className="text-green-500">✓</span> 3 candidates · 1.8s
+                    </div>
+                  </div>
+
+                  <p className="mb-3">{t('landing.preview.botIntro')}</p>
+
+                  {/* Wine card */}
+                  <div className="p-3.5 rounded-xl bg-[rgba(255,255,255,0.025)] border border-border/50 relative overflow-hidden">
+                    <div className="absolute inset-0 rounded-xl bg-gradient-to-br from-primary/4 to-transparent pointer-events-none" />
+                    <div className="flex justify-between gap-3 relative">
+                      <div>
+                        <div className="text-sm font-medium text-foreground mb-1.5">
+                          Château Pesquié Terrasses 2022
+                        </div>
+                        <div className="flex gap-1 flex-wrap mb-1">
+                          <span className="text-[9px] px-2 py-0.5 rounded bg-primary/10 text-primary">
+                            Rouge
+                          </span>
+                          <span className="text-[9px] px-2 py-0.5 rounded bg-[rgba(255,255,255,0.04)] text-muted-foreground">
+                            Ventoux
+                          </span>
+                          <span className="text-[9px] px-2 py-0.5 rounded bg-[rgba(255,255,255,0.04)] text-muted-foreground">
+                            Grenache · Syrah
+                          </span>
+                        </div>
+                        <span className="font-mono text-[9px] text-muted-foreground">
+                          SAQ 10264381
+                        </span>
+                      </div>
+                      <span className="text-lg font-light text-primary whitespace-nowrap">
+                        18,95 $
+                      </span>
+                    </div>
+                    <p className="text-xs font-light text-muted-foreground mt-2.5 pt-2.5 border-t border-border/50 leading-relaxed">
+                      {t('landing.preview.tastingNote')}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Fake input */}
+              <div className="flex items-center gap-3 px-4 py-2.5 rounded-2xl border border-border/50 bg-[rgba(255,255,255,0.02)]">
+                <span className="flex-1 text-[length:var(--text-sidebar)] font-light text-muted-foreground">
+                  {t('landing.preview.placeholder')}
+                </span>
+                <div className="w-7 h-7 rounded-lg bg-primary/20 flex items-center justify-center text-primary text-xs">
+                  ↑
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Stats banner */}
+      <div className="w-full border-y border-border bg-[rgba(255,255,255,0.012)]">
+        <div className="flex items-center justify-center gap-16 py-8">
+          {STATS.map(({ value, labelKey }) => (
+            <div key={labelKey} className="text-center">
+              <div className="text-2xl font-semibold tabular-nums">{value}</div>
+              <div className="text-sm text-muted-foreground mt-0.5">{t(labelKey)}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Features */}
+      <section className="pt-28 pb-28">
+        <div className={`${SECTION}`}>
+          <div className="grid grid-cols-2 gap-16 mb-16">
+            <h2 className="text-4xl font-medium text-foreground leading-tight">
+              {t('landing.features.title')
+                .split(' ')
+                .map((word, i) => (
+                  <Fragment key={i}>
+                    {word}
+                    <br />
+                  </Fragment>
+                ))}
+            </h2>
+            <p className="text-lg font-light text-foreground leading-relaxed pt-2 whitespace-pre-line">
+              {t('landing.features.subtitle')}
+            </p>
+          </div>
+          <div className="grid grid-cols-4 w-full">
+            {FEATURES.map(({ icon: Icon, titleKey, descKey }, i) => (
+              <div
+                key={titleKey}
+                className={`py-2 ${i === 0 ? 'pr-8' : i === 3 ? 'pl-8 border-l border-border/50' : 'px-8 border-l border-border/50'}`}
+              >
+                <div className="font-mono text-xs text-muted-foreground tracking-widest mb-10">
+                  FIG 0.{i + 1}
+                </div>
+                <div className="flex items-center gap-3 mb-3">
+                  <Icon size={22} weight="light" className="text-primary" />
+                  <span className="text-base font-semibold">{t(titleKey)}</span>
+                </div>
+                <div className="text-sm font-light text-muted-foreground leading-relaxed">
+                  {t(descKey)}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* RAG Pipeline */}
+      <section className="pt-20 pb-28">
+        <div className={`${SECTION}`}>
+          {/* Split header: title left, subtitle right */}
+          <div className="grid grid-cols-2 gap-16 mb-16">
+            <h2 className="text-4xl font-light text-foreground">
+              {t('landing.rag.title.before')}{' '}
+              <strong className="font-semibold">{t('landing.rag.title.bold')}</strong>
+            </h2>
+            <p className="text-lg font-light text-foreground leading-relaxed pt-2">
+              {t('landing.rag.subtitle')}
+            </p>
+          </div>
+
+          {/* Row 1: 01 → 02 → 03 */}
+          <div className="grid grid-cols-[1fr_auto_1fr_auto_1fr] items-stretch">
+            {RAG_STEPS.slice(0, 3).map((step, i) => (
+              <Fragment key={step.num}>
+                <div className="rag-card p-6 min-h-[168px]">
+                  <span className="font-mono text-xs font-semibold text-primary drop-shadow-[0_0_8px_oklch(0.7_0.13_65_/_40%)]">
+                    {step.num}
+                  </span>
+                  <div className="text-[15px] font-semibold mt-4 mb-2">{t(step.titleKey)}</div>
+                  <div className="font-mono text-xs text-muted-foreground leading-relaxed">
+                    {t(step.detailKey)}
+                  </div>
+                  {t(step.codeKey) && (
+                    <div className="font-mono text-xs text-primary/80 mt-2">{t(step.codeKey)}</div>
+                  )}
+                </div>
+                {i < 2 && (
+                  <div className="flex items-center justify-center w-10">
+                    <svg width="32" height="16" viewBox="0 0 32 16" className="rag-arrow">
+                      <line x1="0" y1="8" x2="24" y2="8" stroke="currentColor" strokeWidth="1" />
+                      <polyline
+                        points="20,4 26,8 20,12"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1"
+                      />
+                    </svg>
+                  </div>
+                )}
+              </Fragment>
+            ))}
+          </div>
+
+          {/* ↓ connector under col 3 */}
+          <div className="grid grid-cols-[1fr_auto_1fr_auto_1fr]">
+            <div className="col-start-5 flex justify-center py-2">
+              <svg width="16" height="24" viewBox="0 0 16 24" className="rag-arrow">
+                <line x1="8" y1="0" x2="8" y2="18" stroke="currentColor" strokeWidth="1" />
+                <polyline
+                  points="4,14 8,20 12,14"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1"
+                />
+              </svg>
+            </div>
+          </div>
+
+          {/* Row 2: 06 ← 05 ← 04 (reversed so 06 is under 01) */}
+          <div className="grid grid-cols-[1fr_auto_1fr_auto_1fr] items-stretch">
+            {[RAG_STEPS[5], RAG_STEPS[4], RAG_STEPS[3]].map((step, i) => (
+              <Fragment key={step.num}>
+                <div className="rag-card p-6 min-h-[168px]">
+                  <span className="font-mono text-xs font-semibold text-primary drop-shadow-[0_0_8px_oklch(0.7_0.13_65_/_40%)]">
+                    {step.num}
+                  </span>
+                  <div className="text-[15px] font-semibold mt-4 mb-2">{t(step.titleKey)}</div>
+                  <div className="font-mono text-xs text-muted-foreground leading-relaxed">
+                    {t(step.detailKey)}
+                  </div>
+                  {t(step.codeKey) && (
+                    <div className="font-mono text-xs text-primary/80 mt-2">{t(step.codeKey)}</div>
+                  )}
+                  {'result' in step && step.result && (
+                    <div className="font-mono text-xs text-green-500 mt-2">{step.result}</div>
+                  )}
+                </div>
+                {i < 2 && (
+                  <div className="flex items-center justify-center w-10">
+                    <svg width="32" height="16" viewBox="0 0 32 16" className="rag-arrow">
+                      <line x1="8" y1="8" x2="32" y2="8" stroke="currentColor" strokeWidth="1" />
+                      <polyline
+                        points="12,4 6,8 12,12"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1"
+                      />
+                    </svg>
+                  </div>
+                )}
+              </Fragment>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Changelog */}
+      <section className="py-28 border-t border-border">
+        <div className={`${SECTION}`}>
+          {/* Split header */}
+          <div className="grid grid-cols-2 gap-16 mb-16">
+            <h2 className="text-4xl font-light text-foreground">
+              {t('landing.changelog.title.before')}{' '}
+              <strong className="font-semibold">{t('landing.changelog.title.bold')}</strong>
+            </h2>
+            <p className="text-lg font-light text-foreground leading-relaxed pt-2">
+              {t('landing.changelog.subtitle')}
+            </p>
+          </div>
+
+          {/* Timeline */}
+          <div className="relative">
+            {/* Horizontal line */}
+            <div className="absolute top-3 left-0 right-0 h-px bg-border/50" />
+
+            <div className="grid grid-cols-4 gap-6">
+              {CHANGELOG.map(({ version, date, titleKey }, i) => (
+                <div key={version} className="relative pt-8">
+                  {/* Dot on timeline */}
+                  <div
+                    className={`absolute top-1.5 left-0 w-3 h-3 rounded-full border-2 ${i === 0 ? 'bg-primary border-primary shadow-[0_0_8px_oklch(0.7_0.13_65_/_40%)]' : 'bg-background border-border'}`}
+                  />
+                  <div className="text-base font-semibold mb-1">{version}</div>
+                  <p className="text-sm font-light text-muted-foreground leading-relaxed mb-3">
+                    {t(titleKey)}
+                  </p>
+                  <span className="font-mono text-xs text-muted-foreground">{date}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <a
+            href="https://github.com/vpatrin/coupette/blob/main/CHANGELOG.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 mt-8 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {t('landing.changelog.seeAll')} <span>→</span>
+          </a>
+        </div>
+      </section>
+
+      {/* Open Source */}
+      <section className="pt-20 pb-28">
+        <div className={`${SECTION}`}>
+          {/* Split header: title left, subtitle right */}
+          <div className="grid grid-cols-2 gap-16 mb-16">
+            <h2 className="text-4xl font-light text-foreground">
+              {t('landing.dev.title.before')}{' '}
+              <strong className="font-semibold">{t('landing.dev.title.bold')}</strong>
+            </h2>
+            <p className="text-lg font-light text-foreground leading-relaxed pt-2">
+              {t('landing.dev.subtitle')}
+            </p>
+          </div>
+
+          {/* Deploy banner */}
+          {deploy && (
+            <div className="flex items-center justify-center gap-3 mb-5 px-5 py-2.5 rounded-lg bg-card border border-border w-full">
+              <span className="w-1.5 h-1.5 rounded-full bg-green-500 shadow-[0_0_8px_rgba(80,200,120,0.4)]" />
+              <span className="font-mono text-xs text-muted-foreground">
+                {t('landing.dev.deployed')} ·{' '}
+                <span className="text-primary font-medium">{deploy.version}</span> ·{' '}
+                {deploy.timeAgo}
+              </span>
+            </div>
+          )}
+
+          {/* Repo cards */}
+          <div className="grid grid-cols-2 gap-3.5 w-full">
+            {REPOS.map((repo) => {
+              const key = `${repo.owner}/${repo.name}`
+              const data = repos[key]
+              return (
+                <div
+                  key={key}
+                  className="p-5 bg-card border border-border rounded-xl text-left hover:border-border-warm transition-colors"
+                >
+                  <a
+                    href={`https://github.com/${repo.owner}/${repo.name}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 mb-3 hover:text-primary transition-colors"
+                  >
+                    <GithubLogoIcon size={18} className="text-muted-foreground" />
+                    <div>
+                      <div className="text-sm font-medium">
+                        {repo.owner}/{repo.name}
+                      </div>
+                      <div className="font-mono text-[length:var(--text-sidebar-xs)] text-muted-foreground">
+                        {repo.desc}
+                      </div>
+                    </div>
+                  </a>
+
+                  <div className="flex flex-col gap-1.5">
+                    {data?.loading && (
+                      <>
+                        {[1, 2, 3].map((n) => (
+                          <div
+                            key={n}
+                            className="h-7 rounded-md bg-[rgba(255,255,255,0.015)] animate-pulse"
+                          />
+                        ))}
+                      </>
+                    )}
+                    {!data?.loading && data?.commits.length === 0 && (
+                      <a
+                        href={`https://github.com/${repo.owner}/${repo.name}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs text-muted-foreground hover:text-primary transition-colors"
+                      >
+                        {t('landing.dev.viewRepo')} →
+                      </a>
+                    )}
+                    {data?.commits.map((commit, i) => (
+                      <div
+                        key={i}
+                        className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-[rgba(255,255,255,0.015)] border border-[rgba(255,255,255,0.03)]"
+                      >
+                        <span className="w-1.5 h-1.5 rounded-full bg-primary shrink-0" />
+                        <span className="text-xs text-muted-foreground flex-1 truncate">
+                          {commit.message}
+                        </span>
+                        <span className="font-mono text-[9px] text-muted-foreground shrink-0">
+                          {commit.timeAgo}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="py-14 border-t border-border">
+        <div className={`${SECTION} flex flex-col items-center gap-1.5`}>
+          <div className="flex items-center gap-4 text-xs text-muted-foreground">
+            <span>© 2026 Coupette</span>
+            <span className="w-px h-3 bg-border" />
+            <span>Montréal, QC</span>
+            <span className="w-px h-3 bg-border" />
+            <a href={mailtoHref} className="hover:text-foreground transition-colors">
+              Contact
+            </a>
+            <span className="w-px h-3 bg-border" />
+            <a
+              href="https://www.educalcool.qc.ca/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-foreground transition-colors"
+            >
+              Éduc'alcool
+            </a>
+          </div>
+          <p className="text-[length:var(--text-sidebar-xs)] text-muted-foreground text-center">
+            {t('landing.footer.legal')}
+          </p>
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+export default LandingPage

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback } from 'react'
-import { useNavigate, useParams, Navigate } from 'react-router'
+import { useState } from 'react'
+import { useNavigate, useParams, Navigate, Link } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '@/contexts/AuthContext'
 import { TelegramLoginButton, type TelegramLoginData } from '@/components/TelegramLoginButton'
@@ -13,69 +13,109 @@ interface TokenResponse {
 }
 
 function LoginPage() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const { token, login } = useAuth()
   const navigate = useNavigate()
   const { code } = useParams<{ code: string }>()
   const [error, setError] = useState<string | null>(null)
 
-  const handleAuth = useCallback(
-    async (telegramData: TelegramLoginData) => {
-      setError(null)
-      try {
-        const body = {
-          ...telegramData,
-          ...(code ? { invite_code: code } : {}),
-        }
-        const { access_token } = await api<TokenResponse>('/auth/telegram', {
-          method: 'POST',
-          body: JSON.stringify(body),
-        })
-        login(access_token)
-        navigate('/dashboard', { replace: true })
-      } catch (err) {
-        if (err instanceof ApiError) {
-          setError(err.detail)
-        } else {
-          setError(t('login.authFailed'))
-        }
+  const handleAuth = async (telegramData: TelegramLoginData) => {
+    setError(null)
+    try {
+      const body = {
+        ...telegramData,
+        ...(code ? { invite_code: code } : {}),
       }
-    },
-    [code, login, navigate, t],
-  )
+      const { access_token } = await api<TokenResponse>('/auth/telegram', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      })
+      login(access_token)
+      navigate('/dashboard', { replace: true })
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.detail)
+      } else {
+        setError(t('login.authFailed'))
+      }
+    }
+  }
 
-  if (token) return <Navigate to="/dashboard" replace />
+  if (token) return <Navigate to="/chat" replace />
 
   return (
-    <div className="min-h-screen bg-background text-foreground flex flex-col items-center justify-center gap-8 p-8">
-      <div className="flex flex-col items-center gap-2">
-        <h1 className="text-5xl font-bold">{t('brand')}</h1>
-        <p className="text-muted-foreground">{t('login.tagline')}</p>
+    <div className="min-h-screen bg-background text-foreground flex flex-col items-center justify-center p-8 relative overflow-hidden">
+      {/* Ambient orbs */}
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-32 -right-32 w-[500px] h-[500px] rounded-full bg-primary/[0.06] blur-[120px]" />
+        <div className="absolute -bottom-32 -left-32 w-[400px] h-[400px] rounded-full bg-primary/[0.03] blur-[100px]" />
       </div>
 
-      {code && (
-        <p className="text-sm text-primary border border-primary px-4 py-2 rounded-lg">
-          {t('login.invited')}
-        </p>
-      )}
+      {/* Lang toggle */}
+      <button
+        type="button"
+        onClick={() => i18n.changeLanguage(i18n.resolvedLanguage === 'fr' ? 'en' : 'fr')}
+        className="absolute top-4 right-6 w-8 text-center text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {i18n.resolvedLanguage === 'fr' ? 'EN' : 'FR'}
+      </button>
 
-      <div className="flex flex-col items-center gap-4">
-        <TelegramLoginButton botUsername={BOT_USERNAME} onAuth={handleAuth} />
+      <div className="relative flex flex-col items-center gap-6 w-full max-w-sm">
+        <div className="flex flex-col items-center gap-3">
+          <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-primary/35 to-primary/15 flex items-center justify-center text-2xl font-semibold text-primary shadow-[0_8px_32px_oklch(0.7_0.13_65_/_10%)]">
+            C
+          </div>
+          <h1 className="text-2xl font-semibold">{t('brand')}</h1>
+        </div>
 
-        {error && <p className="text-destructive text-sm max-w-xs text-center">{error}</p>}
+        {/* Invite badge */}
+        {code && (
+          <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-green-500/8 border border-green-500/15 text-green-500 text-sm">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+            {t('login.invited')}
+          </div>
+        )}
+
+        <div className="flex flex-col items-center gap-3 w-full">
+          <div className="w-[320px] max-w-full flex justify-center overflow-hidden">
+            <TelegramLoginButton
+              botUsername={BOT_USERNAME}
+              onAuth={handleAuth}
+              lang={i18n.resolvedLanguage}
+            />
+          </div>
+          {error && <p className="text-destructive text-sm text-center">{error}</p>}
+        </div>
+
+        <div className="flex flex-col items-center gap-1.5 mt-2">
+          <div className="flex items-center gap-3 text-xs text-muted-foreground">
+            <Link to="/" className="hover:text-foreground transition-colors">
+              {t('login.backToLanding')}
+            </Link>
+            <span className="w-px h-3 bg-border" />
+            <a
+              href="https://www.educalcool.qc.ca/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-foreground transition-colors"
+            >
+              Éduc'alcool
+            </a>
+          </div>
+          <p className="text-xs text-muted-foreground text-center">{t('login.legal')}</p>
+        </div>
       </div>
-
-      <footer className="text-xs text-muted-foreground flex flex-col items-center gap-1 mt-4">
-        <p>{t('login.madeWith')}</p>
-        <a
-          href="https://github.com/vpatrin/coupette"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-primary underline underline-offset-2"
-        >
-          {t('login.sourceOnGithub')}
-        </a>
-      </footer>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Adds a public bilingual landing page and redesigns the login page. The app now has a proper public-facing entry point at `/` before users authenticate.

## Related issue(s)

Closes #536

## Changes

- **New `LandingPage`** — bilingual hero, RAG pipeline walkthrough (animated border cards), changelog timeline, open source section with live GitHub commits, footer with Éduc'alcool link
- **Login page redesign** — ambient orbs, C logo mark, language toggle, fixed-width Telegram button (handles FR text), invite badge, Éduc'alcool + home links in footer
- **Routing** — `/` → LandingPage, `/login` → LoginPage, `/invite/:code` → LoginPage with invite code pre-filled
- **Locales** — idiomatic FR/EN copy throughout; "Watchlist" → "Favoris" in FR UI; `whitespace-pre-line` subtitle with `\n` line break in features section
- **`TelegramLoginButton`** — added `lang` prop to localize the Telegram widget
- **Favicon** — replaced champagne emoji with SVG "C" amber gradient mark
- **`index.css`** — animated conic-gradient border for RAG cards (`@property --border-angle`)