### PR TITLE
chore: migrate backend tests from TestClient to httpx.AsyncClient (#430)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
-from fastapi.testclient import TestClient
 
 from core.config.test_utils import configure_test_db_env
 from core.db.models import User
@@ -45,27 +45,37 @@ def _mock_regular_user() -> MagicMock:
     return user
 
 
+BASE_URL = "http://test"
+
+
+def make_test_client() -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url=BASE_URL)
+
+
 @pytest.fixture()
-def admin_client():
+async def admin_client():
     """Client authenticated as admin."""
     admin = _mock_admin()
     app.dependency_overrides[verify_auth] = lambda: admin
     app.dependency_overrides[verify_admin] = lambda: admin
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
-    yield TestClient(app)
+    async with make_test_client() as client:
+        yield client
     app.dependency_overrides.clear()
 
 
 @pytest.fixture()
-def user_client():
+async def user_client():
     """Client authenticated as regular user (non-admin)."""
     user = _mock_regular_user()
     app.dependency_overrides[verify_auth] = lambda: user
     # Don't override verify_admin — let it run and reject
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
-    yield TestClient(app)
+    async with make_test_client() as client:
+        yield client
     app.dependency_overrides.clear()
 
 

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -11,7 +11,7 @@ NOW = datetime(2025, 1, 1, tzinfo=UTC)
 # ── GET /api/admin/users ────────────────────────────────────
 
 
-def test_list_users_success(admin_client):
+async def test_list_users_success(admin_client):
     """200 — admin can list all users."""
     users = [_mock_admin(), _mock_regular_user()]
     for i, u in enumerate(users):
@@ -21,22 +21,22 @@ def test_list_users_success(admin_client):
         u.last_login_at = NOW
     with patch("backend.repositories.users.list_all", new_callable=AsyncMock) as mock:
         mock.return_value = users
-        resp = admin_client.get("/api/admin/users")
+        resp = await admin_client.get("/api/admin/users")
 
     assert resp.status_code == status.HTTP_200_OK
     assert len(resp.json()) == 2
 
 
-def test_list_users_non_admin_rejected(user_client):
+async def test_list_users_non_admin_rejected(user_client):
     """403 — regular user cannot list users."""
-    resp = user_client.get("/api/admin/users")
+    resp = await user_client.get("/api/admin/users")
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
 # ── PATCH /api/admin/users/{id} ──────────────────
 
 
-def test_deactivate_user_success(admin_client):
+async def test_deactivate_user_success(admin_client):
     """204 — admin can deactivate a regular user."""
     target = _mock_regular_user()
     with (
@@ -44,12 +44,12 @@ def test_deactivate_user_success(admin_client):
         patch("backend.repositories.users.set_active", new_callable=AsyncMock),
     ):
         mock_find.return_value = target
-        resp = admin_client.patch("/api/admin/users/2", json={"is_active": False})
+        resp = await admin_client.patch("/api/admin/users/2", json={"is_active": False})
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_reactivate_user_success(admin_client):
+async def test_reactivate_user_success(admin_client):
     """204 — admin can reactivate a deactivated user."""
     target = _mock_regular_user()
     target.is_active = False
@@ -58,42 +58,42 @@ def test_reactivate_user_success(admin_client):
         patch("backend.repositories.users.set_active", new_callable=AsyncMock) as mock_set,
     ):
         mock_find.return_value = target
-        resp = admin_client.patch("/api/admin/users/2", json={"is_active": True})
+        resp = await admin_client.patch("/api/admin/users/2", json={"is_active": True})
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     mock_set.assert_called_once()
     assert mock_set.call_args.kwargs["active"] is True
 
 
-def test_deactivate_user_not_found(admin_client):
+async def test_deactivate_user_not_found(admin_client):
     """404 — user does not exist."""
     with patch("backend.repositories.users.find_by_id", new_callable=AsyncMock) as mock_find:
         mock_find.return_value = None
-        resp = admin_client.patch("/api/admin/users/999", json={"is_active": False})
+        resp = await admin_client.patch("/api/admin/users/999", json={"is_active": False})
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_deactivate_admin_rejected(admin_client):
+async def test_deactivate_admin_rejected(admin_client):
     """409 — cannot deactivate an admin user."""
     target = _mock_admin()
     with patch("backend.repositories.users.find_by_id", new_callable=AsyncMock) as mock_find:
         mock_find.return_value = target
-        resp = admin_client.patch("/api/admin/users/1", json={"is_active": False})
+        resp = await admin_client.patch("/api/admin/users/1", json={"is_active": False})
 
     assert resp.status_code == status.HTTP_409_CONFLICT
 
 
-def test_deactivate_user_non_admin_rejected(user_client):
+async def test_deactivate_user_non_admin_rejected(user_client):
     """403 — regular user cannot deactivate users."""
-    resp = user_client.patch("/api/admin/users/2", json={"is_active": False})
+    resp = await user_client.patch("/api/admin/users/2", json={"is_active": False})
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
 # ── DELETE /api/admin/users/{id} ──────────────────
 
 
-def test_delete_user_success(admin_client):
+async def test_delete_user_success(admin_client):
     """204 — admin can permanently delete a regular user."""
     target = _mock_regular_user()
     with (
@@ -101,39 +101,39 @@ def test_delete_user_success(admin_client):
         patch("backend.repositories.users.hard_delete", new_callable=AsyncMock) as mock_delete,
     ):
         mock_find.return_value = target
-        resp = admin_client.delete("/api/admin/users/2")
+        resp = await admin_client.delete("/api/admin/users/2")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     mock_delete.assert_called_once()
 
 
-def test_delete_user_self_rejected(admin_client):
+async def test_delete_user_self_rejected(admin_client):
     """409 — admin cannot delete themselves."""
-    resp = admin_client.delete("/api/admin/users/1")
+    resp = await admin_client.delete("/api/admin/users/1")
     assert resp.status_code == status.HTTP_409_CONFLICT
 
 
-def test_delete_user_not_found(admin_client):
+async def test_delete_user_not_found(admin_client):
     """404 — user does not exist."""
     with patch("backend.repositories.users.find_by_id", new_callable=AsyncMock) as mock_find:
         mock_find.return_value = None
-        resp = admin_client.delete("/api/admin/users/999")
+        resp = await admin_client.delete("/api/admin/users/999")
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_delete_admin_rejected(admin_client):
+async def test_delete_admin_rejected(admin_client):
     """409 — cannot delete an admin user."""
     target = _mock_admin()
     target.id = 99
     with patch("backend.repositories.users.find_by_id", new_callable=AsyncMock) as mock_find:
         mock_find.return_value = target
-        resp = admin_client.delete("/api/admin/users/99")
+        resp = await admin_client.delete("/api/admin/users/99")
 
     assert resp.status_code == status.HTTP_409_CONFLICT
 
 
-def test_delete_user_non_admin_rejected(user_client):
+async def test_delete_user_non_admin_rejected(user_client):
     """403 — regular user cannot delete users."""
-    resp = user_client.delete("/api/admin/users/2")
+    resp = await user_client.delete("/api/admin/users/2")
     assert resp.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import jwt as pyjwt
 import pytest
 from fastapi import status
-from fastapi.testclient import TestClient
 
 from backend.app import app
 from backend.auth import verify_auth
@@ -12,44 +11,46 @@ from backend.config import ROLE_USER
 from backend.db import get_db
 from core.db.models import User
 
-from .conftest import BOT_SECRET, JWT_SECRET
+from .conftest import BOT_SECRET, JWT_SECRET, make_test_client
 
 
 @pytest.fixture()
-def unauthenticated_client():
+async def unauthenticated_client():
     """Client with JWT bypass removed — requests have no auth."""
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
     app.dependency_overrides.pop(verify_auth, None)
-    yield TestClient(app)
+    async with make_test_client() as client:
+        yield client
     app.dependency_overrides.clear()
 
 
 @pytest.fixture()
-def _real_auth_client():
+async def _real_auth_client():
     """Client with auth bypass removed — real verify_auth runs."""
     app.dependency_overrides.pop(verify_auth, None)
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
-    yield TestClient(app)
+    async with make_test_client() as client:
+        yield client
     app.dependency_overrides.clear()
 
 
-def test_missing_secret_returns_401(_real_auth_client):
+async def test_missing_secret_returns_401(_real_auth_client):
     """401 — no auth header and no bot secret when BOT_SECRET is configured."""
     with patch("backend.auth.backend_settings") as mock_settings:
         mock_settings.BOT_SECRET = BOT_SECRET
         mock_settings.JWT_SECRET_KEY = "unused"
-        resp = _real_auth_client.get("/api/watches/notifications")
+        resp = await _real_auth_client.get("/api/watches/notifications")
 
     assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-def test_wrong_secret_returns_403(_real_auth_client):
+async def test_wrong_secret_returns_403(_real_auth_client):
     """403 — X-Bot-Secret header present but incorrect."""
     with patch("backend.auth.backend_settings") as mock_settings:
         mock_settings.BOT_SECRET = BOT_SECRET
-        resp = _real_auth_client.get(
+        resp = await _real_auth_client.get(
             "/api/watches/notifications",
             headers={"X-Bot-Secret": "wrong-value"},
         )
@@ -57,7 +58,7 @@ def test_wrong_secret_returns_403(_real_auth_client):
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_correct_secret_passes(_real_auth_client):
+async def test_correct_secret_passes(_real_auth_client):
     """200 — correct X-Bot-Secret header is accepted."""
     with (
         patch("backend.auth.backend_settings") as mock_settings,
@@ -65,7 +66,7 @@ def test_correct_secret_passes(_real_auth_client):
     ):
         mock_settings.BOT_SECRET = BOT_SECRET
         mock_repo.find_pending_notifications = AsyncMock(return_value=[])
-        resp = _real_auth_client.get(
+        resp = await _real_auth_client.get(
             "/api/watches/notifications",
             headers={"X-Bot-Secret": BOT_SECRET},
         )
@@ -73,18 +74,18 @@ def test_correct_secret_passes(_real_auth_client):
     assert resp.status_code == status.HTTP_200_OK
 
 
-def test_unconfigured_secret_falls_through_to_jwt(_real_auth_client):
+async def test_unconfigured_secret_falls_through_to_jwt(_real_auth_client):
     """401 — no bot secret configured and no JWT → rejected."""
     with patch("backend.auth.backend_settings") as mock_settings:
         mock_settings.BOT_SECRET = ""
         mock_settings.JWT_SECRET_KEY = "unused"
-        resp = _real_auth_client.get("/api/watches/notifications")
+        resp = await _real_auth_client.get("/api/watches/notifications")
 
     # No bot secret configured AND no JWT → 401
     assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-def test_inactive_user_jwt_returns_403(_real_auth_client):
+async def test_inactive_user_jwt_returns_403(_real_auth_client):
     """403 — valid JWT but user.is_active is False."""
     now = datetime.now(UTC)
     payload = {
@@ -106,7 +107,7 @@ def test_inactive_user_jwt_returns_403(_real_auth_client):
         mock_settings.BOT_SECRET = ""
         mock_settings.JWT_SECRET_KEY = JWT_SECRET
         mock_repo.find_by_id = AsyncMock(return_value=inactive_user)
-        resp = _real_auth_client.get(
+        resp = await _real_auth_client.get(
             "/api/watches/notifications",
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -125,12 +126,12 @@ def test_inactive_user_jwt_returns_403(_real_auth_client):
     ],
     ids=["garbage_token", "invalid_signature"],
 )
-def test_malformed_jwt_returns_401(_real_auth_client, auth_header):
+async def test_malformed_jwt_returns_401(_real_auth_client, auth_header):
     """401 — malformed or badly-signed JWT."""
     with patch("backend.auth.backend_settings") as mock_settings:
         mock_settings.BOT_SECRET = ""
         mock_settings.JWT_SECRET_KEY = JWT_SECRET
-        resp = _real_auth_client.get(
+        resp = await _real_auth_client.get(
             "/api/watches/notifications",
             headers={"Authorization": auth_header},
         )
@@ -138,7 +139,7 @@ def test_malformed_jwt_returns_401(_real_auth_client, auth_header):
     assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-def test_expired_jwt_returns_401(_real_auth_client):
+async def test_expired_jwt_returns_401(_real_auth_client):
     """401 — expired JWT is rejected."""
     expired = datetime.now(UTC) - timedelta(hours=1)
     payload = {
@@ -153,7 +154,7 @@ def test_expired_jwt_returns_401(_real_auth_client):
     with patch("backend.auth.backend_settings") as mock_settings:
         mock_settings.BOT_SECRET = ""
         mock_settings.JWT_SECRET_KEY = JWT_SECRET
-        resp = _real_auth_client.get(
+        resp = await _real_auth_client.get(
             "/api/watches/notifications",
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -161,7 +162,7 @@ def test_expired_jwt_returns_401(_real_auth_client):
     assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-def test_jwt_missing_sub_returns_401(_real_auth_client):
+async def test_jwt_missing_sub_returns_401(_real_auth_client):
     """401 — JWT without sub claim is rejected."""
     now = datetime.now(UTC)
     payload = {
@@ -175,7 +176,7 @@ def test_jwt_missing_sub_returns_401(_real_auth_client):
     with patch("backend.auth.backend_settings") as mock_settings:
         mock_settings.BOT_SECRET = ""
         mock_settings.JWT_SECRET_KEY = JWT_SECRET
-        resp = _real_auth_client.get(
+        resp = await _real_auth_client.get(
             "/api/watches/notifications",
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -183,7 +184,7 @@ def test_jwt_missing_sub_returns_401(_real_auth_client):
     assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-def test_jwt_unknown_user_returns_401(_real_auth_client):
+async def test_jwt_unknown_user_returns_401(_real_auth_client):
     """401 — valid JWT but user doesn't exist in DB."""
     now = datetime.now(UTC)
     payload = {
@@ -202,7 +203,7 @@ def test_jwt_unknown_user_returns_401(_real_auth_client):
         mock_settings.BOT_SECRET = ""
         mock_settings.JWT_SECRET_KEY = JWT_SECRET
         mock_repo.find_by_id = AsyncMock(return_value=None)
-        resp = _real_auth_client.get(
+        resp = await _real_auth_client.get(
             "/api/watches/notifications",
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -222,22 +223,22 @@ def test_jwt_unknown_user_returns_401(_real_auth_client):
         ("POST", "/api/recommendations"),
     ],
 )
-def test_protected_routes_reject_unauthenticated(unauthenticated_client, method, path):
+async def test_protected_routes_reject_unauthenticated(unauthenticated_client, method, path):
     """401 — protected routes require a valid JWT."""
-    resp = unauthenticated_client.request(method, path)
+    resp = await unauthenticated_client.request(method, path)
     assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-def test_health_is_public(unauthenticated_client):
+async def test_health_is_public(unauthenticated_client):
     """200 — /health does not require JWT."""
-    resp = unauthenticated_client.get("/health")
+    resp = await unauthenticated_client.get("/health")
     # May fail DB check, but should not be 401
     assert resp.status_code != status.HTTP_401_UNAUTHORIZED
 
 
-def test_auth_endpoint_is_public(unauthenticated_client):
+async def test_auth_endpoint_is_public(unauthenticated_client):
     """422 — /api/auth/telegram is public (422 from missing body, not 401)."""
-    resp = unauthenticated_client.post("/api/auth/telegram", json={})
+    resp = await unauthenticated_client.post("/api/auth/telegram", json={})
     assert resp.status_code != status.HTTP_401_UNAUTHORIZED
 
 
@@ -245,38 +246,39 @@ def test_auth_endpoint_is_public(unauthenticated_client):
 
 
 @pytest.fixture()
-def _check_client():
+async def _check_client():
     """Client with global auth bypassed but bot_secret real."""
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
-    yield TestClient(app), session
+    async with make_test_client() as client:
+        yield client, session
     app.dependency_overrides.clear()
 
 
-def test_check_active_user_returns_204(_check_client):
+async def test_check_active_user_returns_204(_check_client):
     client, _ = _check_client
     with patch("backend.api.auth.users_repo") as mock_repo:
         user = AsyncMock(is_active=True)
         mock_repo.find_by_telegram_id = AsyncMock(return_value=user)
-        resp = client.get("/api/auth/telegram/check?telegram_id=12345")
+        resp = await client.get("/api/auth/telegram/check?telegram_id=12345")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_check_unknown_user_returns_404(_check_client):
+async def test_check_unknown_user_returns_404(_check_client):
     client, _ = _check_client
     with patch("backend.api.auth.users_repo") as mock_repo:
         mock_repo.find_by_telegram_id = AsyncMock(return_value=None)
-        resp = client.get("/api/auth/telegram/check?telegram_id=99999")
+        resp = await client.get("/api/auth/telegram/check?telegram_id=99999")
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_check_inactive_user_returns_403(_check_client):
+async def test_check_inactive_user_returns_403(_check_client):
     client, _ = _check_client
     with patch("backend.api.auth.users_repo") as mock_repo:
         user = AsyncMock(is_active=False)
         mock_repo.find_by_telegram_id = AsyncMock(return_value=user)
-        resp = client.get("/api/auth/telegram/check?telegram_id=12345")
+        resp = await client.get("/api/auth/telegram/check?telegram_id=12345")
 
     assert resp.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import httpx
-import pytest
 from fastapi import status
 
 from backend.app import app
@@ -45,7 +44,6 @@ def _setup() -> httpx.AsyncClient:
 # --- POST /api/chat/sessions (create session) ---
 
 
-@pytest.mark.asyncio
 async def test_create_session_success():
     """201 — session created, titled from message."""
     session = _fake_session()
@@ -63,7 +61,6 @@ async def test_create_session_success():
     assert mock_create.call_args[0][1] == 1  # user.id
 
 
-@pytest.mark.asyncio
 async def test_create_session_empty_message_rejected():
     """422 — empty message fails validation."""
     async with _setup() as client:
@@ -74,7 +71,6 @@ async def test_create_session_empty_message_rejected():
 # --- POST /api/chat/sessions/{id}/messages (send message) ---
 
 
-@pytest.mark.asyncio
 async def test_send_message_success():
     """201 — message sent, assistant response returned."""
     result = ChatMessageOut(
@@ -102,7 +98,6 @@ async def test_send_message_success():
     assert mock_send.call_args[0][2] == 1  # session_id
 
 
-@pytest.mark.asyncio
 async def test_send_message_session_not_found():
     """404 — session doesn't exist."""
     with patch("backend.api.chat.send_message", new_callable=AsyncMock) as mock_send:
@@ -113,7 +108,6 @@ async def test_send_message_session_not_found():
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-@pytest.mark.asyncio
 async def test_send_message_not_owner():
     """403 — session belongs to another user."""
     with patch("backend.api.chat.send_message", new_callable=AsyncMock) as mock_send:
@@ -127,7 +121,6 @@ async def test_send_message_not_owner():
 # --- GET /api/chat/sessions (list) ---
 
 
-@pytest.mark.asyncio
 async def test_list_sessions_success():
     """200 — returns user's sessions."""
     sessions = [_fake_session(id=1), _fake_session(id=2, title="Italian wines")]
@@ -144,7 +137,6 @@ async def test_list_sessions_success():
     assert mock_list.call_args[0][1] == 1  # user.id
 
 
-@pytest.mark.asyncio
 async def test_list_sessions_with_pagination():
     """200 — respects limit and offset params."""
     with patch("backend.api.chat.list_sessions", new_callable=AsyncMock) as mock_list:
@@ -161,7 +153,6 @@ async def test_list_sessions_with_pagination():
 # --- GET /api/chat/sessions/{id} (detail) ---
 
 
-@pytest.mark.asyncio
 async def test_get_session_detail_success():
     """200 — returns session with messages."""
     detail = ChatSessionDetailOut(
@@ -195,7 +186,6 @@ async def test_get_session_detail_success():
     assert data["messages"][1]["role"] == "assistant"
 
 
-@pytest.mark.asyncio
 async def test_get_session_not_found():
     """404 — session doesn't exist."""
     with patch("backend.api.chat.get_session", new_callable=AsyncMock) as mock_get:
@@ -209,7 +199,6 @@ async def test_get_session_not_found():
 # --- PATCH /api/chat/sessions/{id} (update title) ---
 
 
-@pytest.mark.asyncio
 async def test_update_session_title():
     """200 — session title updated."""
     updated = _fake_session(title="New title")
@@ -228,7 +217,6 @@ async def test_update_session_title():
 # --- DELETE /api/chat/sessions/{id} ---
 
 
-@pytest.mark.asyncio
 async def test_delete_session_success():
     """204 — session deleted."""
     with patch("backend.api.chat.delete_session", new_callable=AsyncMock) as mock_del:
@@ -242,7 +230,6 @@ async def test_delete_session_success():
     assert mock_del.call_args[0][2] == 1  # session_id
 
 
-@pytest.mark.asyncio
 async def test_delete_session_not_found():
     """404 — session doesn't exist."""
     with patch("backend.api.chat.delete_session", new_callable=AsyncMock) as mock_del:
@@ -366,7 +353,6 @@ def _fake_chat_message(id: int, role: str, content: str) -> SimpleNamespace:
 class TestSendMessageRouting:
     """Tests for three-way intent routing in send_message()."""
 
-    @pytest.mark.asyncio
     @patch("backend.services.chat.chat_repo")
     @patch("backend.services.chat.recommend", new_callable=AsyncMock)
     @patch("backend.services.chat.parse_intent", new_callable=AsyncMock)
@@ -395,7 +381,6 @@ class TestSendMessageRouting:
         assert mock_recommend.call_args.kwargs["intent"] is intent
         assert isinstance(result.content, RecommendationOut)
 
-    @pytest.mark.asyncio
     @patch("backend.services.chat.chat_repo")
     @patch("backend.services.chat.sommelier_chat", new_callable=AsyncMock)
     @patch("backend.services.chat.parse_intent", new_callable=AsyncMock)
@@ -421,7 +406,6 @@ class TestSendMessageRouting:
         mock_sommelier.assert_called_once()
         assert result.content == "Burgundy is a famous wine region in eastern France."
 
-    @pytest.mark.asyncio
     @patch("backend.services.chat.chat_repo")
     @patch("backend.services.chat.parse_intent", new_callable=AsyncMock)
     async def test_off_topic_path(
@@ -443,7 +427,6 @@ class TestSendMessageRouting:
 
         assert result.content == NON_WINE_MESSAGE
 
-    @pytest.mark.asyncio
     @patch("backend.services.chat.chat_repo")
     @patch("backend.services.chat.sommelier_chat", new_callable=AsyncMock)
     @patch("backend.services.chat.parse_intent", new_callable=AsyncMock)

--- a/backend/tests/test_curation.py
+++ b/backend/tests/test_curation.py
@@ -1,7 +1,5 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 from backend.services.curation import (
     ExplanationResult,
     _build_user_message,
@@ -108,14 +106,12 @@ class TestFallback:
 
 
 class TestExplainRecommendations:
-    @pytest.mark.asyncio
     async def test_empty_products_returns_empty(self) -> None:
         result = await explain_recommendations("query", [])
         assert isinstance(result, ExplanationResult)
         assert result.reasons == []
         assert result.summary == ""
 
-    @pytest.mark.asyncio
     @patch("backend.services.curation.backend_settings")
     async def test_no_api_key_returns_fallback(self, mock_settings: MagicMock) -> None:
         mock_settings.ANTHROPIC_API_KEY = ""
@@ -124,7 +120,6 @@ class TestExplainRecommendations:
         assert len(result.reasons) == 1
         assert result.reasons[0] == ""
 
-    @pytest.mark.asyncio
     @patch("backend.services.curation.get_anthropic_client")
     @patch("backend.services.curation.backend_settings")
     async def test_successful_call(
@@ -151,7 +146,6 @@ class TestExplainRecommendations:
         assert result.reasons == ["Great Bordeaux red"]
         assert result.summary == "A solid pick"
 
-    @pytest.mark.asyncio
     @patch("backend.services.curation.get_anthropic_client")
     @patch("backend.services.curation.backend_settings")
     async def test_api_error_returns_fallback(
@@ -171,7 +165,6 @@ class TestExplainRecommendations:
         assert len(result.reasons) == 1
         assert result.reasons[0] == ""
 
-    @pytest.mark.asyncio
     @patch("backend.services.curation.get_anthropic_client")
     @patch("backend.services.curation.backend_settings")
     async def test_no_tool_use_block_returns_fallback(

--- a/backend/tests/test_github_oauth.py
+++ b/backend/tests/test_github_oauth.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 from fastapi import status
-from fastapi.testclient import TestClient
 
 from backend.app import app
 from backend.exceptions import ForbiddenError
@@ -21,18 +20,23 @@ _STATE = "validstate123"
 
 
 @pytest.fixture
-def client():
-    return TestClient(app, follow_redirects=False)
+async def client():
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        follow_redirects=False,
+    ) as c:
+        yield c
 
 
-def test_github_login_redirects_to_github(client):
+async def test_github_login_redirects_to_github(client):
     """GET /auth/github/login generates state and redirects to GitHub."""
     redis = AsyncMock()
     redis.set = AsyncMock()
     app.dependency_overrides[get_redis] = lambda: redis
 
     with patch("backend.api.auth.store_oauth_state", new=AsyncMock(return_value=_STATE)):
-        resp = client.get("/api/auth/github/login")
+        resp = await client.get("/api/auth/github/login")
 
     app.dependency_overrides.pop(get_redis)
     assert resp.status_code == status.HTTP_307_TEMPORARY_REDIRECT
@@ -42,7 +46,7 @@ def test_github_login_redirects_to_github(client):
     assert "scope=user%3Aemail" in location
 
 
-def test_github_callback_new_user(client):
+async def test_github_callback_new_user(client):
     """New GitHub user with valid state + approved waitlist — redirects with exchange code."""
     with (
         patch("backend.api.auth.consume_oauth_state", new=AsyncMock(return_value=True)),
@@ -61,32 +65,32 @@ def test_github_callback_new_user(client):
         patch("backend.api.auth.backend_settings") as mock_settings,
     ):
         mock_settings.FRONTEND_URL = "https://example.com"
-        resp = client.get(f"/api/auth/github/callback?code=somecode&state={_STATE}")
+        resp = await client.get(f"/api/auth/github/callback?code=somecode&state={_STATE}")
 
     assert resp.status_code == status.HTTP_307_TEMPORARY_REDIRECT
     assert resp.headers["location"] == f"https://example.com/auth/callback?code={_EXCHANGE_CODE}"
 
 
-def test_github_callback_invalid_state(client):
+async def test_github_callback_invalid_state(client):
     """Invalid or expired state token — redirects with error."""
     with (
         patch("backend.api.auth.consume_oauth_state", new=AsyncMock(return_value=False)),
         patch("backend.api.auth.backend_settings") as mock_settings,
     ):
         mock_settings.FRONTEND_URL = "https://example.com"
-        resp = client.get("/api/auth/github/callback?code=somecode&state=badstate")
+        resp = await client.get("/api/auth/github/callback?code=somecode&state=badstate")
 
     assert resp.status_code == status.HTTP_307_TEMPORARY_REDIRECT
     assert resp.headers["location"] == "https://example.com/auth/callback?error=invalid_state"
 
 
-def test_github_callback_missing_state(client):
+async def test_github_callback_missing_state(client):
     """Missing state parameter — 422."""
-    resp = client.get("/api/auth/github/callback?code=somecode")
+    resp = await client.get("/api/auth/github/callback?code=somecode")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-def test_github_callback_github_error(client):
+async def test_github_callback_github_error(client):
     """GitHub returns no access token — 400."""
     from fastapi import HTTPException
 
@@ -97,31 +101,31 @@ def test_github_callback_github_error(client):
             new=AsyncMock(side_effect=HTTPException(status_code=400, detail="GitHub OAuth failed")),
         ),
     ):
-        resp = client.get(f"/api/auth/github/callback?code=badcode&state={_STATE}")
+        resp = await client.get(f"/api/auth/github/callback?code=badcode&state={_STATE}")
 
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_exchange_token_success(client):
+async def test_exchange_token_success(client):
     """Valid exchange code returns JWT."""
     redis = AsyncMock()
     redis.getdel = AsyncMock(return_value=_JWT)
     app.dependency_overrides[get_redis] = lambda: redis
 
-    resp = client.get(f"/api/auth/exchange?code={_EXCHANGE_CODE}")
+    resp = await client.get(f"/api/auth/exchange?code={_EXCHANGE_CODE}")
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["access_token"] == _JWT
     app.dependency_overrides.pop(get_redis)
 
 
-def test_exchange_token_expired(client):
+async def test_exchange_token_expired(client):
     """Expired/unknown exchange code returns 404."""
     redis = AsyncMock()
     redis.getdel = AsyncMock(return_value=None)
     app.dependency_overrides[get_redis] = lambda: redis
 
-    resp = client.get("/api/auth/exchange?code=expiredcode")
+    resp = await client.get("/api/auth/exchange?code=expiredcode")
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
     app.dependency_overrides.pop(get_redis)

--- a/backend/tests/test_google_oauth.py
+++ b/backend/tests/test_google_oauth.py
@@ -3,7 +3,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 from fastapi import status
-from fastapi.testclient import TestClient
 
 from backend.app import app
 from backend.redis_client import get_redis
@@ -18,11 +17,16 @@ _REDIRECT_URI = "http://localhost:8001/api/auth/google/callback"
 
 
 @pytest.fixture
-def client():
-    return TestClient(app, follow_redirects=False)
+async def client():
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        follow_redirects=False,
+    ) as c:
+        yield c
 
 
-def test_google_login_redirects_to_google(client):
+async def test_google_login_redirects_to_google(client):
     """GET /auth/google/login generates state and redirects to Google."""
     redis = AsyncMock()
     redis.set = AsyncMock()
@@ -34,7 +38,7 @@ def test_google_login_redirects_to_google(client):
     ):
         mock_settings.GOOGLE_CLIENT_ID = "test-client-id"
         mock_settings.BACKEND_URL = "http://localhost:8001"
-        resp = client.get("/api/auth/google/login")
+        resp = await client.get("/api/auth/google/login")
 
     app.dependency_overrides.pop(get_redis)
     assert resp.status_code == status.HTTP_307_TEMPORARY_REDIRECT
@@ -44,7 +48,7 @@ def test_google_login_redirects_to_google(client):
     assert "scope=openid+email+profile" in location
 
 
-def test_google_callback_success(client):
+async def test_google_callback_success(client):
     """Valid state + approved waitlist — redirects with exchange code."""
     with (
         patch("backend.api.auth.consume_oauth_state", new=AsyncMock(return_value=True)),
@@ -64,28 +68,28 @@ def test_google_callback_success(client):
     ):
         mock_settings.FRONTEND_URL = "https://example.com"
         mock_settings.BACKEND_URL = "http://localhost:8001"
-        resp = client.get(f"/api/auth/google/callback?code=somecode&state={_STATE}")
+        resp = await client.get(f"/api/auth/google/callback?code=somecode&state={_STATE}")
 
     assert resp.status_code == status.HTTP_307_TEMPORARY_REDIRECT
     assert resp.headers["location"] == f"https://example.com/auth/callback?code={_EXCHANGE_CODE}"
 
 
-def test_google_callback_invalid_state(client):
+async def test_google_callback_invalid_state(client):
     """Invalid or expired state — redirects with error."""
     with (
         patch("backend.api.auth.consume_oauth_state", new=AsyncMock(return_value=False)),
         patch("backend.api.auth.backend_settings") as mock_settings,
     ):
         mock_settings.FRONTEND_URL = "https://example.com"
-        resp = client.get("/api/auth/google/callback?code=somecode&state=badstate")
+        resp = await client.get("/api/auth/google/callback?code=somecode&state=badstate")
 
     assert resp.status_code == status.HTTP_307_TEMPORARY_REDIRECT
     assert resp.headers["location"] == "https://example.com/auth/callback?error=invalid_state"
 
 
-def test_google_callback_missing_state(client):
+async def test_google_callback_missing_state(client):
     """Missing state parameter — 422."""
-    resp = client.get("/api/auth/google/callback?code=somecode")
+    resp = await client.get("/api/auth/google/callback?code=somecode")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,35 +1,39 @@
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 from fastapi import status
-from fastapi.testclient import TestClient
 from sqlalchemy.exc import SQLAlchemyError
 
 from backend.app import app
 from backend.db import get_db
 
+from .conftest import BASE_URL
 
-def test_health():
+
+async def test_health():
     """Health endpoint returns ok when DB is reachable."""
     mock_session = AsyncMock(spec_set=["execute", "__aenter__", "__aexit__"])
     mock_session.execute = AsyncMock(return_value=MagicMock())
 
     app.dependency_overrides[get_db] = lambda: mock_session
-    client = TestClient(app)
-    resp = client.get("/health")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=BASE_URL) as client:
+        resp = await client.get("/health")
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == {"status": "ok"}
     mock_session.execute.assert_called_once()
 
 
-def test_health_db_failure():
+async def test_health_db_failure():
     """Health endpoint returns 500 when DB is unreachable."""
     mock_session = AsyncMock(spec_set=["execute", "__aenter__", "__aexit__"])
     mock_session.execute.side_effect = SQLAlchemyError("connection refused")
 
     app.dependency_overrides[get_db] = lambda: mock_session
-    client = TestClient(app)
-    resp = client.get("/health")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=BASE_URL) as client:
+        resp = await client.get("/health")
 
     assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert resp.json() == {"detail": "Database error"}

--- a/backend/tests/test_intent.py
+++ b/backend/tests/test_intent.py
@@ -2,7 +2,6 @@ from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import anthropic
-import pytest
 
 from backend.services.intent import parse_intent
 
@@ -30,7 +29,6 @@ def _mock_text_response() -> MagicMock:
 
 
 class TestParseIntent:
-    @pytest.mark.asyncio
     @patch("backend.services.intent.get_anthropic_client")
     @patch("backend.services.intent.backend_settings")
     async def test_extracts_category_and_price(
@@ -59,7 +57,6 @@ class TestParseIntent:
         assert result.country is None
         assert result.semantic_query == "fruité"
 
-    @pytest.mark.asyncio
     @patch("backend.services.intent.get_anthropic_client")
     @patch("backend.services.intent.backend_settings")
     async def test_extracts_country(
@@ -83,7 +80,6 @@ class TestParseIntent:
         assert result.country == "France"
         assert result.semantic_query == "crisp dry white"
 
-    @pytest.mark.asyncio
     @patch("backend.services.intent.get_anthropic_client")
     @patch("backend.services.intent.backend_settings")
     async def test_semantic_only_query(
@@ -109,7 +105,6 @@ class TestParseIntent:
         assert result.max_price is None
         assert result.semantic_query == "something for a BBQ with friends"
 
-    @pytest.mark.asyncio
     @patch("backend.services.intent.get_anthropic_client")
     @patch("backend.services.intent.backend_settings")
     async def test_falls_back_on_api_error(
@@ -130,7 +125,6 @@ class TestParseIntent:
         assert result.intent_type == "recommendation"
         assert result.categories == []
 
-    @pytest.mark.asyncio
     @patch("backend.services.intent.backend_settings")
     async def test_falls_back_when_no_api_key(self, mock_settings: MagicMock) -> None:
         mock_settings.ANTHROPIC_API_KEY = ""
@@ -141,7 +135,6 @@ class TestParseIntent:
         assert result.intent_type == "recommendation"
         assert result.categories == []
 
-    @pytest.mark.asyncio
     @patch("backend.services.intent.get_anthropic_client")
     @patch("backend.services.intent.backend_settings")
     async def test_handles_missing_optional_fields(
@@ -163,7 +156,6 @@ class TestParseIntent:
         assert result.country is None
         assert result.semantic_query == "bold red"
 
-    @pytest.mark.asyncio
     @patch("backend.services.intent.get_anthropic_client")
     @patch("backend.services.intent.backend_settings")
     async def test_wine_chat_tool_returns_wine_chat_intent(
@@ -182,7 +174,6 @@ class TestParseIntent:
         assert result.intent_type == "wine_chat"
         assert result.semantic_query == "tell me about Burgundy"
 
-    @pytest.mark.asyncio
     @patch("backend.services.intent.get_anthropic_client")
     @patch("backend.services.intent.backend_settings")
     async def test_off_topic_tool_returns_off_topic_intent(
@@ -198,7 +189,6 @@ class TestParseIntent:
 
         assert result.intent_type == "off_topic"
 
-    @pytest.mark.asyncio
     @patch("backend.services.intent.get_anthropic_client")
     @patch("backend.services.intent.backend_settings")
     async def test_no_tool_call_falls_back_to_wine_chat(
@@ -215,7 +205,6 @@ class TestParseIntent:
         assert result.intent_type == "wine_chat"
         assert result.semantic_query == "bonjour"
 
-    @pytest.mark.asyncio
     @patch("backend.services.intent.get_anthropic_client")
     @patch("backend.services.intent.backend_settings")
     async def test_conversation_history_included_in_messages(

--- a/backend/tests/test_jwt_middleware.py
+++ b/backend/tests/test_jwt_middleware.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import jwt
 import pytest
 from fastapi import Depends, status
-from fastapi.testclient import TestClient
 
 from backend.app import app
 from backend.auth import verify_auth
@@ -12,7 +11,7 @@ from backend.config import ROLE_USER
 from backend.db import get_db
 from core.db.models import User
 
-from .conftest import JWT_SECRET
+from .conftest import JWT_SECRET, make_test_client
 
 
 def _make_token(
@@ -43,7 +42,7 @@ def _mock_user(user_id: int = 1, is_active: bool = True) -> MagicMock:
 
 
 @pytest.fixture()
-def protected_client():
+async def protected_client():
     """Client with a test route protected by verify_auth.
 
     Removes the conftest JWT bypass so real auth logic runs.
@@ -56,14 +55,15 @@ def protected_client():
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
     app.dependency_overrides.pop(verify_auth, None)
-    yield TestClient(app)
+    async with make_test_client() as client:
+        yield client
     app.dependency_overrides.clear()
     # Clean up test route
     app.routes[:] = [r for r in app.routes if getattr(r, "path", None) != "/test/protected"]
 
 
 class TestJWTMiddleware:
-    def test_valid_token_returns_user(self, protected_client: TestClient):
+    async def test_valid_token_returns_user(self, protected_client):
         token = _make_token()
         with (
             patch("backend.auth.backend_settings") as mock_settings,
@@ -72,7 +72,7 @@ class TestJWTMiddleware:
             mock_settings.JWT_SECRET_KEY = JWT_SECRET
             mock_settings.BOT_SECRET = ""
             mock_repo.find_by_id = AsyncMock(return_value=_mock_user())
-            resp = protected_client.get(
+            resp = await protected_client.get(
                 "/test/protected",
                 headers={"Authorization": f"Bearer {token}"},
             )
@@ -80,18 +80,18 @@ class TestJWTMiddleware:
         assert resp.status_code == status.HTTP_200_OK
         assert resp.json()["user_id"] == 1
 
-    def test_missing_token_returns_401(self, protected_client: TestClient):
+    async def test_missing_token_returns_401(self, protected_client):
         with patch("backend.auth.backend_settings") as mock_settings:
             mock_settings.BOT_SECRET = ""
-            resp = protected_client.get("/test/protected")
+            resp = await protected_client.get("/test/protected")
         assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_expired_token_returns_401(self, protected_client: TestClient):
+    async def test_expired_token_returns_401(self, protected_client):
         token = _make_token(expired=True)
         with patch("backend.auth.backend_settings") as mock_settings:
             mock_settings.JWT_SECRET_KEY = JWT_SECRET
             mock_settings.BOT_SECRET = ""
-            resp = protected_client.get(
+            resp = await protected_client.get(
                 "/test/protected",
                 headers={"Authorization": f"Bearer {token}"},
             )
@@ -99,18 +99,18 @@ class TestJWTMiddleware:
         assert resp.status_code == status.HTTP_401_UNAUTHORIZED
         assert "expired" in resp.json()["detail"].lower()
 
-    def test_invalid_token_returns_401(self, protected_client: TestClient):
+    async def test_invalid_token_returns_401(self, protected_client):
         with patch("backend.auth.backend_settings") as mock_settings:
             mock_settings.JWT_SECRET_KEY = JWT_SECRET
             mock_settings.BOT_SECRET = ""
-            resp = protected_client.get(
+            resp = await protected_client.get(
                 "/test/protected",
                 headers={"Authorization": "Bearer garbage.token.here"},
             )
 
         assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_user_not_found_returns_401(self, protected_client: TestClient):
+    async def test_user_not_found_returns_401(self, protected_client):
         token = _make_token()
         with (
             patch("backend.auth.backend_settings") as mock_settings,
@@ -119,14 +119,14 @@ class TestJWTMiddleware:
             mock_settings.JWT_SECRET_KEY = JWT_SECRET
             mock_settings.BOT_SECRET = ""
             mock_repo.find_by_id = AsyncMock(return_value=None)
-            resp = protected_client.get(
+            resp = await protected_client.get(
                 "/test/protected",
                 headers={"Authorization": f"Bearer {token}"},
             )
 
         assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_inactive_user_returns_403(self, protected_client: TestClient):
+    async def test_inactive_user_returns_403(self, protected_client):
         token = _make_token()
         with (
             patch("backend.auth.backend_settings") as mock_settings,
@@ -135,7 +135,7 @@ class TestJWTMiddleware:
             mock_settings.JWT_SECRET_KEY = JWT_SECRET
             mock_settings.BOT_SECRET = ""
             mock_repo.find_by_id = AsyncMock(return_value=_mock_user(is_active=False))
-            resp = protected_client.get(
+            resp = await protected_client.get(
                 "/test/protected",
                 headers={"Authorization": f"Bearer {token}"},
             )

--- a/backend/tests/test_products.py
+++ b/backend/tests/test_products.py
@@ -4,9 +4,9 @@ from types import SimpleNamespace, UnionType
 from typing import get_origin
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 from fastapi import status
-from fastapi.testclient import TestClient
 
 from backend.app import app
 from backend.config import MAX_FILTER_LENGTH, MAX_SEARCH_LENGTH, MAX_SKU_LENGTH
@@ -76,41 +76,44 @@ def _mock_db_for_detail(product):
 # ── Detail endpoint ──────────────────────────────────────────────
 
 
-def test_get_product_found():
+async def test_get_product_found():
     product = _fake_product(sku="ABC123", name="Château Test")
     session = _mock_db_for_detail(product)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products/ABC123")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products/ABC123")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["sku"] == "ABC123"
     assert data["name"] == "Château Test"
 
 
-def test_get_product_not_found():
+async def test_get_product_not_found():
     session = _mock_db_for_detail(None)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products/NOPE")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products/NOPE")
     assert resp.status_code == status.HTTP_404_NOT_FOUND
     assert "NOPE" in resp.json()["detail"]
 
 
-def test_get_product_response_shape():
+async def test_get_product_response_shape():
     """Detail endpoint returns the same fields as the list endpoint."""
     product = _fake_product()
     session = _mock_db_for_detail(product)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products/test")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products/test")
     assert set(resp.json().keys()) == EXPECTED_FIELDS
 
 
-def test_get_product_excludes_sensitive_fields():
+async def test_get_product_excludes_sensitive_fields():
     """Verbatim SAQ content must not appear in detail responses either."""
     product = _fake_product(
         description="SAQ text", url="https://saq.com/x", image="https://saq.com/img.jpg"
@@ -118,8 +121,9 @@ def test_get_product_excludes_sensitive_fields():
     session = _mock_db_for_detail(product)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products/test")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products/test")
     for field in ("description", "image"):
         assert field not in resp.json(), f"{field} should not be exposed in API"
 
@@ -127,13 +131,14 @@ def test_get_product_excludes_sensitive_fields():
 # ── List endpoint ────────────────────────────────────────────────
 
 
-def test_list_products_default_pagination():
+async def test_list_products_default_pagination():
     products = [_fake_product(sku=f"SKU{i}", name=f"Wine {i}") for i in range(3)]
     session = _mock_db_for_products(products, total=3)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["total"] == 3
@@ -143,36 +148,39 @@ def test_list_products_default_pagination():
     assert data["products"][0]["sku"] == "SKU0"
 
 
-def test_list_products_response_shape():
+async def test_list_products_response_shape():
     """Verify exact fields returned — catches accidental additions/removals."""
     products = [_fake_product()]
     session = _mock_db_for_products(products, total=1)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products")
     product = resp.json()["products"][0]
     assert set(product.keys()) == EXPECTED_FIELDS
 
 
-def test_list_products_price_serialization():
+async def test_list_products_price_serialization():
     """Decimal price serializes as string to preserve precision."""
     products = [_fake_product(price=15.99)]
     session = _mock_db_for_products(products, total=1)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products")
     assert resp.json()["products"][0]["price"] == "15.99"
 
 
-def test_list_products_custom_pagination():
+async def test_list_products_custom_pagination():
     products = [_fake_product(sku="SKU5", name="Wine 5")]
     session = _mock_db_for_products(products, total=25)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products?limit=10&offset=10")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products?limit=10&offset=10")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["total"] == 25
@@ -181,12 +189,13 @@ def test_list_products_custom_pagination():
     assert len(data["products"]) == 1
 
 
-def test_list_products_empty():
+async def test_list_products_empty():
     session = _mock_db_for_products([], total=0)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["total"] == 0
@@ -202,12 +211,13 @@ def test_list_products_empty():
     ],
     ids=["limit_zero", "limit_too_large", "negative_offset"],
 )
-def test_pagination_validation_rejected(qs):
+async def test_pagination_validation_rejected(qs):
     """Invalid pagination params return 422."""
     session = _mock_db_for_products([], total=0)
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get(f"/api/products?{qs}")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(f"/api/products?{qs}")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
@@ -223,7 +233,7 @@ def test_product_response_fields_exist_on_model():
     assert not missing, f"ProductOut fields not in Product model: {missing}"
 
 
-def test_list_products_excludes_sensitive_fields():
+async def test_list_products_excludes_sensitive_fields():
     """Verbatim SAQ content must not appear in API responses."""
     products = [
         _fake_product(
@@ -233,8 +243,9 @@ def test_list_products_excludes_sensitive_fields():
     session = _mock_db_for_products(products, total=1)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products")
     product = resp.json()["products"][0]
     # ! We decided to exclude SAQ proprietary data
     for field in ("description", "image"):
@@ -244,50 +255,54 @@ def test_list_products_excludes_sensitive_fields():
 # ── Search & filter endpoint ────────────────────────────────────
 
 
-def test_search_by_name():
+async def test_search_by_name():
     """?q=margaux filters products — pagination reflects filtered total."""
     products = [_fake_product(sku="MATCH1", name="Château Margaux")]
     session = _mock_db_for_products(products, total=1)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products?q=margaux")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products?q=margaux")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["total"] == 1
     assert len(data["products"]) == 1
 
 
-def test_filter_by_category():
+async def test_filter_by_category():
     products = [_fake_product(sku="RED1", category="Vin rouge")]
     session = _mock_db_for_products(products, total=1)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products?category=Vin+rouge")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products?category=Vin+rouge")
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total"] == 1
 
 
-def test_filter_by_price_range():
+async def test_filter_by_price_range():
     products = [_fake_product(sku="MID1", price=Decimal("25.00"))]
     session = _mock_db_for_products(products, total=1)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products?min_price=15&max_price=30")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products?min_price=15&max_price=30")
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total"] == 1
 
 
-def test_combined_filters_with_pagination():
+async def test_combined_filters_with_pagination():
     """Multiple filters + pagination work together."""
     products = [_fake_product(sku="FR1")]
     session = _mock_db_for_products(products, total=15)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products?country=France&min_price=10&limit=10&offset=10")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products?country=France&min_price=10&limit=10&offset=10")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["total"] == 15
@@ -295,13 +310,14 @@ def test_combined_filters_with_pagination():
     assert data["offset"] == 10
 
 
-def test_filter_no_results():
+async def test_filter_no_results():
     """Filters that match nothing return 200 with empty list, not 404."""
     session = _mock_db_for_products([], total=0)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products?country=Atlantis")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products?country=Atlantis")
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total"] == 0
     assert resp.json()["products"] == []
@@ -318,12 +334,13 @@ def test_filter_no_results():
     ],
     ids=["empty_q", "negative_price", "q_too_long", "category_too_long", "sku_too_long"],
 )
-def test_input_validation_rejected(path):
+async def test_input_validation_rejected(path):
     """Invalid filter/search inputs return 422."""
     session = _mock_db_for_products([], total=0)
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get(path)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path)
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
@@ -388,7 +405,7 @@ def _mock_session_factory_for_facets(
     return factory
 
 
-def test_facets_response_shape():
+async def test_facets_response_shape():
     """Facets endpoint returns all expected keys with sorted values."""
     factory = _mock_session_factory_for_facets(
         categories=["Vin blanc", "Vin rouge"],
@@ -399,8 +416,9 @@ def test_facets_response_shape():
     )
 
     app.dependency_overrides[get_session_factory] = lambda: factory
-    client = TestClient(app)
-    resp = client.get("/api/products/facets")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products/facets")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["categories"] == ["Vin blanc", "Vin rouge"]
@@ -415,7 +433,7 @@ def test_facets_response_shape():
     assert isinstance(data["category_families"], list)
 
 
-def test_facets_empty_catalog():
+async def test_facets_empty_catalog():
     """Empty catalog returns empty lists and null price range."""
     factory = _mock_session_factory_for_facets(
         categories=[],
@@ -426,8 +444,9 @@ def test_facets_empty_catalog():
     )
 
     app.dependency_overrides[get_session_factory] = lambda: factory
-    client = TestClient(app)
-    resp = client.get("/api/products/facets")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products/facets")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["categories"] == []
@@ -437,7 +456,7 @@ def test_facets_empty_catalog():
     assert data["price_range"] is None
 
 
-def test_facets_no_prices():
+async def test_facets_no_prices():
     """Products exist but none have prices — lists populated, price_range null."""
     factory = _mock_session_factory_for_facets(
         categories=["Vin rouge"],
@@ -448,8 +467,9 @@ def test_facets_no_prices():
     )
 
     app.dependency_overrides[get_session_factory] = lambda: factory
-    client = TestClient(app)
-    resp = client.get("/api/products/facets")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products/facets")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert len(data["categories"]) == 1
@@ -459,114 +479,124 @@ def test_facets_no_prices():
 # ── Sorting ───────────────────────────────────────────────────
 
 
-def test_sort_recent_returns_200():
+async def test_sort_recent_returns_200():
     """?sort=recent returns 200 with products."""
     products = [_fake_product(sku="NEW1")]
     session = _mock_db_for_products(products, total=1)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products?sort=recent")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products?sort=recent")
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["total"] == 1
 
 
-def test_sort_invalid_rejected():
+async def test_sort_invalid_rejected():
     """Invalid sort value returns 422."""
     session = _mock_db_for_products([], total=0)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products?sort=bogus")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products?sort=bogus")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 @pytest.mark.parametrize("sort_value", ["price_asc", "price_desc"])
-def test_sort_by_price_returns_200(sort_value):
+async def test_sort_by_price_returns_200(sort_value):
     """Price sort options return 200."""
     products = [_fake_product(sku="S1")]
     session = _mock_db_for_products(products, total=1)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get(f"/api/products?sort={sort_value}")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(f"/api/products?sort={sort_value}")
     assert resp.status_code == status.HTTP_200_OK
 
 
 # ── Random endpoint ───────────────────────────────────────────
 
 
-def test_random_product_found():
+async def test_random_product_found():
     """Random endpoint returns a single product."""
     product = _fake_product(sku="RAND1", name="Château Random")
     session = _mock_db_for_detail(product)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products/random")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products/random")
     assert resp.status_code == status.HTTP_200_OK
     assert set(resp.json().keys()) == EXPECTED_FIELDS
 
 
-def test_random_product_not_found():
+async def test_random_product_not_found():
     """Random endpoint returns 404 when no products match."""
     session = _mock_db_for_detail(None)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products/random")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products/random")
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_random_with_filters():
+async def test_random_with_filters():
     """Random endpoint accepts filter params."""
     product = _fake_product(sku="FILT1", category="Vin rouge")
     session = _mock_db_for_detail(product)
 
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.get("/api/products/random?category=Vin+rouge&min_price=10")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products/random?category=Vin+rouge&min_price=10")
     assert resp.status_code == status.HTTP_200_OK
 
 
-def test_scope_wine_is_default_on_list_endpoint():
+async def test_scope_wine_is_default_on_list_endpoint():
     """Default scope=wine means wine prefix filtering is active."""
     products = [_fake_product(sku="W1", category="Vin rouge")]
     session = _mock_db_for_products(products, total=1)
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
 
-    resp = client.get("/api/products")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products")
     assert resp.status_code == status.HTTP_200_OK
 
 
-def test_scope_all_disables_wine_filtering():
+async def test_scope_all_disables_wine_filtering():
     """scope=all returns products from all categories."""
     products = [_fake_product(sku="W1", category="Whisky")]
     session = _mock_db_for_products(products, total=1)
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
 
-    resp = client.get("/api/products?scope=all")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products?scope=all")
     assert resp.status_code == status.HTTP_200_OK
 
 
-def test_scope_invalid_value_rejected():
+async def test_scope_invalid_value_rejected():
     """Invalid scope value is rejected by FastAPI validation."""
     session = _mock_db_for_products([], total=0)
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
 
-    resp = client.get("/api/products?scope=beer")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products?scope=beer")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
-def test_random_endpoint_scope_default():
+async def test_random_endpoint_scope_default():
     """Random endpoint defaults to wine scope."""
     product = _fake_product(sku="R1", category="Vin rouge")
     session = _mock_db_for_detail(product)
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
 
-    resp = client.get("/api/products/random")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/products/random")
     assert resp.status_code == status.HTTP_200_OK

--- a/backend/tests/test_recommendations.py
+++ b/backend/tests/test_recommendations.py
@@ -53,7 +53,6 @@ def _fake_product(
 
 
 class TestRecommend:
-    @pytest.mark.asyncio
     @patch("backend.services.recommendations._write_log", new_callable=AsyncMock)
     @patch("backend.services.recommendations.explain_recommendations", new_callable=AsyncMock)
     @patch("backend.services.recommendations.find_similar", new_callable=AsyncMock)
@@ -93,7 +92,6 @@ class TestRecommend:
         assert "intent" in log_kwargs["latency_ms"]
         assert "total" in log_kwargs["latency_ms"]
 
-    @pytest.mark.asyncio
     @patch("backend.services.recommendations._write_log", new_callable=AsyncMock)
     @patch("backend.services.recommendations.explain_recommendations", new_callable=AsyncMock)
     @patch("backend.services.recommendations.find_similar", new_callable=AsyncMock)
@@ -120,7 +118,6 @@ class TestRecommend:
         assert result.summary == ""
         assert result.intent.semantic_query == "rare wine"
 
-    @pytest.mark.asyncio
     @patch("backend.services.recommendations._write_log", new_callable=AsyncMock)
     @patch("backend.services.recommendations.parse_intent", new_callable=AsyncMock)
     async def test_non_wine_returns_early_without_logging(
@@ -137,7 +134,6 @@ class TestRecommend:
         assert result.log_id is None
         mock_write_log.assert_not_called()
 
-    @pytest.mark.asyncio
     @patch("backend.services.recommendations._write_log", new_callable=AsyncMock)
     @patch("backend.services.recommendations.explain_recommendations", new_callable=AsyncMock)
     @patch("backend.services.recommendations.find_similar", new_callable=AsyncMock)
@@ -172,7 +168,6 @@ class TestRecommend:
             "User: bold red\nAssistant: Great picks."
         )
 
-    @pytest.mark.asyncio
     @patch("backend.services.recommendations.parse_intent", new_callable=AsyncMock)
     async def test_pipeline_failure_does_not_log(
         self,
@@ -190,7 +185,6 @@ def _fake_embedding() -> list[float]:
 
 
 class TestFindSimilar:
-    @pytest.mark.asyncio
     async def test_returns_product_list(self) -> None:
         mock_product = MagicMock()
         mock_result = MagicMock()
@@ -204,7 +198,6 @@ class TestFindSimilar:
 
         assert products == [mock_product]
 
-    @pytest.mark.asyncio
     async def test_returns_empty_list(self) -> None:
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []

--- a/backend/tests/test_sommelier.py
+++ b/backend/tests/test_sommelier.py
@@ -1,7 +1,6 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import anthropic
-import pytest
 
 from backend.services.sommelier import _FALLBACK_MESSAGE, _build_messages, sommelier_chat
 
@@ -23,7 +22,6 @@ class TestBuildMessages:
 
 
 class TestSommelierChat:
-    @pytest.mark.asyncio
     @patch("backend.services.sommelier.get_anthropic_client")
     @patch("backend.services.sommelier.backend_settings")
     async def test_successful_response(
@@ -45,14 +43,12 @@ class TestSommelierChat:
         assert result == "Lamb pairs beautifully with Syrah."
         mock_client.messages.create.assert_called_once()
 
-    @pytest.mark.asyncio
     @patch("backend.services.sommelier.backend_settings")
     async def test_no_api_key_returns_fallback(self, mock_settings: MagicMock) -> None:
         mock_settings.ANTHROPIC_API_KEY = ""
         result = await sommelier_chat("Tell me about Bordeaux")
         assert result == _FALLBACK_MESSAGE
 
-    @pytest.mark.asyncio
     @patch("backend.services.sommelier.get_anthropic_client")
     @patch("backend.services.sommelier.backend_settings")
     async def test_api_error_returns_fallback(
@@ -68,7 +64,6 @@ class TestSommelierChat:
         result = await sommelier_chat("What is tannin?")
         assert result == _FALLBACK_MESSAGE
 
-    @pytest.mark.asyncio
     @patch("backend.services.sommelier.get_anthropic_client")
     @patch("backend.services.sommelier.backend_settings")
     async def test_no_text_blocks_returns_fallback(
@@ -85,7 +80,6 @@ class TestSommelierChat:
         result = await sommelier_chat("Hello")
         assert result == _FALLBACK_MESSAGE
 
-    @pytest.mark.asyncio
     @patch("backend.services.sommelier.get_anthropic_client")
     @patch("backend.services.sommelier.backend_settings")
     async def test_passes_conversation_history(

--- a/backend/tests/test_stores.py
+++ b/backend/tests/test_stores.py
@@ -2,8 +2,8 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import httpx
 from fastapi import status
-from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 
 from backend.app import app
@@ -43,7 +43,7 @@ def _fake_pref(**overrides):
 # ── GET /stores/nearby ────────────────────────────────────────
 
 
-def test_nearby_returns_stores_sorted_by_distance():
+async def test_nearby_returns_stores_sorted_by_distance():
     """200 — stores returned sorted by distance, closest first."""
     close = _fake_store(saq_store_id="A", latitude=45.52, longitude=-73.60, name="Close")
     far = _fake_store(saq_store_id="B", latitude=46.00, longitude=-74.00, name="Far")
@@ -52,8 +52,9 @@ def test_nearby_returns_stores_sorted_by_distance():
         mock_repo.get_all_stores = AsyncMock(return_value=[far, close])
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/stores/nearby?lat=45.52&lng=-73.60")
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/stores/nearby?lat=45.52&lng=-73.60")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -63,7 +64,7 @@ def test_nearby_returns_stores_sorted_by_distance():
     assert data[0]["distance_km"] < data[1]["distance_km"]
 
 
-def test_nearby_limit_respected():
+async def test_nearby_limit_respected():
     """200 — limit query param caps results."""
     stores = [_fake_store(saq_store_id=str(i), name=f"Store {i}") for i in range(10)]
 
@@ -71,14 +72,15 @@ def test_nearby_limit_respected():
         mock_repo.get_all_stores = AsyncMock(return_value=stores)
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/stores/nearby?lat=45.52&lng=-73.60&limit=3")
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/stores/nearby?lat=45.52&lng=-73.60&limit=3")
 
     assert resp.status_code == status.HTTP_200_OK
     assert len(resp.json()) == 3
 
 
-def test_nearby_excludes_stores_without_coordinates():
+async def test_nearby_excludes_stores_without_coordinates():
     """200 — stores with NULL lat/lng are excluded from results."""
     with_coords = _fake_store(saq_store_id="A", latitude=45.52, longitude=-73.60)
     no_coords = _fake_store(saq_store_id="B", latitude=None, longitude=None)
@@ -87,8 +89,9 @@ def test_nearby_excludes_stores_without_coordinates():
         mock_repo.get_all_stores = AsyncMock(return_value=[with_coords, no_coords])
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/stores/nearby?lat=45.52&lng=-73.60")
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/stores/nearby?lat=45.52&lng=-73.60")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -96,7 +99,7 @@ def test_nearby_excludes_stores_without_coordinates():
     assert data[0]["saq_store_id"] == "A"
 
 
-def test_nearby_excludes_non_consumer_store_types():
+async def test_nearby_excludes_non_consumer_store_types():
     """200 — SAQ Restauration and Vin en vrac stores are excluded."""
     consumer = _fake_store(saq_store_id="A", store_type="SAQ")
     restaurant = _fake_store(saq_store_id="B", store_type="SAQ Restauration")
@@ -106,8 +109,9 @@ def test_nearby_excludes_non_consumer_store_types():
         mock_repo.get_all_stores = AsyncMock(return_value=[consumer, restaurant, vrac])
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/stores/nearby?lat=45.52&lng=-73.60")
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/stores/nearby?lat=45.52&lng=-73.60")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -115,14 +119,15 @@ def test_nearby_excludes_non_consumer_store_types():
     assert data[0]["saq_store_id"] == "A"
 
 
-def test_nearby_empty_db():
+async def test_nearby_empty_db():
     """200 — empty list when no stores exist."""
     with patch("backend.services.stores.repo") as mock_repo:
         mock_repo.get_all_stores = AsyncMock(return_value=[])
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/stores/nearby?lat=45.52&lng=-73.60")
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/stores/nearby?lat=45.52&lng=-73.60")
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == []
@@ -131,7 +136,7 @@ def test_nearby_empty_db():
 # ── GET /stores/preferences ──────────────────────────────────
 
 
-def test_get_user_stores_success():
+async def test_get_user_stores_success():
     """200 — returns user's preferred stores (user_id from JWT)."""
     store = _fake_store()
     pref = _fake_pref()
@@ -140,8 +145,9 @@ def test_get_user_stores_success():
         mock_repo.get_user_stores = AsyncMock(return_value=[(pref, store)])
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/stores/preferences")
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/stores/preferences")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -151,33 +157,35 @@ def test_get_user_stores_success():
     assert mock_repo.get_user_stores.call_args[0][1] == JWT_USER_ID
 
 
-def test_get_user_stores_ignores_query_user_id():
+async def test_get_user_stores_ignores_query_user_id():
     """200 — JWT caller's query user_id is ignored."""
     with patch("backend.services.stores.repo") as mock_repo:
         mock_repo.get_user_stores = AsyncMock(return_value=[])
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/stores/preferences?user_id=tg:ATTACKER")
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/stores/preferences?user_id=tg:ATTACKER")
 
     assert resp.status_code == status.HTTP_200_OK
     assert mock_repo.get_user_stores.call_args[0][1] == JWT_USER_ID
 
 
-def test_get_user_stores_empty():
+async def test_get_user_stores_empty():
     """200 — empty list when user has no preferences."""
     with patch("backend.services.stores.repo") as mock_repo:
         mock_repo.get_user_stores = AsyncMock(return_value=[])
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/stores/preferences")
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/stores/preferences")
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == []
 
 
-def test_get_user_stores_bot_uses_query_param():
+async def test_get_user_stores_bot_uses_query_param():
     """200 — bot caller uses explicit user_id query param."""
     store = _fake_store()
     pref = _fake_pref()
@@ -187,8 +195,9 @@ def test_get_user_stores_bot_uses_query_param():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         app.dependency_overrides[get_caller_user_id] = lambda: None
-        client = TestClient(app)
-        resp = client.get("/api/stores/preferences?user_id=tg:999")
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/stores/preferences?user_id=tg:999")
 
     assert resp.status_code == status.HTTP_200_OK
     assert mock_repo.get_user_stores.call_args[0][1] == "tg:999"
@@ -197,7 +206,7 @@ def test_get_user_stores_bot_uses_query_param():
 # ── POST /stores/preferences ────────────────────────────────
 
 
-def test_add_user_store_success():
+async def test_add_user_store_success():
     """201 — preference added (user_id from JWT)."""
     store = _fake_store()
     pref = _fake_pref()
@@ -207,8 +216,9 @@ def test_add_user_store_success():
         mock_repo.add_user_store = AsyncMock(return_value=pref)
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.post("/api/stores/preferences", json={"saq_store_id": "23009"})
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/api/stores/preferences", json={"saq_store_id": "23009"})
 
     assert resp.status_code == status.HTTP_201_CREATED
     data = resp.json()
@@ -217,19 +227,20 @@ def test_add_user_store_success():
     assert mock_repo.add_user_store.call_args[0][1] == JWT_USER_ID
 
 
-def test_add_user_store_store_not_found():
+async def test_add_user_store_store_not_found():
     """404 — store doesn't exist in the stores table."""
     with patch("backend.services.stores.repo") as mock_repo:
         mock_repo.get_store_by_id = AsyncMock(return_value=None)
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.post("/api/stores/preferences", json={"saq_store_id": "99999"})
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/api/stores/preferences", json={"saq_store_id": "99999"})
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_add_user_store_duplicate():
+async def test_add_user_store_duplicate():
     """409 — user already has this store in their preferences."""
     store = _fake_store()
 
@@ -238,8 +249,9 @@ def test_add_user_store_duplicate():
         mock_repo.add_user_store = AsyncMock(side_effect=IntegrityError(None, None, None))
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.post("/api/stores/preferences", json={"saq_store_id": "23009"})
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/api/stores/preferences", json={"saq_store_id": "23009"})
 
     assert resp.status_code == status.HTTP_409_CONFLICT
 
@@ -247,39 +259,42 @@ def test_add_user_store_duplicate():
 # ── DELETE /stores/preferences/{saq_store_id} ────────────────
 
 
-def test_remove_user_store_success():
+async def test_remove_user_store_success():
     """204 — preference deleted (user_id from JWT)."""
     with patch("backend.services.stores.repo") as mock_repo:
         mock_repo.remove_user_store = AsyncMock(return_value=True)
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.delete("/api/stores/preferences/23009")
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.delete("/api/stores/preferences/23009")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     assert mock_repo.remove_user_store.call_args[0][1] == JWT_USER_ID
 
 
-def test_remove_user_store_not_found():
+async def test_remove_user_store_not_found():
     """404 — preference doesn't exist."""
     with patch("backend.services.stores.repo") as mock_repo:
         mock_repo.remove_user_store = AsyncMock(return_value=False)
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.delete("/api/stores/preferences/99999")
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.delete("/api/stores/preferences/99999")
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_remove_user_store_ignores_query_user_id():
+async def test_remove_user_store_ignores_query_user_id():
     """204 — JWT caller's query user_id is ignored."""
     with patch("backend.services.stores.repo") as mock_repo:
         mock_repo.remove_user_store = AsyncMock(return_value=True)
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.delete("/api/stores/preferences/23009?user_id=tg:ATTACKER")
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.delete("/api/stores/preferences/23009?user_id=tg:ATTACKER")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     assert mock_repo.remove_user_store.call_args[0][1] == JWT_USER_ID

--- a/backend/tests/test_tastings.py
+++ b/backend/tests/test_tastings.py
@@ -2,8 +2,9 @@ from datetime import UTC, date, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import httpx
+import pytest
 from fastapi import status
-from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 
 from backend.app import app
@@ -15,7 +16,13 @@ OTHER_USER_ID = "user:2"
 NOW = datetime(2025, 1, 1, tzinfo=UTC)
 TODAY = date(2025, 1, 1)
 
-client = TestClient(app)
+
+@pytest.fixture()
+async def client():
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
 
 
 def _fake_note(**overrides):
@@ -45,35 +52,35 @@ def _fake_product(**overrides):
 # ── POST /tastings ────────────────────────────────────────────
 
 
-def test_create_tasting_returns_201():
+async def test_create_tasting_returns_201(client):
     note = _fake_note()
     with patch("backend.services.tastings.repo.create", new_callable=AsyncMock, return_value=note):
-        resp = client.post("/api/tastings", json={"sku": "SKU001", "rating": 88})
+        resp = await client.post("/api/tastings", json={"sku": "SKU001", "rating": 88})
     assert resp.status_code == status.HTTP_201_CREATED
     data = resp.json()
     assert data["sku"] == "SKU001"
     assert data["rating"] == 88
 
 
-def test_create_tasting_unknown_sku_returns_404():
+async def test_create_tasting_unknown_sku_returns_404(client):
     with patch(
         "backend.services.tastings.repo.create",
         new_callable=AsyncMock,
         side_effect=IntegrityError("fk", {}, None),
     ):
-        resp = client.post("/api/tastings", json={"sku": "NOPE", "rating": 88})
+        resp = await client.post("/api/tastings", json={"sku": "NOPE", "rating": 88})
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_create_tasting_rating_out_of_range_returns_422():
-    resp = client.post("/api/tastings", json={"sku": "SKU001", "rating": 150})
+async def test_create_tasting_rating_out_of_range_returns_422(client):
+    resp = await client.post("/api/tastings", json={"sku": "SKU001", "rating": 150})
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 # ── GET /tastings ─────────────────────────────────────────────
 
 
-def test_list_tastings_returns_200():
+async def test_list_tastings_returns_200(client):
     note = _fake_note()
     product = _fake_product()
     with patch(
@@ -81,20 +88,20 @@ def test_list_tastings_returns_200():
         new_callable=AsyncMock,
         return_value=[(note, product)],
     ):
-        resp = client.get("/api/tastings")
+        resp = await client.get("/api/tastings")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert len(data) == 1
     assert data[0]["product_name"] == "Château Test"
 
 
-def test_list_tastings_empty_returns_empty_list():
+async def test_list_tastings_empty_returns_empty_list(client):
     with patch(
         "backend.services.tastings.repo.find_by_user",
         new_callable=AsyncMock,
         return_value=[],
     ):
-        resp = client.get("/api/tastings")
+        resp = await client.get("/api/tastings")
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == []
 
@@ -102,7 +109,7 @@ def test_list_tastings_empty_returns_empty_list():
 # ── PATCH /tastings/{id} ──────────────────────────────────────
 
 
-def test_update_tasting_returns_200():
+async def test_update_tasting_returns_200(client):
     note = _fake_note()
     updated = _fake_note(rating=92, notes="Even better on day 2")
     with (
@@ -111,69 +118,71 @@ def test_update_tasting_returns_200():
             "backend.services.tastings.repo.update", new_callable=AsyncMock, return_value=updated
         ),
     ):
-        resp = client.patch("/api/tastings/1", json={"rating": 92, "notes": "Even better on day 2"})
+        resp = await client.patch(
+            "/api/tastings/1", json={"rating": 92, "notes": "Even better on day 2"}
+        )
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["rating"] == 92
 
 
-def test_update_tasting_not_found_returns_404():
+async def test_update_tasting_not_found_returns_404(client):
     with patch(
         "backend.services.tastings.repo.find_one", new_callable=AsyncMock, return_value=None
     ):
-        resp = client.patch("/api/tastings/999", json={"rating": 90})
+        resp = await client.patch("/api/tastings/999", json={"rating": 90})
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_update_tasting_wrong_owner_returns_403():
+async def test_update_tasting_wrong_owner_returns_403(client):
     note = _fake_note(user_id=OTHER_USER_ID)
     with patch(
         "backend.services.tastings.repo.find_one", new_callable=AsyncMock, return_value=note
     ):
-        resp = client.patch("/api/tastings/1", json={"rating": 90})
+        resp = await client.patch("/api/tastings/1", json={"rating": 90})
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
 # ── DELETE /tastings/{id} ─────────────────────────────────────
 
 
-def test_delete_tasting_returns_204():
+async def test_delete_tasting_returns_204(client):
     note = _fake_note()
     with (
         patch("backend.services.tastings.repo.find_one", new_callable=AsyncMock, return_value=note),
         patch("backend.services.tastings.repo.delete", new_callable=AsyncMock),
     ):
-        resp = client.delete("/api/tastings/1")
+        resp = await client.delete("/api/tastings/1")
     assert resp.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_delete_tasting_not_found_returns_404():
+async def test_delete_tasting_not_found_returns_404(client):
     with patch(
         "backend.services.tastings.repo.find_one", new_callable=AsyncMock, return_value=None
     ):
-        resp = client.delete("/api/tastings/999")
+        resp = await client.delete("/api/tastings/999")
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_delete_tasting_wrong_owner_returns_403():
+async def test_delete_tasting_wrong_owner_returns_403(client):
     note = _fake_note(user_id=OTHER_USER_ID)
     with patch(
         "backend.services.tastings.repo.find_one", new_callable=AsyncMock, return_value=note
     ):
-        resp = client.delete("/api/tastings/1")
+        resp = await client.delete("/api/tastings/1")
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
 # ── GET /tastings/ratings ─────────────────────────────────────
 
 
-def test_get_ratings_returns_rated_skus():
+async def test_get_ratings_returns_rated_skus(client):
     rows = {"SKU001": (88, 1), "SKU002": (95, 2)}
     with patch(
         "backend.services.tastings.repo.ratings_by_skus",
         new_callable=AsyncMock,
         return_value=rows,
     ):
-        resp = client.get("/api/tastings/ratings?skus=SKU001&skus=SKU002&skus=SKU999")
+        resp = await client.get("/api/tastings/ratings?skus=SKU001&skus=SKU002&skus=SKU999")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert data["SKU001"] == {"rating": 88, "note_id": 1}
@@ -181,12 +190,12 @@ def test_get_ratings_returns_rated_skus():
     assert "SKU999" not in data
 
 
-def test_get_ratings_empty_skus_returns_empty_without_db_call():
+async def test_get_ratings_empty_skus_returns_empty_without_db_call(client):
     with patch(
         "backend.services.tastings.repo.ratings_by_skus",
         new_callable=AsyncMock,
     ) as mock_repo:
-        resp = client.get("/api/tastings/ratings")
+        resp = await client.get("/api/tastings/ratings")
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == {}
     mock_repo.assert_not_called()

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,8 +1,9 @@
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 from fastapi import status
-from fastapi.testclient import TestClient
 
 from backend.app import app
 from backend.auth import get_current_active_user
@@ -21,22 +22,26 @@ def _mock_user() -> MagicMock:
     return user
 
 
-def _authed_client(user: MagicMock) -> TestClient:
+@asynccontextmanager
+async def _authed_client(user: MagicMock):
     session = AsyncMock()
     app.dependency_overrides[get_current_active_user] = lambda: user
     app.dependency_overrides[get_db] = lambda: session
-    return TestClient(app)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        yield client
 
 
 # ── GET /api/users/me ──────────────────
 
 
-def test_get_me_success():
+async def test_get_me_success():
     """200 — returns authenticated user's profile."""
     user = _mock_user()
     user.locale = "fr"
-    client = _authed_client(user)
-    resp = client.get("/api/users/me")
+    async with _authed_client(user) as client:
+        resp = await client.get("/api/users/me")
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_200_OK
@@ -48,11 +53,13 @@ def test_get_me_success():
     assert data["role"] == "user"
 
 
-def test_get_me_unauthenticated():
+async def test_get_me_unauthenticated():
     """401 — no token."""
     app.dependency_overrides.clear()
-    client = TestClient(app)
-    resp = client.get("/api/users/me")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/users/me")
 
     assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
@@ -60,42 +67,42 @@ def test_get_me_unauthenticated():
 # ── PATCH /api/users/me ──────────────────
 
 
-def test_update_me_success():
+async def test_update_me_success():
     """204 — authenticated user can update their display name."""
     user = _mock_user()
-    client = _authed_client(user)
-    resp = client.patch("/api/users/me", json={"display_name": "NewName"})
+    async with _authed_client(user) as client:
+        resp = await client.patch("/api/users/me", json={"display_name": "NewName"})
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     assert user.display_name == "NewName"
 
 
-def test_update_me_empty_name():
+async def test_update_me_empty_name():
     """422 — empty display name rejected."""
     user = _mock_user()
-    client = _authed_client(user)
-    resp = client.patch("/api/users/me", json={"display_name": ""})
+    async with _authed_client(user) as client:
+        resp = await client.patch("/api/users/me", json={"display_name": ""})
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-def test_update_me_too_long():
+async def test_update_me_too_long():
     """422 — display name over 100 chars rejected."""
     user = _mock_user()
-    client = _authed_client(user)
-    resp = client.patch("/api/users/me", json={"display_name": "A" * 101})
+    async with _authed_client(user) as client:
+        resp = await client.patch("/api/users/me", json={"display_name": "A" * 101})
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-def test_update_me_locale():
+async def test_update_me_locale():
     """204 — can update locale alone without sending display_name."""
     user = _mock_user()
-    client = _authed_client(user)
-    resp = client.patch("/api/users/me", json={"locale": "en"})
+    async with _authed_client(user) as client:
+        resp = await client.patch("/api/users/me", json={"locale": "en"})
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
@@ -103,33 +110,33 @@ def test_update_me_locale():
     assert user.display_name == "Victor"
 
 
-def test_update_me_invalid_locale():
+async def test_update_me_invalid_locale():
     """422 — locale must be 'fr' or 'en'."""
     user = _mock_user()
-    client = _authed_client(user)
-    resp = client.patch("/api/users/me", json={"locale": "de"})
+    async with _authed_client(user) as client:
+        resp = await client.patch("/api/users/me", json={"locale": "de"})
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-def test_update_me_null_locale_ignored():
+async def test_update_me_null_locale_ignored():
     """204 — sending locale: null does not wipe existing locale."""
     user = _mock_user()
     user.locale = "en"
-    client = _authed_client(user)
-    resp = client.patch("/api/users/me", json={"locale": None})
+    async with _authed_client(user) as client:
+        resp = await client.patch("/api/users/me", json={"locale": None})
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     assert user.locale == "en"
 
 
-def test_update_me_null_display_name_ignored():
+async def test_update_me_null_display_name_ignored():
     """204 — sending display_name: null does not wipe existing name."""
     user = _mock_user()
-    client = _authed_client(user)
-    resp = client.patch("/api/users/me", json={"display_name": None, "locale": "fr"})
+    async with _authed_client(user) as client:
+        resp = await client.patch("/api/users/me", json={"display_name": None, "locale": "fr"})
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
@@ -137,11 +144,13 @@ def test_update_me_null_display_name_ignored():
     assert user.locale == "fr"
 
 
-def test_update_me_unauthenticated():
+async def test_update_me_unauthenticated():
     """401 — no token."""
     app.dependency_overrides.clear()
-    client = TestClient(app)
-    resp = client.patch("/api/users/me", json={"display_name": "Test"})
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.patch("/api/users/me", json={"display_name": "Test"})
 
     assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
@@ -149,22 +158,22 @@ def test_update_me_unauthenticated():
 # ── GET /api/users/me/accounts ──────────────────
 
 
-def test_list_accounts_success():
+async def test_list_accounts_success():
     """200 — returns linked OAuth accounts."""
     user = _mock_user()
-    client = _authed_client(user)
     accounts = [
         SimpleNamespace(
             provider="github", email="v@example.com", created_at="2026-01-01T00:00:00Z"
         ),
         SimpleNamespace(provider="google", email="v@gmail.com", created_at="2026-01-02T00:00:00Z"),
     ]
-    with patch(
-        "backend.repositories.oauth_accounts.list_by_user",
-        new_callable=AsyncMock,
-        return_value=accounts,
-    ):
-        resp = client.get("/api/users/me/accounts")
+    async with _authed_client(user) as client:
+        with patch(
+            "backend.repositories.oauth_accounts.list_by_user",
+            new_callable=AsyncMock,
+            return_value=accounts,
+        ):
+            resp = await client.get("/api/users/me/accounts")
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_200_OK
@@ -177,60 +186,60 @@ def test_list_accounts_success():
 # ── DELETE /api/users/me/accounts/{provider} ──────────────────
 
 
-def test_disconnect_account_success():
+async def test_disconnect_account_success():
     """204 — disconnect one of two linked accounts."""
     user = _mock_user()
-    client = _authed_client(user)
-    with (
-        patch(
-            "backend.repositories.oauth_accounts.count_by_user",
-            new_callable=AsyncMock,
-            return_value=2,
-        ),
-        patch(
-            "backend.repositories.oauth_accounts.delete_by_user_and_provider",
-            new_callable=AsyncMock,
-            return_value=True,
-        ),
-    ):
-        resp = client.delete("/api/users/me/accounts/github")
+    async with _authed_client(user) as client:
+        with (
+            patch(
+                "backend.repositories.oauth_accounts.count_by_user",
+                new_callable=AsyncMock,
+                return_value=2,
+            ),
+            patch(
+                "backend.repositories.oauth_accounts.delete_by_user_and_provider",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            resp = await client.delete("/api/users/me/accounts/github")
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_disconnect_last_account_rejected():
+async def test_disconnect_last_account_rejected():
     """409 — cannot disconnect the only linked account."""
     user = _mock_user()
-    client = _authed_client(user)
-    with patch(
-        "backend.repositories.oauth_accounts.count_by_user",
-        new_callable=AsyncMock,
-        return_value=1,
-    ):
-        resp = client.delete("/api/users/me/accounts/github")
+    async with _authed_client(user) as client:
+        with patch(
+            "backend.repositories.oauth_accounts.count_by_user",
+            new_callable=AsyncMock,
+            return_value=1,
+        ):
+            resp = await client.delete("/api/users/me/accounts/github")
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_409_CONFLICT
 
 
-def test_disconnect_nonexistent_provider():
+async def test_disconnect_nonexistent_provider():
     """404 — provider not linked to this user."""
     user = _mock_user()
-    client = _authed_client(user)
-    with (
-        patch(
-            "backend.repositories.oauth_accounts.count_by_user",
-            new_callable=AsyncMock,
-            return_value=2,
-        ),
-        patch(
-            "backend.repositories.oauth_accounts.delete_by_user_and_provider",
-            new_callable=AsyncMock,
-            return_value=False,
-        ),
-    ):
-        resp = client.delete("/api/users/me/accounts/apple")
+    async with _authed_client(user) as client:
+        with (
+            patch(
+                "backend.repositories.oauth_accounts.count_by_user",
+                new_callable=AsyncMock,
+                return_value=2,
+            ),
+            patch(
+                "backend.repositories.oauth_accounts.delete_by_user_and_provider",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            resp = await client.delete("/api/users/me/accounts/apple")
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
@@ -239,15 +248,15 @@ def test_disconnect_nonexistent_provider():
 # ── DELETE /api/users/me ──────────────────
 
 
-def test_delete_me_success():
+async def test_delete_me_success():
     """204 — user can delete their own account."""
     user = _mock_user()
-    client = _authed_client(user)
-    with patch(
-        "backend.repositories.users.hard_delete",
-        new_callable=AsyncMock,
-    ) as mock_delete:
-        resp = client.delete("/api/users/me")
+    async with _authed_client(user) as client:
+        with patch(
+            "backend.repositories.users.hard_delete",
+            new_callable=AsyncMock,
+        ) as mock_delete:
+            resp = await client.delete("/api/users/me")
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
@@ -257,24 +266,24 @@ def test_delete_me_success():
 # ── GET /api/users/me/telegram ──────────────────
 
 
-def test_telegram_status_linked():
+async def test_telegram_status_linked():
     """200 — returns linked=true when telegram_id is set."""
     user = _mock_user()
     user.telegram_id = 12345
-    client = _authed_client(user)
-    resp = client.get("/api/users/me/telegram")
+    async with _authed_client(user) as client:
+        resp = await client.get("/api/users/me/telegram")
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == {"linked": True}
 
 
-def test_telegram_status_unlinked():
+async def test_telegram_status_unlinked():
     """200 — returns linked=false when telegram_id is None."""
     user = _mock_user()
     user.telegram_id = None
-    client = _authed_client(user)
-    resp = client.get("/api/users/me/telegram")
+    async with _authed_client(user) as client:
+        resp = await client.get("/api/users/me/telegram")
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_200_OK
@@ -291,62 +300,62 @@ _TELEGRAM_PAYLOAD = {
 }
 
 
-def test_link_telegram_success():
+async def test_link_telegram_success():
     """204 — links Telegram account when HMAC is valid and no conflict."""
     user = _mock_user()
     user.telegram_id = None
-    client = _authed_client(user)
-    with (
-        patch("backend.api.users.verify_telegram_data"),
-        patch(
-            "backend.repositories.users.find_by_telegram_id",
-            new_callable=AsyncMock,
-            return_value=None,
-        ),
-        patch("backend.repositories.users.link_telegram", new_callable=AsyncMock) as mock_link,
-    ):
-        resp = client.post("/api/users/me/telegram", json=_TELEGRAM_PAYLOAD)
+    async with _authed_client(user) as client:
+        with (
+            patch("backend.api.users.verify_telegram_data"),
+            patch(
+                "backend.repositories.users.find_by_telegram_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("backend.repositories.users.link_telegram", new_callable=AsyncMock) as mock_link,
+        ):
+            resp = await client.post("/api/users/me/telegram", json=_TELEGRAM_PAYLOAD)
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     mock_link.assert_called_once()
 
 
-def test_link_telegram_conflict():
+async def test_link_telegram_conflict():
     """409 — telegram_id already belongs to another user."""
     user = _mock_user()
     other_user = MagicMock(spec=User)
     other_user.id = 99
-    client = _authed_client(user)
-    with (
-        patch("backend.api.users.verify_telegram_data"),
-        patch(
-            "backend.repositories.users.find_by_telegram_id",
-            new_callable=AsyncMock,
-            return_value=other_user,
-        ),
-    ):
-        resp = client.post("/api/users/me/telegram", json=_TELEGRAM_PAYLOAD)
+    async with _authed_client(user) as client:
+        with (
+            patch("backend.api.users.verify_telegram_data"),
+            patch(
+                "backend.repositories.users.find_by_telegram_id",
+                new_callable=AsyncMock,
+                return_value=other_user,
+            ),
+        ):
+            resp = await client.post("/api/users/me/telegram", json=_TELEGRAM_PAYLOAD)
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_409_CONFLICT
 
 
-def test_link_telegram_already_linked_to_self():
+async def test_link_telegram_already_linked_to_self():
     """204 — re-linking the same telegram_id to the same user is idempotent."""
     user = _mock_user()
     user.telegram_id = 12345
-    client = _authed_client(user)
-    with (
-        patch("backend.api.users.verify_telegram_data"),
-        patch(
-            "backend.repositories.users.find_by_telegram_id",
-            new_callable=AsyncMock,
-            return_value=user,
-        ),
-        patch("backend.repositories.users.link_telegram", new_callable=AsyncMock),
-    ):
-        resp = client.post("/api/users/me/telegram", json=_TELEGRAM_PAYLOAD)
+    async with _authed_client(user) as client:
+        with (
+            patch("backend.api.users.verify_telegram_data"),
+            patch(
+                "backend.repositories.users.find_by_telegram_id",
+                new_callable=AsyncMock,
+                return_value=user,
+            ),
+            patch("backend.repositories.users.link_telegram", new_callable=AsyncMock),
+        ):
+            resp = await client.post("/api/users/me/telegram", json=_TELEGRAM_PAYLOAD)
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
@@ -355,13 +364,15 @@ def test_link_telegram_already_linked_to_self():
 # ── DELETE /api/users/me/telegram ──────────────────
 
 
-def test_unlink_telegram_success():
+async def test_unlink_telegram_success():
     """204 — unlinks Telegram account."""
     user = _mock_user()
     user.telegram_id = 12345
-    client = _authed_client(user)
-    with patch("backend.repositories.users.unlink_telegram", new_callable=AsyncMock) as mock_unlink:
-        resp = client.delete("/api/users/me/telegram")
+    async with _authed_client(user) as client:
+        with patch(
+            "backend.repositories.users.unlink_telegram", new_callable=AsyncMock
+        ) as mock_unlink:
+            resp = await client.delete("/api/users/me/telegram")
     app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT

--- a/backend/tests/test_waitlist.py
+++ b/backend/tests/test_waitlist.py
@@ -2,9 +2,9 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from fastapi import status
-from fastapi.testclient import TestClient
 
 from backend.app import app
 from backend.config import WAITLIST_APPROVED, WAITLIST_REJECTED
@@ -27,76 +27,79 @@ def _fake_request(**overrides):
 
 
 @pytest.fixture()
-def public_client():
+async def public_client():
     """Unauthenticated client for public endpoints."""
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
-    yield TestClient(app)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        yield client
     app.dependency_overrides.clear()
 
 
 # ── POST /api/waitlist ───────────────────────────────────────
 
 
-def test_submit_waitlist_success(public_client):
+async def test_submit_waitlist_success(public_client):
     """201 — new email creates a pending request."""
     entry = _fake_request()
     with patch("backend.repositories.waitlist.create", new_callable=AsyncMock) as mock_create:
         mock_create.return_value = entry
-        resp = public_client.post("/api/waitlist", json={"email": "alice@example.com"})
+        resp = await public_client.post("/api/waitlist", json={"email": "alice@example.com"})
 
     assert resp.status_code == status.HTTP_201_CREATED
 
 
-def test_submit_waitlist_duplicate_silent(public_client):
+async def test_submit_waitlist_duplicate_silent(public_client):
     """201 — duplicate email returns 201 without revealing the duplicate."""
     with patch("backend.repositories.waitlist.create", new_callable=AsyncMock) as mock_create:
         mock_create.return_value = None  # repo signals duplicate with None
-        resp = public_client.post("/api/waitlist", json={"email": "alice@example.com"})
+        resp = await public_client.post("/api/waitlist", json={"email": "alice@example.com"})
 
     assert resp.status_code == status.HTTP_201_CREATED
 
 
-def test_submit_waitlist_invalid_email(public_client):
+async def test_submit_waitlist_invalid_email(public_client):
     """422 — malformed email is rejected by Pydantic."""
-    resp = public_client.post("/api/waitlist", json={"email": "not-an-email"})
+    resp = await public_client.post("/api/waitlist", json={"email": "not-an-email"})
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 # ── GET /api/admin/waitlist ──────────────────────────────────
 
 
-def test_list_waitlist_success(admin_client):
+async def test_list_waitlist_success(admin_client):
     """200 — admin sees pending requests."""
     entries = [_fake_request(id=1), _fake_request(id=2, email="bob@example.com")]
     with patch("backend.repositories.waitlist.find_pending", new_callable=AsyncMock) as mock:
         mock.return_value = entries
-        resp = admin_client.get("/api/admin/waitlist")
+        resp = await admin_client.get("/api/admin/waitlist")
 
     assert resp.status_code == status.HTTP_200_OK
     assert len(resp.json()) == 2
 
 
-def test_list_waitlist_empty(admin_client):
+async def test_list_waitlist_empty(admin_client):
     """200 — empty list when no pending requests."""
     with patch("backend.repositories.waitlist.find_pending", new_callable=AsyncMock) as mock:
         mock.return_value = []
-        resp = admin_client.get("/api/admin/waitlist")
+        resp = await admin_client.get("/api/admin/waitlist")
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == []
 
 
-def test_list_waitlist_non_admin_rejected(user_client):
+async def test_list_waitlist_non_admin_rejected(user_client):
     """403 — regular user cannot list waitlist."""
-    resp = user_client.get("/api/admin/waitlist")
+    resp = await user_client.get("/api/admin/waitlist")
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
 # ── POST /api/admin/waitlist/{id}/approve ───────────────────
 
 
-def test_approve_waitlist_success(admin_client):
+async def test_approve_waitlist_success(admin_client):
     """204 — admin can approve a pending request."""
     entry = _fake_request()
     with (
@@ -105,31 +108,31 @@ def test_approve_waitlist_success(admin_client):
     ):
         mock_find.return_value = entry
         mock_approve.return_value = _fake_request(status=WAITLIST_APPROVED)
-        resp = admin_client.post("/api/admin/waitlist/1/approve")
+        resp = await admin_client.post("/api/admin/waitlist/1/approve")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     mock_approve.assert_called_once()
 
 
-def test_approve_waitlist_not_found(admin_client):
+async def test_approve_waitlist_not_found(admin_client):
     """404 — request does not exist."""
     with patch("backend.repositories.waitlist.find_by_id", new_callable=AsyncMock) as mock_find:
         mock_find.return_value = None
-        resp = admin_client.post("/api/admin/waitlist/999/approve")
+        resp = await admin_client.post("/api/admin/waitlist/999/approve")
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_approve_waitlist_non_admin_rejected(user_client):
+async def test_approve_waitlist_non_admin_rejected(user_client):
     """403 — regular user cannot approve."""
-    resp = user_client.post("/api/admin/waitlist/1/approve")
+    resp = await user_client.post("/api/admin/waitlist/1/approve")
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
 # ── POST /api/admin/waitlist/{id}/reject ────────────────────
 
 
-def test_reject_waitlist_success(admin_client):
+async def test_reject_waitlist_success(admin_client):
     """204 — admin can reject a pending request."""
     entry = _fake_request()
     with (
@@ -138,31 +141,31 @@ def test_reject_waitlist_success(admin_client):
     ):
         mock_find.return_value = entry
         mock_reject.return_value = _fake_request(status=WAITLIST_REJECTED)
-        resp = admin_client.post("/api/admin/waitlist/1/reject")
+        resp = await admin_client.post("/api/admin/waitlist/1/reject")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     mock_reject.assert_called_once()
 
 
-def test_reject_waitlist_not_found(admin_client):
+async def test_reject_waitlist_not_found(admin_client):
     """404 — request does not exist."""
     with patch("backend.repositories.waitlist.find_by_id", new_callable=AsyncMock) as mock_find:
         mock_find.return_value = None
-        resp = admin_client.post("/api/admin/waitlist/999/reject")
+        resp = await admin_client.post("/api/admin/waitlist/999/reject")
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_reject_waitlist_non_admin_rejected(user_client):
+async def test_reject_waitlist_non_admin_rejected(user_client):
     """403 — regular user cannot reject."""
-    resp = user_client.post("/api/admin/waitlist/1/reject")
+    resp = await user_client.post("/api/admin/waitlist/1/reject")
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
 # ── POST /api/admin/waitlist/{id}/approve — email behaviour ─────────────────
 
 
-def test_approve_sends_email(admin_client):
+async def test_approve_sends_email(admin_client):
     """204 — approval triggers send_approval_email and marks email_sent_at."""
     entry = _fake_request()
     with (
@@ -172,14 +175,14 @@ def test_approve_sends_email(admin_client):
         patch("backend.repositories.waitlist.mark_email_sent", new_callable=AsyncMock) as mock_mark,
     ):
         mock_find.return_value = entry
-        resp = admin_client.post("/api/admin/waitlist/1/approve")
+        resp = await admin_client.post("/api/admin/waitlist/1/approve")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     mock_email.assert_called_once_with("alice@example.com")
     mock_mark.assert_called_once()
 
 
-def test_approve_email_failure_does_not_block(admin_client):
+async def test_approve_email_failure_does_not_block(admin_client):
     """204 — email failure is swallowed; approval still succeeds, email_sent_at not recorded."""
     entry = _fake_request()
     with (
@@ -190,7 +193,7 @@ def test_approve_email_failure_does_not_block(admin_client):
     ):
         mock_find.return_value = entry
         mock_email.side_effect = Exception("Resend down")
-        resp = admin_client.post("/api/admin/waitlist/1/approve")
+        resp = await admin_client.post("/api/admin/waitlist/1/approve")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     mock_mark.assert_not_called()
@@ -199,7 +202,7 @@ def test_approve_email_failure_does_not_block(admin_client):
 # ── POST /api/admin/waitlist/{id}/resend ────────────────────────────────────
 
 
-def test_resend_email_success(admin_client):
+async def test_resend_email_success(admin_client):
     """204 — admin can resend approval email for an approved request."""
     entry = _fake_request(status=WAITLIST_APPROVED)
     with (
@@ -208,33 +211,33 @@ def test_resend_email_success(admin_client):
         patch("backend.repositories.waitlist.mark_email_sent", new_callable=AsyncMock) as mock_mark,
     ):
         mock_find.return_value = entry
-        resp = admin_client.post("/api/admin/waitlist/1/resend")
+        resp = await admin_client.post("/api/admin/waitlist/1/resend")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     mock_email.assert_called_once_with("alice@example.com")
     mock_mark.assert_called_once()
 
 
-def test_resend_email_not_found(admin_client):
+async def test_resend_email_not_found(admin_client):
     """404 — request does not exist."""
     with patch("backend.repositories.waitlist.find_by_id", new_callable=AsyncMock) as mock_find:
         mock_find.return_value = None
-        resp = admin_client.post("/api/admin/waitlist/999/resend")
+        resp = await admin_client.post("/api/admin/waitlist/999/resend")
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_resend_email_not_approved(admin_client):
+async def test_resend_email_not_approved(admin_client):
     """409 — cannot resend for a non-approved (pending) request."""
     entry = _fake_request(status="pending")
     with patch("backend.repositories.waitlist.find_by_id", new_callable=AsyncMock) as mock_find:
         mock_find.return_value = entry
-        resp = admin_client.post("/api/admin/waitlist/1/resend")
+        resp = await admin_client.post("/api/admin/waitlist/1/resend")
 
     assert resp.status_code == status.HTTP_409_CONFLICT
 
 
-def test_resend_email_non_admin_rejected(user_client):
+async def test_resend_email_non_admin_rejected(user_client):
     """403 — regular user cannot resend."""
-    resp = user_client.post("/api/admin/waitlist/1/resend")
+    resp = await user_client.post("/api/admin/waitlist/1/resend")
     assert resp.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/tests/test_watches.py
+++ b/backend/tests/test_watches.py
@@ -2,8 +2,8 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import httpx
 from fastapi import status
-from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 
 from backend.app import app
@@ -57,10 +57,14 @@ def _fake_product(**overrides):
     return SimpleNamespace(**defaults)
 
 
+def make_test_client():
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+
+
 # ── POST /watches ─────────────────────────────────────────────
 
 
-def test_create_watch_success():
+async def test_create_watch_success():
     """201 — watch created, user_id derived from JWT (body.user_id ignored)."""
     watch = _fake_watch()
     product = _fake_product()
@@ -73,8 +77,8 @@ def test_create_watch_success():
         mock_products.find_by_sku = AsyncMock(return_value=product)
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.post("/api/watches", json={"sku": "SKU001"})
+        async with make_test_client() as client:
+            resp = await client.post("/api/watches", json={"sku": "SKU001"})
 
     assert resp.status_code == status.HTTP_201_CREATED
     data = resp.json()
@@ -86,7 +90,7 @@ def test_create_watch_success():
     assert call_args[0][1] == JWT_USER_ID
 
 
-def test_create_watch_ignores_body_user_id():
+async def test_create_watch_ignores_body_user_id():
     """201 — JWT caller's body.user_id is ignored; JWT-derived ID is used."""
     watch = _fake_watch()
     product = _fake_product()
@@ -99,16 +103,18 @@ def test_create_watch_ignores_body_user_id():
         mock_products.find_by_sku = AsyncMock(return_value=product)
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        # Send a different user_id in body — should be ignored
-        resp = client.post("/api/watches", json={"user_id": "tg:ATTACKER", "sku": "SKU001"})
+        async with make_test_client() as client:
+            # Send a different user_id in body — should be ignored
+            resp = await client.post(
+                "/api/watches", json={"user_id": "tg:ATTACKER", "sku": "SKU001"}
+            )
 
     assert resp.status_code == status.HTTP_201_CREATED
     call_args = mock_repo.create.call_args
     assert call_args[0][1] == JWT_USER_ID
 
 
-def test_create_watch_bot_uses_body_user_id():
+async def test_create_watch_bot_uses_body_user_id():
     """201 — bot-secret caller uses body.user_id (no JWT)."""
     watch = _fake_watch(user_id="tg:999")
     product = _fake_product()
@@ -123,25 +129,25 @@ def test_create_watch_bot_uses_body_user_id():
         app.dependency_overrides[get_db] = lambda: session
         # Simulate bot caller: verify_auth returns None → get_caller_user_id returns None
         app.dependency_overrides[get_caller_user_id] = lambda: None
-        client = TestClient(app)
-        resp = client.post("/api/watches", json={"user_id": "tg:999", "sku": "SKU001"})
+        async with make_test_client() as client:
+            resp = await client.post("/api/watches", json={"user_id": "tg:999", "sku": "SKU001"})
 
     assert resp.status_code == status.HTTP_201_CREATED
     call_args = mock_repo.create.call_args
     assert call_args[0][1] == "tg:999"
 
 
-def test_create_watch_bot_missing_user_id():
+async def test_create_watch_bot_missing_user_id():
     """422 — bot caller without user_id in body is rejected."""
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
     app.dependency_overrides[get_caller_user_id] = lambda: None
-    client = TestClient(app)
-    resp = client.post("/api/watches", json={"sku": "SKU001"})
+    async with make_test_client() as client:
+        resp = await client.post("/api/watches", json={"sku": "SKU001"})
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
-def test_create_watch_duplicate():
+async def test_create_watch_duplicate():
     """409 — watch already exists for this user + SKU."""
     orig = Exception("uq_watches_user_sku")
     exc = IntegrityError("INSERT", {}, orig)
@@ -150,14 +156,14 @@ def test_create_watch_duplicate():
         mock_repo.create = AsyncMock(side_effect=exc)
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.post("/api/watches", json={"sku": "SKU001"})
+        async with make_test_client() as client:
+            resp = await client.post("/api/watches", json={"sku": "SKU001"})
 
     assert resp.status_code == status.HTTP_409_CONFLICT
     assert "already watches" in resp.json()["detail"]
 
 
-def test_create_watch_invalid_sku():
+async def test_create_watch_invalid_sku():
     """404 — SKU doesn't exist in products table (FK violation)."""
     orig = Exception("foreign key constraint")
     exc = IntegrityError("INSERT", {}, orig)
@@ -166,35 +172,35 @@ def test_create_watch_invalid_sku():
         mock_repo.create = AsyncMock(side_effect=exc)
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.post("/api/watches", json={"sku": "NOPE"})
+        async with make_test_client() as client:
+            resp = await client.post("/api/watches", json={"sku": "NOPE"})
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
     assert "NOPE" in resp.json()["detail"]
 
 
-def test_create_watch_empty_sku_rejected():
+async def test_create_watch_empty_sku_rejected():
     """422 — empty sku fails validation."""
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.post("/api/watches", json={"sku": ""})
+    async with make_test_client() as client:
+        resp = await client.post("/api/watches", json={"sku": ""})
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
-def test_create_watch_missing_body():
+async def test_create_watch_missing_body():
     """422 — missing request body."""
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.post("/api/watches")
+    async with make_test_client() as client:
+        resp = await client.post("/api/watches")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 # ── GET /watches ──────────────────────────────────────────────
 
 
-def test_list_watches_with_product():
+async def test_list_watches_with_product():
     """200 — returns watches with embedded product data (user_id from JWT)."""
     watch = _fake_watch()
     product = _fake_product()
@@ -203,8 +209,8 @@ def test_list_watches_with_product():
         mock_repo.find_by_user = AsyncMock(return_value=[(watch, product)])
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/watches")
+        async with make_test_client() as client:
+            resp = await client.get("/api/watches")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -215,20 +221,20 @@ def test_list_watches_with_product():
     assert mock_repo.find_by_user.call_args[0][1] == JWT_USER_ID
 
 
-def test_list_watches_ignores_query_user_id():
+async def test_list_watches_ignores_query_user_id():
     """200 — JWT caller's query user_id is ignored; JWT-derived ID is used."""
     with patch("backend.services.watches.repo") as mock_repo:
         mock_repo.find_by_user = AsyncMock(return_value=[])
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/watches?user_id=tg:ATTACKER")
+        async with make_test_client() as client:
+            resp = await client.get("/api/watches?user_id=tg:ATTACKER")
 
     assert resp.status_code == status.HTTP_200_OK
     assert mock_repo.find_by_user.call_args[0][1] == JWT_USER_ID
 
 
-def test_list_watches_product_missing():
+async def test_list_watches_product_missing():
     """200 — watch exists but product was deleted (LEFT JOIN returns None)."""
     watch = _fake_watch(sku="GONE99")
 
@@ -236,8 +242,8 @@ def test_list_watches_product_missing():
         mock_repo.find_by_user = AsyncMock(return_value=[(watch, None)])
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/watches")
+        async with make_test_client() as client:
+            resp = await client.get("/api/watches")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -245,20 +251,20 @@ def test_list_watches_product_missing():
     assert data[0]["product"] is None
 
 
-def test_list_watches_empty():
+async def test_list_watches_empty():
     """200 — user has no watches."""
     with patch("backend.services.watches.repo") as mock_repo:
         mock_repo.find_by_user = AsyncMock(return_value=[])
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/watches")
+        async with make_test_client() as client:
+            resp = await client.get("/api/watches")
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == []
 
 
-def test_list_watches_bot_uses_query_param():
+async def test_list_watches_bot_uses_query_param():
     """200 — bot caller uses explicit user_id query param."""
     watch = _fake_watch(user_id="tg:999")
     product = _fake_product()
@@ -268,27 +274,27 @@ def test_list_watches_bot_uses_query_param():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         app.dependency_overrides[get_caller_user_id] = lambda: None
-        client = TestClient(app)
-        resp = client.get("/api/watches?user_id=tg:999")
+        async with make_test_client() as client:
+            resp = await client.get("/api/watches?user_id=tg:999")
 
     assert resp.status_code == status.HTTP_200_OK
     assert mock_repo.find_by_user.call_args[0][1] == "tg:999"
 
 
-def test_list_watches_bot_missing_user_id():
+async def test_list_watches_bot_missing_user_id():
     """422 — bot caller without user_id query param is rejected."""
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
     app.dependency_overrides[get_caller_user_id] = lambda: None
-    client = TestClient(app)
-    resp = client.get("/api/watches")
+    async with make_test_client() as client:
+        resp = await client.get("/api/watches")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 # ── DELETE /watches/{sku} ─────────────────────────────────────
 
 
-def test_delete_watch_success():
+async def test_delete_watch_success():
     """204 — watch deleted (user_id from JWT)."""
     watch = _fake_watch()
 
@@ -297,14 +303,14 @@ def test_delete_watch_success():
         mock_repo.delete = AsyncMock()
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.delete("/api/watches/SKU001")
+        async with make_test_client() as client:
+            resp = await client.delete("/api/watches/SKU001")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     assert mock_repo.find_one.call_args[0][1] == JWT_USER_ID
 
 
-def test_delete_watch_ignores_query_user_id():
+async def test_delete_watch_ignores_query_user_id():
     """204 — JWT caller's query user_id is ignored."""
     watch = _fake_watch()
 
@@ -313,27 +319,27 @@ def test_delete_watch_ignores_query_user_id():
         mock_repo.delete = AsyncMock()
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.delete("/api/watches/SKU001?user_id=tg:ATTACKER")
+        async with make_test_client() as client:
+            resp = await client.delete("/api/watches/SKU001?user_id=tg:ATTACKER")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     assert mock_repo.find_one.call_args[0][1] == JWT_USER_ID
 
 
-def test_delete_watch_not_found():
+async def test_delete_watch_not_found():
     """404 — watch doesn't exist."""
     with patch("backend.services.watches.repo") as mock_repo:
         mock_repo.find_one = AsyncMock(return_value=None)
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.delete("/api/watches/NOPE")
+        async with make_test_client() as client:
+            resp = await client.delete("/api/watches/NOPE")
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
     assert "NOPE" in resp.json()["detail"]
 
 
-def test_delete_watch_bot_uses_query_param():
+async def test_delete_watch_bot_uses_query_param():
     """204 — bot caller uses explicit user_id query param."""
     watch = _fake_watch(user_id="tg:999")
 
@@ -343,8 +349,8 @@ def test_delete_watch_bot_uses_query_param():
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
         app.dependency_overrides[get_caller_user_id] = lambda: None
-        client = TestClient(app)
-        resp = client.delete("/api/watches/SKU001?user_id=tg:999")
+        async with make_test_client() as client:
+            resp = await client.delete("/api/watches/SKU001?user_id=tg:999")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     assert mock_repo.find_one.call_args[0][1] == "tg:999"
@@ -353,7 +359,7 @@ def test_delete_watch_bot_uses_query_param():
 # ── GET /watches/notifications ───────────────────────────────
 
 
-def test_pending_notifications_success():
+async def test_pending_notifications_success():
     """200 — returns pending notifications with product data."""
     event = _fake_event()
     watch = _fake_watch()
@@ -365,8 +371,8 @@ def test_pending_notifications_success():
         )
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/watches/notifications")
+        async with make_test_client() as client:
+            resp = await client.get("/api/watches/notifications")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -380,20 +386,20 @@ def test_pending_notifications_success():
     assert "detected_at" in data[0]
 
 
-def test_pending_notifications_empty():
+async def test_pending_notifications_empty():
     """200 — no pending notifications."""
     with patch("backend.services.watches.repo") as mock_repo:
         mock_repo.find_pending_notifications = AsyncMock(return_value=[])
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/watches/notifications")
+        async with make_test_client() as client:
+            resp = await client.get("/api/watches/notifications")
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == []
 
 
-def test_pending_notifications_product_missing():
+async def test_pending_notifications_product_missing():
     """200 — notification for a delisted product (no product data)."""
     event = _fake_event(sku="GONE99")
     watch = _fake_watch(sku="GONE99")
@@ -402,8 +408,8 @@ def test_pending_notifications_product_missing():
         mock_repo.find_pending_notifications = AsyncMock(return_value=[(event, watch, None, None)])
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/watches/notifications")
+        async with make_test_client() as client:
+            resp = await client.get("/api/watches/notifications")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -411,7 +417,7 @@ def test_pending_notifications_product_missing():
     assert data[0]["online_available"] is None
 
 
-def test_pending_notifications_destock_event():
+async def test_pending_notifications_destock_event():
     """200 — destock event (available=False) is included in notifications."""
     event = _fake_event(available=False)
     watch = _fake_watch()
@@ -423,8 +429,8 @@ def test_pending_notifications_destock_event():
         )
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/watches/notifications")
+        async with make_test_client() as client:
+            resp = await client.get("/api/watches/notifications")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -433,7 +439,7 @@ def test_pending_notifications_destock_event():
     assert data[0]["sku"] == "SKU001"
 
 
-def test_pending_notifications_store_event():
+async def test_pending_notifications_store_event():
     """200 — store event includes saq_store_id and store_name."""
     event = _fake_event(saq_store_id="23009")
     watch = _fake_watch()
@@ -446,8 +452,8 @@ def test_pending_notifications_store_event():
         )
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/watches/notifications")
+        async with make_test_client() as client:
+            resp = await client.get("/api/watches/notifications")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -455,7 +461,7 @@ def test_pending_notifications_store_event():
     assert data[0]["store_name"] == "Du Parc - Fairmount Ouest"
 
 
-def test_pending_notifications_online_event_has_null_store():
+async def test_pending_notifications_online_event_has_null_store():
     """200 — online event has null store fields."""
     event = _fake_event()
     watch = _fake_watch()
@@ -467,8 +473,8 @@ def test_pending_notifications_online_event_has_null_store():
         )
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.get("/api/watches/notifications")
+        async with make_test_client() as client:
+            resp = await client.get("/api/watches/notifications")
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -479,56 +485,56 @@ def test_pending_notifications_online_event_has_null_store():
 # ── PATCH /watches/notifications ──────────────────────────
 
 
-def test_ack_notifications_success():
+async def test_ack_notifications_success():
     """204 — events acknowledged."""
     with patch("backend.services.watches.repo") as mock_repo:
         mock_repo.delete_by_delisted_event_ids = AsyncMock(return_value=0)
         mock_repo.ack_events = AsyncMock(return_value=2)
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.patch(
-            "/api/watches/notifications",
-            json={"event_ids": [1, 2]},
-        )
+        async with make_test_client() as client:
+            resp = await client.patch(
+                "/api/watches/notifications",
+                json={"event_ids": [1, 2]},
+            )
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_ack_notifications_removes_watches_for_delisted_products():
+async def test_ack_notifications_removes_watches_for_delisted_products():
     """204 — watches for delisted products are auto-removed before ack."""
     with patch("backend.services.watches.repo") as mock_repo:
         mock_repo.delete_by_delisted_event_ids = AsyncMock(return_value=1)
         mock_repo.ack_events = AsyncMock(return_value=1)
         session = AsyncMock()
         app.dependency_overrides[get_db] = lambda: session
-        client = TestClient(app)
-        resp = client.patch(
-            "/api/watches/notifications",
-            json={"event_ids": [5]},
-        )
+        async with make_test_client() as client:
+            resp = await client.patch(
+                "/api/watches/notifications",
+                json={"event_ids": [5]},
+            )
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     mock_repo.delete_by_delisted_event_ids.assert_called_once()
     mock_repo.ack_events.assert_called_once()
 
 
-def test_ack_notifications_empty_list_rejected():
+async def test_ack_notifications_empty_list_rejected():
     """422 — empty event_ids list fails validation."""
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.patch(
-        "/api/watches/notifications",
-        json={"event_ids": []},
-    )
+    async with make_test_client() as client:
+        resp = await client.patch(
+            "/api/watches/notifications",
+            json={"event_ids": []},
+        )
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
-def test_ack_notifications_missing_body():
+async def test_ack_notifications_missing_body():
     """422 — missing request body."""
     session = AsyncMock()
     app.dependency_overrides[get_db] = lambda: session
-    client = TestClient(app)
-    resp = client.patch("/api/watches/notifications")
+    async with make_test_client() as client:
+        resp = await client.patch("/api/watches/notifications")
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT

--- a/backend/tests/test_watches.py
+++ b/backend/tests/test_watches.py
@@ -2,13 +2,14 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
-import httpx
 from fastapi import status
 from sqlalchemy.exc import IntegrityError
 
 from backend.app import app
 from backend.auth import get_caller_user_id
 from backend.db import get_db
+
+from .conftest import make_test_client
 
 NOW = datetime(2025, 1, 1, tzinfo=UTC)
 
@@ -55,10 +56,6 @@ def _fake_product(**overrides):
     )
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
-
-
-def make_test_client():
-    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
 
 
 # ── POST /watches ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Migrate all backend tests from FastAPI's sync `TestClient` to `httpx.AsyncClient` with `ASGITransport`. Tests now run async end-to-end, matching production behavior.

## Related issue(s)

Closes #430

## Changes

- **conftest.py:** replaced `TestClient` fixtures with async `httpx.AsyncClient` via `make_test_client()` helper
- **12 test files migrated:** `def test_` → `async def test_`, `client.get()` → `await client.get()`, `TestClient(app)` → `async with httpx.AsyncClient(transport=ASGITransport(app=app))`
- **Removed 40 unnecessary `@pytest.mark.asyncio` decorators** from 5 files (test_chat, test_intent, test_recommendations, test_curation, test_sommelier) — redundant with `asyncio_mode = "auto"`
- **Zero `TestClient` references remain** in the test suite
- 279/279 tests pass