### PR TITLE
feat: Redis setup — OAuth exchange code storage (#589)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -76,5 +76,8 @@ class BackendSettings(BaseSettings):
     # From address for transactional emails — must match a verified Resend domain.
     RESEND_FROM_EMAIL: str = "Coupette <noreply@coupette.club>"
 
+    # Redis URL — used for OAuth exchange code storage.
+    REDIS_URL: str = "redis://coupette-redis:6379/0"
+
 
 backend_settings = BackendSettings()

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -2004,6 +2004,26 @@ files = [
 ]
 
 [[package]]
+name = "redis"
+version = "7.4.0"
+description = "Python client for Redis database and key-value store"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec"},
+    {file = "redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad"},
+]
+
+[package.extras]
+circuit-breaker = ["pybreaker (>=1.4.0)"]
+hiredis = ["hiredis (>=3.2.0)"]
+jwt = ["pyjwt (>=2.9.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (>=20.0.1)", "requests (>=2.31.0)"]
+otel = ["opentelemetry-api (>=1.39.1)", "opentelemetry-exporter-otlp-proto-http (>=1.39.1)", "opentelemetry-sdk (>=1.39.1)"]
+xxhash = ["xxhash (>=3.6.0,<3.7.0)"]
+
+[[package]]
 name = "requests"
 version = "2.33.0"
 description = "Python HTTP for Humans."
@@ -2677,4 +2697,4 @@ dev = ["black (>=19.3b0) ; python_version >= \"3.6\"", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "2875955830fd8a463d1135369569035acf4a418a04ba518c406c7f7a1dd368ea"
+content-hash = "b4794b5b0e56ba2245d50a20a58d436a484202e3e74860bdb868357d9fa08fa8"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,6 +23,7 @@ prometheus-client = "^0.24.1"
 prometheus-fastapi-instrumentator = "^7.1.0"
 email-validator = "^2.3.0"
 resend = "^2.27.0"
+redis = {version = ">=5.0", extras = ["asyncio"]}
 
 [tool.poetry.group.dev.dependencies]
 httpx = ">=0.28"

--- a/backend/redis_client.py
+++ b/backend/redis_client.py
@@ -1,0 +1,28 @@
+import secrets
+
+from redis.asyncio import Redis
+
+from backend.config import backend_settings
+
+#! Exchange codes are single-use JWTs stored in Redis — TTL is intentionally short.
+_EXCHANGE_CODE_TTL = 60  # seconds
+
+
+async def get_redis():
+    client: Redis = Redis.from_url(backend_settings.REDIS_URL, decode_responses=True)
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+async def store_exchange_code(redis: Redis, jwt: str) -> str:
+    """Store a JWT under a random code. Returns the code."""
+    code = secrets.token_urlsafe(32)
+    await redis.set(code, jwt, ex=_EXCHANGE_CODE_TTL)
+    return code
+
+
+async def consume_exchange_code(redis: Redis, code: str) -> str | None:
+    """Atomically read and delete an exchange code. Returns the JWT or None if expired/invalid."""
+    return await redis.getdel(code)

--- a/backend/tests/test_redis.py
+++ b/backend/tests/test_redis.py
@@ -1,0 +1,42 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.redis_client import consume_exchange_code, store_exchange_code
+
+
+@pytest.fixture
+def mock_redis():
+    return AsyncMock()
+
+
+async def test_store_exchange_code_sets_key_with_ttl(mock_redis):
+    mock_redis.getdel.return_value = None
+    jwt = "header.payload.sig"
+
+    code = await store_exchange_code(mock_redis, jwt)
+
+    assert len(code) > 20
+    mock_redis.set.assert_called_once_with(code, jwt, ex=60)
+
+
+async def test_consume_exchange_code_returns_jwt(mock_redis):
+    mock_redis.getdel.return_value = "header.payload.sig"
+
+    result = await consume_exchange_code(mock_redis, "somecode")
+
+    assert result == "header.payload.sig"
+    mock_redis.getdel.assert_called_once_with("somecode")
+
+
+async def test_consume_exchange_code_returns_none_when_expired(mock_redis):
+    mock_redis.getdel.return_value = None
+
+    result = await consume_exchange_code(mock_redis, "expiredcode")
+
+    assert result is None
+
+
+async def test_store_exchange_code_generates_unique_codes(mock_redis):
+    codes = {await store_exchange_code(mock_redis, "jwt") for _ in range(10)}
+    assert len(codes) == 10

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,6 +12,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_healthy
 
   bot:
     volumes:
@@ -57,6 +59,18 @@ services:
     # DAC_READ_SEARCH: reads data dir before ownership is transferred.
     cap_drop: [ALL]
     cap_add: [SETUID, SETGID, DAC_READ_SEARCH, CHOWN, FOWNER]
+
+  redis:
+    image: redis:7-bookworm
+    container_name: coupette-redis
+    command: redis-server --save "" --appendonly no --bind 0.0.0.0
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
 
 volumes:
   pgdata:

--- a/docs/ENGINEERING.md
+++ b/docs/ENGINEERING.md
@@ -256,6 +256,10 @@ Five actionables identified from a full frontend audit (2026-04-02). In priority
 - Contract tests — snapshot API response shapes so bot's assumptions are validated on every PR
 - Frontend coverage threshold — add once test coverage is meaningful
 
+**Auth:**
+
+- Migrate JWT storage from `localStorage` to `HttpOnly` cookies — eliminates XSS token theft risk. Backend sets/clears cookie on login/logout, frontend drops manual `Authorization` header, CORS needs `credentials: 'include'`. Do after OAuth is fully shipped and stable.
+
 **Observability:**
 
 - [ ] Request correlation — X-Request-ID middleware across bot → backend → DB (#315)


### PR DESCRIPTION
## Summary

Add Redis client to the backend for short-lived OAuth exchange code storage. Exchange codes are single-use JWTs stored with a 60-second TTL — the browser sends the code back to the frontend SPA after OAuth redirect, and the backend atomically reads and deletes it.

## Related issue(s)

Closes #589

## Changes

- Add \`redis[asyncio]>=5.0\` dependency
- \`REDIS_URL\` config var (default: \`redis://coupette-redis:6379/0\`)
- \`backend/redis_client.py\` — \`get_redis()\` FastAPI dependency, \`store_exchange_code()\`, \`consume_exchange_code()\`
- \`docker-compose.dev.yml\` — add \`coupette-redis\` service matching infra config, backend \`depends_on\` redis healthcheck
- 4 unit tests (mocked redis client)