### PR TITLE
chore: component tests + testing standards in CLAUDE.md

### DIFF
--- a/.github/badges/coverage.svg
+++ b/.github/badges/coverage.svg
@@ -1,18 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="370.0" height="20">
+<svg xmlns="http://www.w3.org/2000/svg" width="376.5" height="20">
   <linearGradient id="b" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
   <mask id="a">
-    <rect width="370.0" height="20" rx="3" fill="#fff"/>
+    <rect width="376.5" height="20" rx="3" fill="#fff"/>
   </mask>
   <g mask="url(#a)">
     <rect width="62.0" height="20" fill="#555"/>
     <rect x="62.0" width="83.5" height="20" fill="#a3c51c"/>
     <rect x="145.5" width="83.5" height="20" fill="#dfb317"/>
     <rect x="229.0" width="57.5" height="20" fill="#4c1"/>
-    <rect x="286.5" width="83.5" height="20" fill="#e05d44"/>
-    <rect width="370.0" height="20" fill="url(#b)"/>
+    <rect x="286.5" width="90.0" height="20" fill="#e05d44"/>
+    <rect width="376.5" height="20" fill="url(#b)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="31.0" y="15" fill="#010101" fill-opacity=".3">coverage</text>
@@ -23,7 +23,7 @@
     <text x="187.25" y="14">scraper 77%</text>
     <text x="257.75" y="15" fill="#010101" fill-opacity=".3">bot 88%</text>
     <text x="257.75" y="14">bot 88%</text>
-    <text x="328.25" y="15" fill="#010101" fill-opacity=".3">frontend 5%</text>
-    <text x="328.25" y="14">frontend 5%</text>
+    <text x="331.5" y="15" fill="#010101" fill-opacity=".3">frontend 13%</text>
+    <text x="331.5" y="14">frontend 13%</text>
   </g>
 </svg>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,33 +43,56 @@ and rollback plan. See #347 as the template.
 
 ## Testing Standards
 
-These rules apply to all services (Python `pytest` and frontend Vitest).
+Apply to all services — Python (`pytest`) and frontend (Vitest + RTL).
 
-### Test naming
+### 1. Names are the spec
 
-`describe` + `it` (or `class` + `def test_`) must read as a complete behavioral sentence without opening the body. The test suite is living documentation — someone new should skim the names and understand the contract.
+`describe` + `it` (JS) or `class` + `def test_` (Python) must read as a complete behavioral sentence. Someone new should skim the names and understand the contract without opening any body.
 
-- `describe('FilterChips')` + `it('renders no buttons when options array is empty')` ✅
-- `describe('FilterChips')` + `it('renders empty')` ❌ — empty what?
-- `describe('ProtectedRoute')` + `it('redirects to /onboarding when authenticated but not onboarded')` ✅
-- `describe('ProtectedRoute')` + `it('does not render children when not onboarded')` ❌ — says what doesn't happen, not what does
+- `describe` / `class` = the thing under test: component name, function name, or logical group (`'ProtectedRoute'`, `'formatOrigin'`, `'login / logout'`)
+- `it` / `def test_` = what it does in a specific scenario
 
-Rules:
+**Naming rules:**
 
-- Present tense, active voice: "returns X", "calls Y", "renders Z", "throws when"
-- Name the outcome, not the absence — "redirects to /onboarding" not "does not render children"
-- Be specific: "renders colored dot for Vin rouge category" not "renders dot for known category"
-- When the subject is ambiguous, include the scenario: "when lang prop is provided", "when unauthenticated"
+- Active voice, present tense: "returns X", "renders Z", "calls Y", "throws when", "redirects to"
+- Name the outcome, not the absence — use active verbs even for negative cases:
+  - ✅ `'omits description when prop is not provided'`
+  - ✅ `'skips onUnauthorized callback for non-401 errors'`
+  - ❌ `'does not render description when omitted'`
+  - ❌ `'does not call onUnauthorized on non-401 errors'`
+- Be specific — no vague stubs:
+  - ✅ `'renders colored dot for Vin rouge category'`
+  - ✅ `'redirects to /onboarding when authenticated but not onboarded'`
+  - ❌ `'renders dot for known category'` — "known" means nothing
+  - ❌ `'happy_path'`, `'clean_run'`, `'valid_input'`, `'successful_call'` — always vague
+- Include the scenario when it disambiguates: "when lang prop is provided", "when unauthenticated", "when options array is empty"
 
-### Test behavior, not implementation
+### 2. Test behavior, not implementation
 
-Assert what a user or caller observes — never assert internal state, prop values, or private methods. RTL: prefer `getByRole` > `getByText` > `getByTestId` (last resort). Python: assert return values and side effects, not intermediate variables.
+Assert what a user or caller observes. Never assert internal state, intermediate variables, or private methods.
 
-### Test anatomy
+- **Frontend (RTL):** prefer `getByRole` → `getByText` → `getByTestId` (last resort, only when no semantic query works)
+- **Python:** assert return values and observable side effects (DB writes, events emitted, HTTP calls made) — not what happened inside the function
+- Never test that a mock was called with specific internal arguments unless that call IS the contract (e.g. an HTTP request body)
+- Don't test third-party library behavior — test your code's response to it
 
-- One scenario per test (one `it` = one behavior)
-- Arrange at the top, act in the middle, assert at the bottom — no interleaving
-- Use factory helpers (`product()`, `make_red()`) instead of repeating fixture setup inline
+### 3. Test anatomy
+
+- One scenario per test — one `it` or `def test_` = one behavior
+- Arrange → Act → Assert, top to bottom, no interleaving
+- Use factory helpers for fixtures (`product()`, `make_red()`) — never repeat raw object literals across tests
+- Mock at the boundary: external APIs, DB, context providers — not internal helpers
+
+### 4. Coverage targets
+
+| Service  | Line threshold   | Tool       |
+| -------- | ---------------- | ---------- |
+| Backend  | ≥ 83%            | pytest-cov |
+| Bot      | ≥ 85%            | pytest-cov |
+| Scraper  | ≥ 78%            | pytest-cov |
+| Frontend | no threshold yet | Vitest     |
+
+Frontend threshold will be set at ~60% once component extraction is complete (tracked in `docs/ENGINEERING.md`).
 
 ## Definition of Done
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ Assert what a user or caller observes. Never assert internal state, intermediate
 | Backend  | ≥ 83%            | pytest-cov |
 | Bot      | ≥ 85%            | pytest-cov |
 | Scraper  | ≥ 78%            | pytest-cov |
+| Core     | none             | pytest-cov |
 | Frontend | no threshold yet | Vitest     |
 
 Frontend threshold will be set at ~60% once component extraction is complete (tracked in `docs/ENGINEERING.md`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,36 @@ pre-deploy checks, env var changes, infra prerequisites (e.g. image swaps, exten
 migration order, post-deploy bootstrap commands, systemd unit updates, verification steps,
 and rollback plan. See #347 as the template.
 
+## Testing Standards
+
+These rules apply to all services (Python `pytest` and frontend Vitest).
+
+### Test naming
+
+`describe` + `it` (or `class` + `def test_`) must read as a complete behavioral sentence without opening the body. The test suite is living documentation — someone new should skim the names and understand the contract.
+
+- `describe('FilterChips')` + `it('renders no buttons when options array is empty')` ✅
+- `describe('FilterChips')` + `it('renders empty')` ❌ — empty what?
+- `describe('ProtectedRoute')` + `it('redirects to /onboarding when authenticated but not onboarded')` ✅
+- `describe('ProtectedRoute')` + `it('does not render children when not onboarded')` ❌ — says what doesn't happen, not what does
+
+Rules:
+
+- Present tense, active voice: "returns X", "calls Y", "renders Z", "throws when"
+- Name the outcome, not the absence — "redirects to /onboarding" not "does not render children"
+- Be specific: "renders colored dot for Vin rouge category" not "renders dot for known category"
+- When the subject is ambiguous, include the scenario: "when lang prop is provided", "when unauthenticated"
+
+### Test behavior, not implementation
+
+Assert what a user or caller observes — never assert internal state, prop values, or private methods. RTL: prefer `getByRole` > `getByText` > `getByTestId` (last resort). Python: assert return values and side effects, not intermediate variables.
+
+### Test anatomy
+
+- One scenario per test (one `it` = one behavior)
+- Arrange at the top, act in the middle, assert at the bottom — no interleaving
+- Use factory helpers (`product()`, `make_red()`) instead of repeating fixture setup inline
+
 ## Definition of Done
 
 A task/PR is "done" when all of the following are true:

--- a/docs/ENGINEERING.md
+++ b/docs/ENGINEERING.md
@@ -236,9 +236,11 @@ Five actionables identified from a full frontend audit (2026-04-02). In priority
 **Testing — Frontend:**
 
 - [x] Test infrastructure setup — add Vitest + React Testing Library + jsdom, wire `yarn test` script, configure CI step (#639)
-- [ ] Shared components — `WineCard`, `EmptyState`, `FilterChips` (render + props variants)
-- [ ] Auth components — `ProtectedRoute` (redirects unauthenticated), `TelegramLoginButton` (renders in Settings, calls link callback)
-- [ ] `UserMenu` — open/close, logout action
+- [x] Shared components — `WineCard`, `FilterChips` (render + props variants)
+- [x] Auth components — `ProtectedRoute` (redirects unauthenticated), `TelegramLoginButton` (widget mount + cleanup)
+- [x] `UserMenu` — logout action, settings nav, admin visibility
+- [ ] `EmptyState` — render + props variants
+- [ ] `WineDetailPanel` — renders wine data, open/close state
 - [ ] `WineDetailPanel` — renders wine data, open/close state
 - [ ] `AppShell` — sidebar collapsed/expanded state
 - [ ] Pages (API-mocked) — `SearchPage`, `WatchesPage`, `SavedStoresPage` (loading state, empty state, populated state)

--- a/docs/ENGINEERING.md
+++ b/docs/ENGINEERING.md
@@ -10,22 +10,7 @@ This file describes **how we build** — tools, patterns, and decisions in place
 
 Unit tests across all services: scraper (products, stores, sitemap, robots), backend (endpoints, services, repositories), bot (handlers, filters, formatters, keyboards), frontend (Vitest + React Testing Library). Alignment tests verify dataclass ↔ model column sync.
 
-Coverage thresholds enforced in CI:
-
-| Service | Threshold | Tool |
-|---------|-----------|------|
-| Backend | ≥83% | pytest-cov |
-| Bot | ≥85% | pytest-cov |
-| Scraper | ≥78% | pytest-cov |
-| Core | — | pytest (no threshold) |
-| Frontend | — | Vitest (no threshold yet) |
-
-Test patterns:
-
-- Python: `pytest` + `pytest-asyncio` + `unittest.mock` (AsyncMock for async services)
-- Frontend: Vitest + React Testing Library
-- Tests co-located with source (`Component.test.tsx`) in frontend, `tests/` directory in Python services
-- Mocked external calls (Anthropic, OpenAI, httpx) — no live API calls in tests
+Standards (naming rules, patterns, coverage thresholds): see `CLAUDE.md` → Testing Standards.
 
 ---
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -16,7 +16,7 @@ function renderApp(route = '/') {
 }
 
 describe('App', () => {
-  it('renders without crashing on /', () => {
+  it('renders the root route', () => {
     const { container } = renderApp('/')
     expect(container.firstChild).toBeTruthy()
   })

--- a/frontend/src/components/EmptyState.test.tsx
+++ b/frontend/src/components/EmptyState.test.tsx
@@ -20,7 +20,7 @@ describe('EmptyState', () => {
     expect(screen.queryByText('Try adding one')).not.toBeInTheDocument()
   })
 
-  it('calls cta onClick when clicked', async () => {
+  it('calls cta.onClick when the CTA button is clicked', async () => {
     const user = userEvent.setup()
     const onClick = vi.fn()
     render(<EmptyState icon={<span>X</span>} title="Empty" cta={{ label: 'Add', onClick }} />)

--- a/frontend/src/components/EmptyState.test.tsx
+++ b/frontend/src/components/EmptyState.test.tsx
@@ -15,7 +15,7 @@ describe('EmptyState', () => {
     expect(screen.getByText('Try adding one')).toBeInTheDocument()
   })
 
-  it('does not render description when omitted', () => {
+  it('omits description when prop is not provided', () => {
     render(<EmptyState icon={<span>X</span>} title="Empty" />)
     expect(screen.queryByText('Try adding one')).not.toBeInTheDocument()
   })

--- a/frontend/src/components/FilterChips.test.tsx
+++ b/frontend/src/components/FilterChips.test.tsx
@@ -34,7 +34,7 @@ describe('FilterChips', () => {
     expect(onChange).toHaveBeenCalledWith('')
   })
 
-  it('renders empty when no options', () => {
+  it('renders no buttons when options array is empty', () => {
     const { container } = render(<FilterChips options={[]} value="" onChange={vi.fn()} />)
     expect(container.querySelectorAll('button')).toHaveLength(0)
   })

--- a/frontend/src/components/FilterChips.test.tsx
+++ b/frontend/src/components/FilterChips.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import FilterChips from './FilterChips'
+
+const OPTIONS = [
+  { label: 'Rouge', value: 'red' },
+  { label: 'Blanc', value: 'white' },
+  { label: 'Rosé', value: 'rose' },
+]
+
+describe('FilterChips', () => {
+  it('renders all options as buttons', () => {
+    render(<FilterChips options={OPTIONS} value="" onChange={vi.fn()} />)
+    expect(screen.getAllByRole('button')).toHaveLength(3)
+    expect(screen.getByText('Rouge')).toBeInTheDocument()
+    expect(screen.getByText('Blanc')).toBeInTheDocument()
+    expect(screen.getByText('Rosé')).toBeInTheDocument()
+  })
+
+  it('calls onChange with value when clicking inactive chip', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<FilterChips options={OPTIONS} value="" onChange={onChange} />)
+    await user.click(screen.getByText('Rouge'))
+    expect(onChange).toHaveBeenCalledWith('red')
+  })
+
+  it('calls onChange with empty string when clicking active chip (deselect)', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<FilterChips options={OPTIONS} value="red" onChange={onChange} />)
+    await user.click(screen.getByText('Rouge'))
+    expect(onChange).toHaveBeenCalledWith('')
+  })
+
+  it('renders empty when no options', () => {
+    const { container } = render(<FilterChips options={[]} value="" onChange={vi.fn()} />)
+    expect(container.querySelectorAll('button')).toHaveLength(0)
+  })
+})

--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router'
+import { MemoryRouter, Route, Routes } from 'react-router'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ProtectedRoute } from './ProtectedRoute'
 
@@ -16,26 +16,34 @@ beforeEach(() => {
 
 function renderProtected() {
   return render(
-    <MemoryRouter>
-      <ProtectedRoute>
-        <div data-testid="protected-content">Secret</div>
-      </ProtectedRoute>
+    <MemoryRouter initialEntries={['/protected']}>
+      <Routes>
+        <Route path="/" element={<div data-testid="home" />} />
+        <Route path="/onboarding" element={<div data-testid="onboarding" />} />
+        <Route
+          path="/protected"
+          element={
+            <ProtectedRoute>
+              <div data-testid="protected-content">Secret</div>
+            </ProtectedRoute>
+          }
+        />
+      </Routes>
     </MemoryRouter>,
   )
 }
 
 describe('ProtectedRoute', () => {
-  it('redirects to / when not authenticated', () => {
+  it('redirects to / when unauthenticated', () => {
     mockUseAuth.mockReturnValue({ token: null } as ReturnType<typeof useAuth>)
     renderProtected()
-    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument()
+    expect(screen.getByTestId('home')).toBeInTheDocument()
   })
 
-  it('redirects to /onboarding when not onboarded', () => {
+  it('redirects to /onboarding when authenticated but not onboarded', () => {
     mockUseAuth.mockReturnValue({ token: 'jwt.token.here' } as ReturnType<typeof useAuth>)
-    // No 'onboarded' in localStorage
     renderProtected()
-    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument()
+    expect(screen.getByTestId('onboarding')).toBeInTheDocument()
   })
 
   it('renders children when authenticated and onboarded', () => {

--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ProtectedRoute } from './ProtectedRoute'
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}))
+
+import { useAuth } from '@/contexts/AuthContext'
+const mockUseAuth = vi.mocked(useAuth)
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+function renderProtected() {
+  return render(
+    <MemoryRouter>
+      <ProtectedRoute>
+        <div data-testid="protected-content">Secret</div>
+      </ProtectedRoute>
+    </MemoryRouter>,
+  )
+}
+
+describe('ProtectedRoute', () => {
+  it('redirects to / when not authenticated', () => {
+    mockUseAuth.mockReturnValue({ token: null } as ReturnType<typeof useAuth>)
+    renderProtected()
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument()
+  })
+
+  it('redirects to /onboarding when not onboarded', () => {
+    mockUseAuth.mockReturnValue({ token: 'jwt.token.here' } as ReturnType<typeof useAuth>)
+    // No 'onboarded' in localStorage
+    renderProtected()
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument()
+  })
+
+  it('renders children when authenticated and onboarded', () => {
+    mockUseAuth.mockReturnValue({ token: 'jwt.token.here' } as ReturnType<typeof useAuth>)
+    localStorage.setItem('onboarded', '1')
+    renderProtected()
+    expect(screen.getByTestId('protected-content')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/TelegramLoginButton.test.tsx
+++ b/frontend/src/components/TelegramLoginButton.test.tsx
@@ -12,7 +12,7 @@ describe('TelegramLoginButton', () => {
     expect(script?.getAttribute('data-size')).toBe('large')
   })
 
-  it('sets lang attribute when provided', () => {
+  it('sets data-lang on the script when lang prop is provided', () => {
     const { container } = render(
       <TelegramLoginButton botUsername="CoupetteBot" onAuth={vi.fn()} lang="fr" />,
     )
@@ -20,14 +20,14 @@ describe('TelegramLoginButton', () => {
     expect(script?.getAttribute('data-lang')).toBe('fr')
   })
 
-  it('registers global callback', () => {
+  it('registers __telegram_login_callback on window', () => {
     render(<TelegramLoginButton botUsername="CoupetteBot" onAuth={vi.fn()} />)
     expect(
       (window as unknown as Record<string, unknown>)['__telegram_login_callback'],
     ).toBeDefined()
   })
 
-  it('cleans up on unmount', () => {
+  it('removes __telegram_login_callback from window on unmount', () => {
     const { unmount } = render(<TelegramLoginButton botUsername="CoupetteBot" onAuth={vi.fn()} />)
     unmount()
     expect(

--- a/frontend/src/components/TelegramLoginButton.test.tsx
+++ b/frontend/src/components/TelegramLoginButton.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { TelegramLoginButton } from './TelegramLoginButton'
+
+describe('TelegramLoginButton', () => {
+  it('appends Telegram widget script to container', () => {
+    const { container } = render(<TelegramLoginButton botUsername="CoupetteBot" onAuth={vi.fn()} />)
+    const script = container.querySelector('script')
+    expect(script).toBeInTheDocument()
+    expect(script?.src).toContain('telegram.org/js/telegram-widget.js')
+    expect(script?.getAttribute('data-telegram-login')).toBe('CoupetteBot')
+    expect(script?.getAttribute('data-size')).toBe('large')
+  })
+
+  it('sets lang attribute when provided', () => {
+    const { container } = render(
+      <TelegramLoginButton botUsername="CoupetteBot" onAuth={vi.fn()} lang="fr" />,
+    )
+    const script = container.querySelector('script')
+    expect(script?.getAttribute('data-lang')).toBe('fr')
+  })
+
+  it('registers global callback', () => {
+    render(<TelegramLoginButton botUsername="CoupetteBot" onAuth={vi.fn()} />)
+    expect(
+      (window as unknown as Record<string, unknown>)['__telegram_login_callback'],
+    ).toBeDefined()
+  })
+
+  it('cleans up on unmount', () => {
+    const { unmount } = render(<TelegramLoginButton botUsername="CoupetteBot" onAuth={vi.fn()} />)
+    unmount()
+    expect(
+      (window as unknown as Record<string, unknown>)['__telegram_login_callback'],
+    ).toBeUndefined()
+  })
+})

--- a/frontend/src/components/UserMenu.test.tsx
+++ b/frontend/src/components/UserMenu.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import '../i18n'
+import UserMenu from './UserMenu'
+
+describe('UserMenu', () => {
+  it('renders display name initial in avatar', () => {
+    render(<UserMenu displayName="Victor" onLogout={vi.fn()} />)
+    expect(screen.getByText('V')).toBeInTheDocument()
+  })
+
+  it('renders ? when display name is null', () => {
+    render(<UserMenu displayName={null} onLogout={vi.fn()} />)
+    expect(screen.getByText('?')).toBeInTheDocument()
+  })
+
+  it('calls onLogout when logout button clicked', async () => {
+    const user = userEvent.setup()
+    const onLogout = vi.fn()
+    render(<UserMenu displayName="Victor" onLogout={onLogout} />)
+    // i18n key: userMenu.logout → "Sign out" (en) / "Déconnexion" (fr)
+    await user.click(screen.getByText(/sign out|déconnexion/i))
+    expect(onLogout).toHaveBeenCalledOnce()
+  })
+
+  it('calls onNavigate with /settings when settings clicked', async () => {
+    const user = userEvent.setup()
+    const onNavigate = vi.fn()
+    render(<UserMenu displayName="Victor" onLogout={vi.fn()} onNavigate={onNavigate} />)
+    await user.click(screen.getByText(/settings|réglages/i))
+    expect(onNavigate).toHaveBeenCalledWith('/settings')
+  })
+
+  it('shows admin link when role is admin', () => {
+    render(<UserMenu displayName="Victor" role="admin" onLogout={vi.fn()} onNavigate={vi.fn()} />)
+    // i18n key: nav.admin → "Console"
+    expect(screen.getByText(/console/i)).toBeInTheDocument()
+  })
+
+  it('hides admin link for regular users', () => {
+    render(<UserMenu displayName="Victor" role="user" onLogout={vi.fn()} />)
+    expect(screen.queryByText(/console/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/WineCard.test.tsx
+++ b/frontend/src/components/WineCard.test.tsx
@@ -66,7 +66,7 @@ describe('WineCard', () => {
     expect(screen.queryByText('Merlot')).not.toBeInTheDocument()
   })
 
-  it('renders category dot for known category', () => {
+  it('renders colored dot for Vin rouge category', () => {
     const { container } = render(<WineCard product={product({ category: 'Vin rouge' })} />)
     const dot = container.querySelector('.bg-red-500\\/80')
     expect(dot).toBeInTheDocument()

--- a/frontend/src/components/WineCard.test.tsx
+++ b/frontend/src/components/WineCard.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import '../i18n'
+import type { ProductOut } from '@/lib/types'
+import WineCard from './WineCard'
+
+function product(overrides: Partial<ProductOut> = {}): ProductOut {
+  return {
+    sku: 'SKU001',
+    name: 'Château Test',
+    category: 'Vin rouge',
+    country: 'France',
+    region: 'Bordeaux',
+    size: '750 ml',
+    price: '24.95',
+    url: 'https://saq.com/SKU001',
+    online_availability: true,
+    store_availability: [],
+    rating: null,
+    review_count: null,
+    appellation: null,
+    designation: null,
+    classification: null,
+    grape: 'Merlot',
+    grape_blend: null,
+    alcohol: '13.5%',
+    sugar: null,
+    producer: null,
+    vintage: '2021',
+    taste_tag: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as ProductOut
+}
+
+describe('WineCard', () => {
+  it('renders wine name and vintage', () => {
+    render(<WineCard product={product()} />)
+    expect(screen.getByText(/Château Test/)).toBeInTheDocument()
+    expect(screen.getByText(/2021/)).toBeInTheDocument()
+  })
+
+  it('renders price', () => {
+    render(<WineCard product={product()} />)
+    expect(screen.getByText('24.95 $')).toBeInTheDocument()
+  })
+
+  it('hides price when null', () => {
+    render(<WineCard product={product({ price: null })} />)
+    expect(screen.queryByText(/\d+\.\d+ \$/)).not.toBeInTheDocument()
+  })
+
+  it('renders origin from region + country', () => {
+    render(<WineCard product={product()} />)
+    expect(screen.getByText('Bordeaux, France')).toBeInTheDocument()
+  })
+
+  it('renders grape variety', () => {
+    render(<WineCard product={product()} />)
+    expect(screen.getByText('Merlot')).toBeInTheDocument()
+  })
+
+  it('hides grape when null', () => {
+    render(<WineCard product={product({ grape: null })} />)
+    expect(screen.queryByText('Merlot')).not.toBeInTheDocument()
+  })
+
+  it('renders category dot for known category', () => {
+    const { container } = render(<WineCard product={product({ category: 'Vin rouge' })} />)
+    const dot = container.querySelector('.bg-red-500\\/80')
+    expect(dot).toBeInTheDocument()
+  })
+
+  it('renders reason when provided', () => {
+    render(<WineCard product={product()} reason="Great with steak" />)
+    expect(screen.getByText('Great with steak')).toBeInTheDocument()
+  })
+
+  it('renders name as link when url present', () => {
+    render(<WineCard product={product()} />)
+    const link = screen.getByRole('link', { name: /Château Test/ })
+    expect(link).toHaveAttribute('href', 'https://saq.com/SKU001')
+    expect(link).toHaveAttribute('target', '_blank')
+  })
+
+  it('renders name as plain text when url is null', () => {
+    render(<WineCard product={product({ url: null })} />)
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.getByText(/Château Test/)).toBeInTheDocument()
+  })
+
+  it('renders user rating when provided', () => {
+    render(<WineCard product={product()} userRating={{ rating: 88, note_id: 1 }} />)
+    expect(screen.getByText(/88/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -154,7 +154,7 @@ describe('updateUser', () => {
     expect(result.current.user?.display_name).toBe('After')
   })
 
-  it('is a no-op when not logged in', () => {
+  it('leaves state unchanged when called while logged out', () => {
     const { result } = renderHook(() => useAuth(), { wrapper })
 
     act(() => result.current.updateUser({ display_name: 'Ghost' }))

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -98,7 +98,7 @@ describe('api', () => {
     expect(onUnauthorized).toHaveBeenCalledOnce()
   })
 
-  it('does not call onUnauthorized on non-401 errors', async () => {
+  it('skips onUnauthorized callback for non-401 errors', async () => {
     const onUnauthorized = vi.fn()
     fetchMock.mockResolvedValueOnce(jsonResponse({ detail: 'Forbidden' }, 403))
 

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { TFunction } from 'i18next'
 import type { ProductOut } from '@/lib/types'
 import { formatOrigin, CATEGORY_DOT, timeAgoPrecise, timeAgo } from './utils'
 
@@ -52,10 +53,11 @@ describe('CATEGORY_DOT', () => {
 
 describe('timeAgoPrecise', () => {
   const NOW = new Date('2026-01-15T12:00:00Z').getTime()
-  const t = vi.fn((key: string, opts?: { count: number }) => `${key}:${opts?.count}`)
+  const tMock = vi.fn((key: string, opts?: { count: number }) => `${key}:${opts?.count}`)
+  const t = tMock as unknown as TFunction
 
   beforeEach(() => {
-    t.mockClear()
+    tMock.mockClear()
     vi.useFakeTimers()
     vi.setSystemTime(NOW)
   })
@@ -63,41 +65,42 @@ describe('timeAgoPrecise', () => {
 
   it('returns minutes for < 60 min', () => {
     timeAgoPrecise('2026-01-15T11:30:00Z', t)
-    expect(t).toHaveBeenCalledWith('time.minutesAgoPrecise', { count: 30 })
+    expect(tMock).toHaveBeenCalledWith('time.minutesAgoPrecise', { count: 30 })
   })
 
   it('clamps to 1 minute minimum', () => {
     timeAgoPrecise('2026-01-15T11:59:50Z', t)
-    expect(t).toHaveBeenCalledWith('time.minutesAgoPrecise', { count: 1 })
+    expect(tMock).toHaveBeenCalledWith('time.minutesAgoPrecise', { count: 1 })
   })
 
   it('returns hours for < 24h', () => {
     timeAgoPrecise('2026-01-15T06:00:00Z', t)
-    expect(t).toHaveBeenCalledWith('time.hoursAgoPrecise', { count: 6 })
+    expect(tMock).toHaveBeenCalledWith('time.hoursAgoPrecise', { count: 6 })
   })
 
   it('returns days for < 30d', () => {
     timeAgoPrecise('2026-01-10T12:00:00Z', t)
-    expect(t).toHaveBeenCalledWith('time.daysAgoPrecise', { count: 5 })
+    expect(tMock).toHaveBeenCalledWith('time.daysAgoPrecise', { count: 5 })
   })
 
   it('returns months for < 12mo', () => {
     timeAgoPrecise('2025-10-15T12:00:00Z', t)
-    expect(t).toHaveBeenCalledWith('time.monthsAgoPrecise', { count: 3 })
+    expect(tMock).toHaveBeenCalledWith('time.monthsAgoPrecise', { count: 3 })
   })
 
   it('returns years for >= 12mo', () => {
     timeAgoPrecise('2024-01-15T12:00:00Z', t)
-    expect(t).toHaveBeenCalledWith('time.yearsAgoPrecise', { count: 2 })
+    expect(tMock).toHaveBeenCalledWith('time.yearsAgoPrecise', { count: 2 })
   })
 })
 
 describe('timeAgo', () => {
   const NOW = new Date('2026-01-15T12:00:00Z').getTime()
-  const t = vi.fn((key: string) => key)
+  const tMock = vi.fn((key: string) => key)
+  const t = tMock as unknown as TFunction
 
   beforeEach(() => {
-    t.mockClear()
+    tMock.mockClear()
     vi.useFakeTimers()
     vi.setSystemTime(NOW)
   })
@@ -105,37 +108,37 @@ describe('timeAgo', () => {
 
   it('returns justNow for < 2 min', () => {
     timeAgo('2026-01-15T11:59:00Z', t)
-    expect(t).toHaveBeenCalledWith('time.justNow')
+    expect(tMock).toHaveBeenCalledWith('time.justNow')
   })
 
   it('returns today for < 24h', () => {
     timeAgo('2026-01-15T06:00:00Z', t)
-    expect(t).toHaveBeenCalledWith('time.today')
+    expect(tMock).toHaveBeenCalledWith('time.today')
   })
 
   it('returns yesterday for < 48h', () => {
     timeAgo('2026-01-14T06:00:00Z', t)
-    expect(t).toHaveBeenCalledWith('time.yesterday')
+    expect(tMock).toHaveBeenCalledWith('time.yesterday')
   })
 
   it('returns pastWeek for < 7d', () => {
     timeAgo('2026-01-10T12:00:00Z', t)
-    expect(t).toHaveBeenCalledWith('time.pastWeek')
+    expect(tMock).toHaveBeenCalledWith('time.pastWeek')
   })
 
   it('returns pastMonth for < 30d', () => {
     timeAgo('2026-01-01T12:00:00Z', t)
-    expect(t).toHaveBeenCalledWith('time.pastMonth')
+    expect(tMock).toHaveBeenCalledWith('time.pastMonth')
   })
 
   it('returns pastYear for < 365d', () => {
     timeAgo('2025-06-15T12:00:00Z', t)
-    expect(t).toHaveBeenCalledWith('time.pastYear')
+    expect(tMock).toHaveBeenCalledWith('time.pastYear')
   })
 
   it('returns formatted date for >= 1 year', () => {
     const result = timeAgo('2024-01-15T12:00:00Z', t)
-    // Falls through to toLocaleDateString — t is not called with a time key
+    // Falls through to toLocaleDateString — tMock is not called with a time key
     expect(result).toContain('2024')
   })
 })

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -27,6 +27,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/setupTests.ts"]
+  "include": ["src"]
 }

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -27,5 +27,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/setupTests.ts"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -7,6 +7,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
   ]
 }

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary

Adds component-level frontend tests and establishes the project's testing standards as documented rules in CLAUDE.md.

## Related issue(s)

No dedicated issue — part of the ongoing frontend test coverage work tracked in `docs/ENGINEERING.md`.

## Changes

**Tests — new files:**
- `ProtectedRoute.test.tsx` — redirect destinations verified via real Routes (unauthenticated → `/`, not onboarded → `/onboarding`, both → children)
- `FilterChips.test.tsx` — render, select, deselect, empty array
- `WineCard.test.tsx` — name/vintage, price, origin, grape, category dot, reason, link vs plain text, user rating (11 tests)
- `UserMenu.test.tsx` — avatar initial, logout, settings nav, admin visibility
- `TelegramLoginButton.test.tsx` — script mount, data-lang attribute, global callback registration, cleanup on unmount

**Tests — existing files corrected:**
- All `describe` + `it` names across all 12 test files reviewed and aligned to naming standards (active voice, outcome-focused, no "does not / happy_path / valid_input")
- `utils.test.ts` — fixed real type error: `vi.fn()` mock split into `tMock` (Mock interface) + `t` (cast to `TFunction`) so both assertions and function calls are correctly typed

**Config:**
- `tsconfig.app.json` — restored test file exclusions so `yarn build` does not type-check tests
- `tsconfig.test.json` — new file extending app config, includes test files; VS Code uses this for IDE type support in test files
- `tsconfig.json` — references `tsconfig.test.json` so the IDE discovers it

**Docs:**
- `CLAUDE.md` — new "Testing Standards" section: naming rules, behavior vs implementation, test anatomy, coverage targets (single source of truth)
- `docs/ENGINEERING.md` — removed duplicate coverage table and test pattern list; now cross-references CLAUDE.md

## How to test

```bash
cd frontend && yarn test
cd frontend && yarn build
```

Both must pass with 0 errors.