### PR TITLE
feat: Resend approval email + resend action (#582)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,3 +82,10 @@ VITE_TELEGRAM_BOT_USERNAME=
 #! Grab from DevTools → Application → Local Storage → access_token (expires every 7 days)
 K6_JWT=
 K6_BASE_URL=
+
+
+# ============================================================================
+# Email (Resend)
+# ============================================================================
+#! Required in production — get from resend.com/api-keys
+RESEND_API_KEY=

--- a/.env.prod.enc
+++ b/.env.prod.enc
@@ -17,6 +17,7 @@
 	"OPENAI_API_KEY": "ENC[AES256_GCM,data:IcOafg/Ejqzo/fHOS8qd+we57WQhtKYwJgwqZSLn53UWcNTqk/JV+/wUxfFksd8f+zFXtHAdAh3/QKi1LzEs42iHlEu/ZX7r3hw9kKzokw2mDwtcllR/9bUQFcg6GouPutTigVvZyYZ4awlU2pxzWwdcZ8RmCVGaULpUj/HkF6PNCMTJsvbGl4NyjEspN3qEIug/q86JnCl+FxQNyTSPCyI4WvRhQ5o=,iv:FasEMkcyoqFIKbfSXU87E7As4WBJ8iEar8WDfRW3STg=,tag:dgYvU5u6BmbPfWUCGX3VdQ==,type:str]",
 	"ANTHROPIC_API_KEY": "ENC[AES256_GCM,data:EgQMj3ZOy8mJ3baJ+IWgBs5Leu80UxTyk+aMtQX+SjXfQJBhigW+loIxz9wvwjoeojYViHynuaLg136QOk5jP0Gr54GgmBWZD9mxDUDqd+4dJtjS8E+8Ols4kaCVQih1OH0P9JwFPrdpMVgd,iv:zMFJ+6C1jDhIi/nQagNruxtf3lvhSstMQL4HihH4Ogc=,tag:CkA13PIx7E/zm6UBkUo2Qg==,type:str]",
 	"ADMIN_TELEGRAM_ID": "ENC[AES256_GCM,data:AKJ2ocMDS4XC,iv:sJcWDlPQvTNdU7YONh6++KNsVHgpxO8txjq5+pYnOeA=,tag:eqkUFDdodCmKalMuT1AIlw==,type:str]",
+	"RESEND_API_KEY": "ENC[AES256_GCM,data:zjMH13vXoC4x+7y12FoTkT0cDiUO4/T1U649ykVC/KPvcveW,iv:SP1kwe+r3bBNmEp4orGO3ZnL9YKd0O00X2mKGPP0TOk=,tag:hGfld0mjtjnLI2N3owifPg==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -28,8 +29,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6M2pjQnBaNEU5UUFBb3JW\nalg3U1VtY0F1VE53dkdiaXl6OWRJRjlpbFY4Cm50OWozdTU2RFp2U045SW0rVGV5\nMHd3OThxTnN2NGNNczlLR1ZCODhQVzQKLS0tIHdoWHlCcHUvUkxhWEt6dkJGR2Fq\nbEJWblAwbTdCeW9KczQvY2g1OHpPZ2cKWyh8GrtwRjwxobZyB8YXjhBhgFCk3h0z\npqufLcQMfMmGbsfYsOC+pJhUqninvlO7RsKEMn/Q793/32EgnmnGKA==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-03-20T16:58:37Z",
-		"mac": "ENC[AES256_GCM,data:U3pU4AkEfh6VeDAxy1qk1OPHjqd4YTmTwain8GD6zbCDSEmvDUwjsVO8/ihhfs5UYRTrobIrypBZR2p2X/N+3qOugud7Q5SAP0CCMdOHzXeoN8+CmQtvD/xv6laj4U5iJQtcQlDThEgbwl4tPWGrKXdFfxMJe/s6lkxCFzXf2iw=,iv:xlu1Fb6cMP48/58vtq3ZN519a4uLmz00bjhZy3B/qT4=,tag:tUcpPg8X+jaqkprJWh/dbQ==,type:str]",
+		"lastmodified": "2026-04-03T20:00:44Z",
+		"mac": "ENC[AES256_GCM,data:VWjT7TJKjhkifYJCG5PJ/W8RuzCYeI5u5ZtOAyc9m9Cuvzq6VFaubUDl456a4tA0VcV1pkPJHvF0lQLh4O38GcBOOKPoYKfM5IOd8jQlEa0eAtVpzxefPOgAK+kCZdXw30cpavVxFnXAMHqAILhHZvsKE2LhuAFNRPXX+tNa380=,iv:p8ARP3NZV3iIF4Uj1n+slPXUShQ3fgNO0h07N2UacIA=,tag:1/7KAjrrHwKrPHjRKcVQPw==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.12.2"
 	}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Approval email via Resend — admin approval sends a confirmation email with a login link; admin can resend if delivery failed
 - Waitlist form on landing page — visitors enter their email to request early access; replaces the mailto CTA
 - Waitlist submission — visitors can request early access by email; admins can approve or reject requests via the API
 - Search results show your rating ("You: 92") on wines you've previously tasted

--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, Depends, status
+from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.auth import verify_admin
-from backend.config import ROLE_ADMIN
+from backend.config import ROLE_ADMIN, WAITLIST_APPROVED
 from backend.db import get_db
 from backend.exceptions import ConflictError, NotFoundError
 from backend.repositories import invites as invites_repo
@@ -11,6 +12,7 @@ from backend.repositories import waitlist as waitlist_repo
 from backend.schemas.invite import InviteCodeOut
 from backend.schemas.user import UserOut, UserUpdateIn
 from backend.schemas.waitlist import WaitlistRequestOut
+from backend.services.email import send_approval_email
 from core.db.models import User
 
 router = APIRouter(prefix="/admin", tags=["admin"])
@@ -52,11 +54,28 @@ async def list_waitlist(db: AsyncSession = Depends(get_db)) -> list[WaitlistRequ
 
 @router.post("/waitlist/{request_id}/approve", status_code=status.HTTP_204_NO_CONTENT)
 async def approve_waitlist(request_id: int, db: AsyncSession = Depends(get_db)) -> None:
-    """Approve a waitlist request — sets status=approved, triggers email (W-PR2)."""
+    """Approve a waitlist request — sets status=approved and sends confirmation email."""
     request = await waitlist_repo.find_by_id(db, request_id)
     if request is None:
         raise NotFoundError("WaitlistRequest", str(request_id))
     await waitlist_repo.approve(db, request)
+    try:
+        await send_approval_email(request.email)
+        await waitlist_repo.mark_email_sent(db, request)
+    except Exception:
+        logger.warning("Failed to send approval email to {}", request.email, exc_info=True)
+
+
+@router.post("/waitlist/{request_id}/resend", status_code=status.HTTP_204_NO_CONTENT)
+async def resend_waitlist(request_id: int, db: AsyncSession = Depends(get_db)) -> None:
+    """Re-send the approval email for an already-approved request."""
+    request = await waitlist_repo.find_by_id(db, request_id)
+    if request is None:
+        raise NotFoundError("WaitlistRequest", str(request_id))
+    if request.status != WAITLIST_APPROVED:
+        raise ConflictError("WaitlistRequest", "can only resend email for approved requests")
+    await send_approval_email(request.email)
+    await waitlist_repo.mark_email_sent(db, request)
 
 
 @router.post("/waitlist/{request_id}/reject", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/config.py
+++ b/backend/config.py
@@ -70,5 +70,11 @@ class BackendSettings(BaseSettings):
     # Telegram ID of the admin user — verified at startup.
     ADMIN_TELEGRAM_ID: int = 0
 
+    # Resend API key — required in production. Leave empty to skip email (dev mode).
+    RESEND_API_KEY: str = ""
+
+    # From address for transactional emails — must match a verified Resend domain.
+    RESEND_FROM_EMAIL: str = "Coupette <noreply@coupette.club>"
+
 
 backend_settings = BackendSettings()

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -219,7 +219,7 @@ version = "3.4.4"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "charset_normalizer-3.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d"},
     {file = "charset_normalizer-3.4.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8"},
@@ -2009,7 +2009,7 @@ version = "2.33.0"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b"},
     {file = "requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652"},
@@ -2025,6 +2025,25 @@ urllib3 = ">=1.26,<3"
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 test = ["PySocks (>=1.5.6,!=1.5.7)", "pytest (>=3)", "pytest-cov", "pytest-httpbin (==2.1.0)", "pytest-mock", "pytest-xdist"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
+
+[[package]]
+name = "resend"
+version = "2.27.0"
+description = "Resend Python SDK"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "resend-2.27.0-py2.py3-none-any.whl", hash = "sha256:5bc8ddebb0418127fc3e47eb29ab72af727861481c4b051b96cb693df8f8dc40"},
+    {file = "resend-2.27.0.tar.gz", hash = "sha256:abc183da7566c1fdba8221ec5acd9f954c2ff516a0c2615bee2a41bc9db3e277"},
+]
+
+[package.dependencies]
+requests = ">=2.31.0"
+typing-extensions = ">=4.4.0"
+
+[package.extras]
+async = ["httpx (>=0.24.0)"]
 
 [[package]]
 name = "rich"
@@ -2343,7 +2362,7 @@ version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
     {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
@@ -2658,4 +2677,4 @@ dev = ["black (>=19.3b0) ; python_version >= \"3.6\"", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "e955587d0787a2844b2c9606c81c1748a4c3835b1a41a609cb19dc89e6630176"
+content-hash = "2875955830fd8a463d1135369569035acf4a418a04ba518c406c7f7a1dd368ea"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,6 +22,7 @@ pyjwt = "^2.12.0"
 prometheus-client = "^0.24.1"
 prometheus-fastapi-instrumentator = "^7.1.0"
 email-validator = "^2.3.0"
+resend = "^2.27.0"
 
 [tool.poetry.group.dev.dependencies]
 httpx = ">=0.28"

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -1,0 +1,55 @@
+import asyncio
+
+import resend
+from loguru import logger
+
+from backend.config import backend_settings
+
+resend.api_key = backend_settings.RESEND_API_KEY
+
+_APPROVAL_SUBJECT = "Ta demande d'accès à Coupette a été approuvée"
+
+_APPROVAL_HTML = """\
+<p>Allo !</p>
+<p>Ta demande d'accès à Coupette a été approuvée.</p>
+<p>
+  <a href="https://coupette.club/login"
+     style="display:inline-block;padding:10px 20px;background:#c89248;color:#fff;
+            text-decoration:none;border-radius:8px;font-weight:500;">
+    Accéder à Coupette →
+  </a>
+</p>
+<p>Santé !<br>Victor</p>
+"""
+
+_APPROVAL_TEXT = """\
+Allo !
+
+Ta demande d'accès à Coupette a été approuvée.
+
+Accéder à Coupette : https://coupette.club/login
+
+Santé !
+Victor
+"""
+
+
+async def send_approval_email(email: str) -> None:
+    """Send the waitlist approval email via Resend.
+
+    No-ops if RESEND_API_KEY is not configured (dev / CI).
+    Raises on Resend errors — caller decides whether to swallow or propagate.
+    """
+    if not backend_settings.RESEND_API_KEY:
+        logger.warning("RESEND_API_KEY not set — skipping approval email to {}", email)
+        return
+
+    params: resend.Emails.SendParams = {
+        "from": backend_settings.RESEND_FROM_EMAIL,
+        "to": [email],
+        "subject": _APPROVAL_SUBJECT,
+        "html": _APPROVAL_HTML,
+        "text": _APPROVAL_TEXT,
+    }
+
+    await asyncio.get_running_loop().run_in_executor(None, resend.Emails.send, params)

--- a/backend/tests/test_waitlist.py
+++ b/backend/tests/test_waitlist.py
@@ -157,3 +157,84 @@ def test_reject_waitlist_non_admin_rejected(user_client):
     """403 — regular user cannot reject."""
     resp = user_client.post("/api/admin/waitlist/1/reject")
     assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+# ── POST /api/admin/waitlist/{id}/approve — email behaviour ─────────────────
+
+
+def test_approve_sends_email(admin_client):
+    """204 — approval triggers send_approval_email and marks email_sent_at."""
+    entry = _fake_request()
+    with (
+        patch("backend.repositories.waitlist.find_by_id", new_callable=AsyncMock) as mock_find,
+        patch("backend.repositories.waitlist.approve", new_callable=AsyncMock),
+        patch("backend.api.admin.send_approval_email", new_callable=AsyncMock) as mock_email,
+        patch("backend.repositories.waitlist.mark_email_sent", new_callable=AsyncMock) as mock_mark,
+    ):
+        mock_find.return_value = entry
+        resp = admin_client.post("/api/admin/waitlist/1/approve")
+
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
+    mock_email.assert_called_once_with("alice@example.com")
+    mock_mark.assert_called_once()
+
+
+def test_approve_email_failure_does_not_block(admin_client):
+    """204 — email failure is swallowed; approval still succeeds, email_sent_at not recorded."""
+    entry = _fake_request()
+    with (
+        patch("backend.repositories.waitlist.find_by_id", new_callable=AsyncMock) as mock_find,
+        patch("backend.repositories.waitlist.approve", new_callable=AsyncMock),
+        patch("backend.api.admin.send_approval_email", new_callable=AsyncMock) as mock_email,
+        patch("backend.repositories.waitlist.mark_email_sent", new_callable=AsyncMock) as mock_mark,
+    ):
+        mock_find.return_value = entry
+        mock_email.side_effect = Exception("Resend down")
+        resp = admin_client.post("/api/admin/waitlist/1/approve")
+
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
+    mock_mark.assert_not_called()
+
+
+# ── POST /api/admin/waitlist/{id}/resend ────────────────────────────────────
+
+
+def test_resend_email_success(admin_client):
+    """204 — admin can resend approval email for an approved request."""
+    entry = _fake_request(status=WAITLIST_APPROVED)
+    with (
+        patch("backend.repositories.waitlist.find_by_id", new_callable=AsyncMock) as mock_find,
+        patch("backend.api.admin.send_approval_email", new_callable=AsyncMock) as mock_email,
+        patch("backend.repositories.waitlist.mark_email_sent", new_callable=AsyncMock) as mock_mark,
+    ):
+        mock_find.return_value = entry
+        resp = admin_client.post("/api/admin/waitlist/1/resend")
+
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
+    mock_email.assert_called_once_with("alice@example.com")
+    mock_mark.assert_called_once()
+
+
+def test_resend_email_not_found(admin_client):
+    """404 — request does not exist."""
+    with patch("backend.repositories.waitlist.find_by_id", new_callable=AsyncMock) as mock_find:
+        mock_find.return_value = None
+        resp = admin_client.post("/api/admin/waitlist/999/resend")
+
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_resend_email_not_approved(admin_client):
+    """409 — cannot resend for a non-approved (pending) request."""
+    entry = _fake_request(status="pending")
+    with patch("backend.repositories.waitlist.find_by_id", new_callable=AsyncMock) as mock_find:
+        mock_find.return_value = entry
+        resp = admin_client.post("/api/admin/waitlist/1/resend")
+
+    assert resp.status_code == status.HTTP_409_CONFLICT
+
+
+def test_resend_email_non_admin_rejected(user_client):
+    """403 — regular user cannot resend."""
+    resp = user_client.post("/api/admin/waitlist/1/resend")
+    assert resp.status_code == status.HTTP_403_FORBIDDEN

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -81,10 +81,18 @@ Replace invite codes with a waitlist + admin approval flow. Landing page collect
 
 - [x] `POST /api/waitlist` — public endpoint, email only, silent 201 on duplicate, IP rate limited (#580)
 - [x] Admin waitlist endpoints — list pending, approve, reject (#581)
-- [ ] Resend integration — approval email on approve, `email_sent_at` tracking, resend action (#582)
+- [x] Resend integration — approval email on approve, `email_sent_at` tracking, resend action (#582)
 - [x] Frontend — landing page waitlist form, replace invite code input (#583)
 - [ ] Frontend — admin panel: pending queue, approve/reject, active users (#584)
 - [ ] Remove invite codes — model, migration, repo, endpoints, frontend (#585)
+
+#### Custom Email Domain
+
+Add `contact@coupette.club` via Proton Mail custom domain (requires Proton Unlimited). After Waitlist & Admin Panel milestone.
+
+- [ ] Add `coupette.club` as custom domain in Proton Mail dashboard
+- [ ] Update MX records on Hetzner DNS
+- [ ] Update `noreply@coupette.club` → `contact@coupette.club` as reply-to (optional)
 
 #### Extended Auth — GitHub + Google OAuth
 


### PR DESCRIPTION
## Summary

When an admin approves a waitlist request, a confirmation email is sent via Resend with a login link. If delivery fails, the approval still goes through and the admin can retry via a new \`/resend\` endpoint. Domain \`coupette.club\` is verified on Resend.

## Related issue(s)

Closes #582

## Changes

- \`backend/services/email.py\` — \`send_approval_email()\` via Resend SDK, runs in thread executor (sync SDK), no-ops if \`RESEND_API_KEY\` is empty
- \`backend/api/admin.py\` — \`approve_waitlist\` now sends email + records \`email_sent_at\`; email failure is swallowed (approve-first design); new \`POST /api/admin/waitlist/{id}/resend\` endpoint
- \`backend/config.py\` — \`RESEND_API_KEY\` and \`RESEND_FROM_EMAIL\` settings
- \`.env.example\` — \`RESEND_API_KEY\` documented
- \`.env.prod.enc\` — \`RESEND_API_KEY\` added to SOPS-encrypted prod secrets
- 6 new tests covering email send, failure swallowing, resend success/404/409/403

## How to test

```bash
# Approve a pending request (triggers email if RESEND_API_KEY is set)
curl -X POST http://localhost:8001/api/admin/waitlist/1/approve \
  -H "Authorization: Bearer <admin_jwt>"
# → 204, email sent to applicant

# Resend if delivery failed
curl -X POST http://localhost:8001/api/admin/waitlist/1/resend \
  -H "Authorization: Bearer <admin_jwt>"
# → 204, email resent

# Without RESEND_API_KEY set — approve still returns 204, warning logged
```