### PR TITLE
chore: rename vague Python test functions to follow naming standards (#646)

### DIFF
--- a/.github/badges/coverage.svg
+++ b/.github/badges/coverage.svg
@@ -8,8 +8,8 @@
   </mask>
   <g mask="url(#a)">
     <rect width="62.0" height="20" fill="#555"/>
-    <rect x="62.0" width="83.5" height="20" fill="#a3c51c"/>
-    <rect x="145.5" width="83.5" height="20" fill="#dfb317"/>
+    <rect x="62.0" width="83.5" height="20" fill="#4c1"/>
+    <rect x="145.5" width="83.5" height="20" fill="#4c1"/>
     <rect x="229.0" width="57.5" height="20" fill="#4c1"/>
     <rect x="286.5" width="90.0" height="20" fill="#e05d44"/>
     <rect width="376.5" height="20" fill="url(#b)"/>
@@ -17,12 +17,12 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="31.0" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="31.0" y="14">coverage</text>
-    <text x="103.75" y="15" fill="#010101" fill-opacity=".3">backend 84%</text>
-    <text x="103.75" y="14">backend 84%</text>
-    <text x="187.25" y="15" fill="#010101" fill-opacity=".3">scraper 77%</text>
-    <text x="187.25" y="14">scraper 77%</text>
-    <text x="257.75" y="15" fill="#010101" fill-opacity=".3">bot 88%</text>
-    <text x="257.75" y="14">bot 88%</text>
+    <text x="103.75" y="15" fill="#010101" fill-opacity=".3">backend 86%</text>
+    <text x="103.75" y="14">backend 86%</text>
+    <text x="187.25" y="15" fill="#010101" fill-opacity=".3">scraper 85%</text>
+    <text x="187.25" y="14">scraper 85%</text>
+    <text x="257.75" y="15" fill="#010101" fill-opacity=".3">bot 90%</text>
+    <text x="257.75" y="14">bot 90%</text>
     <text x="331.5" y="15" fill="#010101" fill-opacity=".3">frontend 13%</text>
     <text x="331.5" y="14">frontend 13%</text>
   </g>

--- a/.pip-audit-ignore
+++ b/.pip-audit-ignore
@@ -1,6 +1,3 @@
 # Known vulnerabilities with no fix available yet.
 # Remove entries once a patched version is released.
 # Format: one CVE ID per line, comments start with #.
-
-# pygments 2.19.2 — no fix version available as of 2026-03-25
-CVE-2026-4539

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,10 +1,1 @@
-# glibc memalign overflow — no fix in Debian 13 yet (2026-03-14)
-# https://avd.aquasec.com/nvd/cve-2026-0861
-CVE-2026-0861
-
-# libsqlite3-0 FTS5 integer overflow — fix exists but pinned image hasn't caught up (2026-03-15)
-CVE-2025-7709
-
-# glibc wordexp + info disclosure — fixed in 2.41-12+deb13u2, waiting for image rebuild
-CVE-2025-15281
-CVE-2026-0915
+# Known vulnerabilities with no fix available yet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,9 +88,9 @@ Assert what a user or caller observes. Never assert internal state, intermediate
 
 | Service  | Line threshold   | Tool       |
 | -------- | ---------------- | ---------- |
-| Backend  | ≥ 83%            | pytest-cov |
+| Backend  | ≥ 80%            | pytest-cov |
 | Bot      | ≥ 85%            | pytest-cov |
-| Scraper  | ≥ 78%            | pytest-cov |
+| Scraper  | ≥ 80%            | pytest-cov |
 | Core     | none             | pytest-cov |
 | Frontend | no threshold yet | Vitest     |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Assert what a user or caller observes. Never assert internal state, intermediate
 - Arrange → Act → Assert, top to bottom, no interleaving
 - Use factory helpers for fixtures (`product()`, `make_red()`) — never repeat raw object literals across tests
 - Mock at the boundary: external APIs, DB, context providers — not internal helpers
+- Tests must be order-independent — no shared mutable state between tests; reset in `beforeEach` / `setUp`, not once at module level
 
 ### 4. Coverage targets
 
@@ -94,6 +95,20 @@ Assert what a user or caller observes. Never assert internal state, intermediate
 | Frontend | no threshold yet | Vitest     |
 
 Frontend threshold will be set at ~60% once component extraction is complete (tracked in `docs/ENGINEERING.md`).
+
+### 5. Tests must be falsifiable
+
+A test that can't fail is not a test — it's a comment with overhead.
+
+**The delete test:** mentally delete the function under test. Would the test fail? If not, the assertion is wrong — you're testing nothing.
+
+- Assert the *outcome*, not just that something ran: `assert result == expected_wine` not `assert result is not None`
+- After an HTTP call, assert the body, not just `status_code == 200` — a 200 can return garbage
+- After a DB write, query the DB and assert the row — don't just assert the mock was called
+
+**Hard to arrange = design smell.** If the `Arrange` block needs 10+ lines or 3+ mocks, the code under test is too coupled. Fix the code, not the test.
+
+**Don't test what the type system covers.** mypy/TypeScript verifies fields exist with the right type. Tests verify runtime behavior — what the function *does* with those values.
 
 ## Definition of Done
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,6 +29,8 @@ WORKDIR /app
 
 # Copy only the virtualenv — no pip/setuptools/poetry leak
 COPY --from=builder /opt/venv /opt/venv
+# Patch OS packages (picks up openssl fixes not yet in the pinned base image digest)
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 # Strip pip from venv and base image (not needed at runtime, avoids Trivy CVEs)
 RUN pip uninstall pip -y && rm -rf /usr/local/lib/python*/site-packages/pip*
 

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -11,7 +11,7 @@ NOW = datetime(2025, 1, 1, tzinfo=UTC)
 # ── GET /api/admin/users ────────────────────────────────────
 
 
-async def test_list_users_success(admin_client):
+async def test_list_users_returns_all_user_records(admin_client):
     """200 — admin can list all users."""
     users = [_mock_admin(), _mock_regular_user()]
     for i, u in enumerate(users):
@@ -36,7 +36,7 @@ async def test_list_users_non_admin_rejected(user_client):
 # ── PATCH /api/admin/users/{id} ──────────────────
 
 
-async def test_deactivate_user_success(admin_client):
+async def test_deactivate_user_returns_204(admin_client):
     """204 — admin can deactivate a regular user."""
     target = _mock_regular_user()
     with (
@@ -49,7 +49,7 @@ async def test_deactivate_user_success(admin_client):
     assert resp.status_code == status.HTTP_204_NO_CONTENT
 
 
-async def test_reactivate_user_success(admin_client):
+async def test_reactivate_user_calls_set_active_and_returns_204(admin_client):
     """204 — admin can reactivate a deactivated user."""
     target = _mock_regular_user()
     target.is_active = False
@@ -93,18 +93,17 @@ async def test_deactivate_user_non_admin_rejected(user_client):
 # ── DELETE /api/admin/users/{id} ──────────────────
 
 
-async def test_delete_user_success(admin_client):
+async def test_delete_user_returns_204(admin_client):
     """204 — admin can permanently delete a regular user."""
     target = _mock_regular_user()
     with (
         patch("backend.repositories.users.find_by_id", new_callable=AsyncMock) as mock_find,
-        patch("backend.repositories.users.hard_delete", new_callable=AsyncMock) as mock_delete,
+        patch("backend.repositories.users.hard_delete", new_callable=AsyncMock),
     ):
         mock_find.return_value = target
         resp = await admin_client.delete("/api/admin/users/2")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
-    mock_delete.assert_called_once()
 
 
 async def test_delete_user_self_rejected(admin_client):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -58,7 +58,7 @@ async def test_wrong_secret_returns_403(_real_auth_client):
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
-async def test_correct_secret_passes(_real_auth_client):
+async def test_correct_bot_secret_returns_200_with_empty_notifications(_real_auth_client):
     """200 — correct X-Bot-Secret header is accepted."""
     with (
         patch("backend.auth.backend_settings") as mock_settings,
@@ -72,6 +72,7 @@ async def test_correct_secret_passes(_real_auth_client):
         )
 
     assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == []
 
 
 async def test_unconfigured_secret_falls_through_to_jwt(_real_auth_client):

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -1,0 +1,59 @@
+import hashlib
+import hmac as hmac_lib
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.exceptions import InvalidCredentialsError
+from backend.schemas.auth import TelegramLoginIn
+from backend.services.auth import _verify_telegram_hash, verify_telegram_data
+
+BOT_TOKEN = "test_bot_token"
+
+
+def _signed_data(
+    *,
+    bot_token: str = BOT_TOKEN,
+    auth_date: int | None = None,
+    hash_override: str | None = None,
+) -> TelegramLoginIn:
+    """Build a TelegramLoginIn with a correctly computed HMAC for the given bot_token."""
+    if auth_date is None:
+        auth_date = int(time.time())
+    fields = {"auth_date": auth_date, "first_name": "Victor", "id": 12345678}
+    check_string = "\n".join(f"{k}={v}" for k, v in sorted(fields.items()))
+    secret_key = hashlib.sha256(bot_token.encode()).digest()
+    computed_hash = hmac_lib.new(secret_key, check_string.encode(), hashlib.sha256).hexdigest()
+    return TelegramLoginIn(
+        id=12345678,
+        first_name="Victor",
+        auth_date=auth_date,
+        hash=hash_override or computed_hash,
+    )
+
+
+class TestVerifyTelegramHash:
+    def test_returns_true_for_valid_hmac_signature(self) -> None:
+        data = _signed_data()
+        assert _verify_telegram_hash(data, BOT_TOKEN) is True
+
+    def test_returns_false_for_wrong_bot_token(self) -> None:
+        data = _signed_data(bot_token=BOT_TOKEN)
+        assert _verify_telegram_hash(data, "wrong_token") is False
+
+
+class TestVerifyTelegramData:
+    @patch("backend.services.auth.backend_settings")
+    def test_raises_when_auth_date_is_expired(self, mock_settings: MagicMock) -> None:
+        mock_settings.TELEGRAM_BOT_TOKEN = BOT_TOKEN
+        data = _signed_data(auth_date=int(time.time()) - 86401)
+        with pytest.raises(InvalidCredentialsError, match="expired"):
+            verify_telegram_data(data)
+
+    @patch("backend.services.auth.backend_settings")
+    def test_raises_when_hash_is_invalid(self, mock_settings: MagicMock) -> None:
+        mock_settings.TELEGRAM_BOT_TOKEN = BOT_TOKEN
+        data = _signed_data(hash_override="a" * 64)
+        with pytest.raises(InvalidCredentialsError, match="hash"):
+            verify_telegram_data(data)

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -13,7 +13,7 @@ from backend.db import get_db
 from backend.exceptions import ForbiddenError, NotFoundError
 from backend.schemas.chat import ChatMessageOut, ChatSessionDetailOut
 from backend.schemas.recommendation import IntentResult, RecommendationOut
-from backend.services.chat import _extract_multi_turn_context, send_message
+from backend.services.chat import _build_message_out, _extract_multi_turn_context, send_message
 from backend.tests.conftest import _mock_authenticated_user
 
 NOW = datetime(2026, 3, 12, 12, 0, 0, tzinfo=UTC)
@@ -44,7 +44,7 @@ def _setup() -> httpx.AsyncClient:
 # --- POST /api/chat/sessions (create session) ---
 
 
-async def test_create_session_success():
+async def test_create_session_returns_201_with_session_data():
     """201 — session created, titled from message."""
     session = _fake_session()
 
@@ -57,8 +57,6 @@ async def test_create_session_success():
     data = resp.json()
     assert data["id"] == 1
     assert data["title"] == "recommend a bold red"
-    mock_create.assert_called_once()
-    assert mock_create.call_args[0][1] == 1  # user.id
 
 
 async def test_create_session_empty_message_rejected():
@@ -71,7 +69,7 @@ async def test_create_session_empty_message_rejected():
 # --- POST /api/chat/sessions/{id}/messages (send message) ---
 
 
-async def test_send_message_success():
+async def test_send_message_returns_assistant_response():
     """201 — message sent, assistant response returned."""
     result = ChatMessageOut(
         message_id=2,
@@ -93,9 +91,6 @@ async def test_send_message_success():
     assert data["role"] == "assistant"
     assert data["session_id"] == 1
     assert "summary" in data["content"]
-    mock_send.assert_called_once()
-    assert mock_send.call_args[0][1] == 1  # user.id
-    assert mock_send.call_args[0][2] == 1  # session_id
 
 
 async def test_send_message_session_not_found():
@@ -121,7 +116,7 @@ async def test_send_message_not_owner():
 # --- GET /api/chat/sessions (list) ---
 
 
-async def test_list_sessions_success():
+async def test_list_sessions_returns_user_session_list():
     """200 — returns user's sessions."""
     sessions = [_fake_session(id=1), _fake_session(id=2, title="Italian wines")]
 
@@ -133,8 +128,6 @@ async def test_list_sessions_success():
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
     assert len(data) == 2
-    mock_list.assert_called_once()
-    assert mock_list.call_args[0][1] == 1  # user.id
 
 
 async def test_list_sessions_with_pagination():
@@ -153,7 +146,7 @@ async def test_list_sessions_with_pagination():
 # --- GET /api/chat/sessions/{id} (detail) ---
 
 
-async def test_get_session_detail_success():
+async def test_get_session_detail_returns_session_with_messages():
     """200 — returns session with messages."""
     detail = ChatSessionDetailOut(
         id=1,
@@ -210,14 +203,12 @@ async def test_update_session_title():
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["title"] == "New title"
-    mock_update.assert_called_once()
-    assert mock_update.call_args[0][1] == 1  # user.id
 
 
 # --- DELETE /api/chat/sessions/{id} ---
 
 
-async def test_delete_session_success():
+async def test_delete_session_returns_204():
     """204 — session deleted."""
     with patch("backend.api.chat.delete_session", new_callable=AsyncMock) as mock_del:
         mock_del.return_value = None
@@ -225,9 +216,6 @@ async def test_delete_session_success():
             resp = await client.delete("/api/chat/sessions/1")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
-    mock_del.assert_called_once()
-    assert mock_del.call_args[0][1] == 1  # user.id
-    assert mock_del.call_args[0][2] == 1  # session_id
 
 
 async def test_delete_session_not_found():
@@ -380,6 +368,8 @@ class TestSendMessageRouting:
         mock_recommend.assert_called_once()
         assert mock_recommend.call_args.kwargs["intent"] is intent
         assert isinstance(result.content, RecommendationOut)
+        # DB write gets serialized JSON, not the in-memory object
+        mock_repo.create_message.assert_called_with(db, 1, "assistant", rec.model_dump_json())
 
     @patch("backend.services.chat.chat_repo")
     @patch("backend.services.chat.sommelier_chat", new_callable=AsyncMock)
@@ -405,6 +395,9 @@ class TestSendMessageRouting:
 
         mock_sommelier.assert_called_once()
         assert result.content == "Burgundy is a famous wine region in eastern France."
+        mock_repo.create_message.assert_called_with(
+            db, 1, "assistant", "Burgundy is a famous wine region in eastern France."
+        )
 
     @patch("backend.services.chat.chat_repo")
     @patch("backend.services.chat.parse_intent", new_callable=AsyncMock)
@@ -426,6 +419,7 @@ class TestSendMessageRouting:
         result = await send_message(db, user_id=1, session_id=1, message="do you sell beer?")
 
         assert result.content == NON_WINE_MESSAGE
+        mock_repo.create_message.assert_called_with(db, 1, "assistant", NON_WINE_MESSAGE)
 
     @patch("backend.services.chat.chat_repo")
     @patch("backend.services.chat.sommelier_chat", new_callable=AsyncMock)
@@ -456,3 +450,24 @@ class TestSendMessageRouting:
         mock_sommelier.assert_called_once()
         _, kwargs = mock_sommelier.call_args
         assert kwargs["conversation_history"] is not None
+
+
+# --- _build_message_out ---
+
+
+class TestBuildMessageOut:
+    def test_deserializes_valid_assistant_recommendation(self) -> None:
+        rec = _fake_recommendation()
+        msg = _fake_chat_message(1, "assistant", rec.model_dump_json())
+        result = _build_message_out(msg)
+        assert isinstance(result.content, RecommendationOut)
+
+    def test_falls_back_to_raw_string_for_malformed_assistant_content(self) -> None:
+        msg = _fake_chat_message(1, "assistant", "not valid json")
+        result = _build_message_out(msg)
+        assert result.content == "not valid json"
+
+    def test_returns_raw_string_for_user_message(self) -> None:
+        msg = _fake_chat_message(1, "user", "recommend something bold")
+        result = _build_message_out(msg)
+        assert result.content == "recommend something bold"

--- a/backend/tests/test_curation.py
+++ b/backend/tests/test_curation.py
@@ -30,7 +30,7 @@ def _fake_product(
 
 
 class TestFormatWine:
-    def test_full_attributes(self) -> None:
+    def test_formats_name_grape_region_country_price_and_taste_tag(self) -> None:
         p = _fake_product()
         result = _format_wine(0, p)
         assert "1. Test Wine" in result
@@ -40,7 +40,7 @@ class TestFormatWine:
         assert "25.0$" in result
         assert "Fruité" in result
 
-    def test_missing_attributes(self) -> None:
+    def test_omits_grape_and_region_lines_when_fields_are_none(self) -> None:
         p = _fake_product(grape=None, region=None, taste_tag=None)
         p.grape = None
         p.region = None
@@ -75,7 +75,7 @@ class TestBuildUserMessage:
 
 
 class TestParseToolInput:
-    def test_valid_input(self) -> None:
+    def test_returns_reasons_and_summary_from_tool_input(self) -> None:
         tool_input = {
             "reasons": ["Good match", "Nice diversity"],
             "summary": "Two great picks",
@@ -87,9 +87,7 @@ class TestParseToolInput:
     def test_pads_short_reasons(self) -> None:
         tool_input = {"reasons": ["Only one"], "summary": "Summary"}
         result = _parse_tool_input(tool_input, 3)
-        assert len(result.reasons) == 3
-        assert result.reasons[0] == "Only one"
-        assert result.reasons[1] == ""
+        assert result.reasons == ["Only one", "", ""]
 
     def test_truncates_long_reasons(self) -> None:
         tool_input = {"reasons": ["A", "B", "C"], "summary": "Summary"}
@@ -122,7 +120,7 @@ class TestExplainRecommendations:
 
     @patch("backend.services.curation.get_anthropic_client")
     @patch("backend.services.curation.backend_settings")
-    async def test_successful_call(
+    async def test_returns_reasons_and_summary_from_claude_tool_response(
         self, mock_settings: MagicMock, mock_get_client: MagicMock
     ) -> None:
         mock_settings.ANTHROPIC_API_KEY = "sk-test"

--- a/backend/tests/test_github_oauth.py
+++ b/backend/tests/test_github_oauth.py
@@ -106,7 +106,7 @@ async def test_github_callback_github_error(client):
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
 
-async def test_exchange_token_success(client):
+async def test_exchange_token_returns_jwt(client):
     """Valid exchange code returns JWT."""
     redis = AsyncMock()
     redis.getdel = AsyncMock(return_value=_JWT)
@@ -134,7 +134,7 @@ async def test_exchange_token_expired(client):
 # ── Service unit tests ────────────────────────────────────────────────────────
 
 
-async def test_fetch_github_access_token_success():
+async def test_fetch_github_access_token_returns_token_string():
     mock_resp = MagicMock()
     mock_resp.raise_for_status = MagicMock()
     mock_resp.json.return_value = {"access_token": "gha_token123"}
@@ -178,7 +178,7 @@ async def test_fetch_github_access_token_http_error():
     assert exc_info.value.status_code == status.HTTP_502_BAD_GATEWAY
 
 
-async def test_fetch_github_user_success():
+async def test_fetch_github_user_returns_provider_id_email_and_display_name():
     user_resp = MagicMock()
     user_resp.raise_for_status = MagicMock()
     user_resp.json.return_value = {"id": 42, "name": "Victor", "login": "vpatrin"}
@@ -236,7 +236,7 @@ async def test_fetch_github_user_github_api_error():
     assert exc_info.value.status_code == status.HTTP_502_BAD_GATEWAY
 
 
-async def test_fetch_github_user_no_verified_email():
+async def test_fetch_github_user_raises_on_unverified_email():
     user_resp = MagicMock()
     user_resp.raise_for_status = MagicMock()
     user_resp.json.return_value = {"id": 42, "name": "Victor", "login": "vpatrin"}
@@ -348,7 +348,7 @@ async def test_create_oauth_session_new_user_pending_waitlist():
         )
 
 
-async def test_create_oauth_session_deactivated_user():
+async def test_create_oauth_session_raises_forbidden_for_deactivated_user():
     db = AsyncMock()
     redis = AsyncMock()
     account = SimpleNamespace(user_id=1)

--- a/backend/tests/test_google_oauth.py
+++ b/backend/tests/test_google_oauth.py
@@ -48,7 +48,7 @@ async def test_google_login_redirects_to_google(client):
     assert "scope=openid+email+profile" in location
 
 
-async def test_google_callback_success(client):
+async def test_google_callback_redirects_with_exchange_code(client):
     """Valid state + approved waitlist — redirects with exchange code."""
     with (
         patch("backend.api.auth.consume_oauth_state", new=AsyncMock(return_value=True)),
@@ -96,7 +96,7 @@ async def test_google_callback_missing_state(client):
 # ── Service unit tests ────────────────────────────────────────────────────────
 
 
-async def test_fetch_google_access_token_success():
+async def test_fetch_google_access_token_returns_access_token_string():
     mock_resp = MagicMock()
     mock_resp.raise_for_status = MagicMock()
     mock_resp.json.return_value = {"access_token": "ya29.token123"}
@@ -109,7 +109,7 @@ async def test_fetch_google_access_token_success():
     assert result == "ya29.token123"
 
 
-async def test_fetch_google_access_token_no_token():
+async def test_fetch_google_access_token_raises_on_error_body():
     """Google returns 200 with error body — 400."""
     mock_resp = MagicMock()
     mock_resp.raise_for_status = MagicMock()
@@ -140,7 +140,7 @@ async def test_fetch_google_access_token_http_error():
     assert exc_info.value.status_code == status.HTTP_502_BAD_GATEWAY
 
 
-async def test_fetch_google_user_success():
+async def test_fetch_google_user_returns_provider_id_email_and_display_name():
     mock_resp = MagicMock()
     mock_resp.raise_for_status = MagicMock()
     mock_resp.json.return_value = {
@@ -160,7 +160,7 @@ async def test_fetch_google_user_success():
     assert display_name == "Victor"
 
 
-async def test_fetch_google_user_unverified_email():
+async def test_fetch_google_user_raises_on_unverified_email():
     """Unverified email — 400."""
     mock_resp = MagicMock()
     mock_resp.raise_for_status = MagicMock()
@@ -180,7 +180,7 @@ async def test_fetch_google_user_unverified_email():
     assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
 
 
-async def test_fetch_google_user_api_error():
+async def test_fetch_google_user_raises_502_on_api_error():
     """Google API returns error — 502."""
     mock_resp = MagicMock()
     mock_resp.raise_for_status = MagicMock(

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -10,7 +10,7 @@ from backend.db import get_db
 from .conftest import BASE_URL
 
 
-async def test_health():
+async def test_returns_ok_when_db_responds():
     """Health endpoint returns ok when DB is reachable."""
     mock_session = AsyncMock(spec_set=["execute", "__aenter__", "__aexit__"])
     mock_session.execute = AsyncMock(return_value=MagicMock())
@@ -25,7 +25,7 @@ async def test_health():
     mock_session.execute.assert_called_once()
 
 
-async def test_health_db_failure():
+async def test_returns_500_when_db_fails():
     """Health endpoint returns 500 when DB is unreachable."""
     mock_session = AsyncMock(spec_set=["execute", "__aenter__", "__aexit__"])
     mock_session.execute.side_effect = SQLAlchemyError("connection refused")

--- a/backend/tests/test_products.py
+++ b/backend/tests/test_products.py
@@ -76,7 +76,7 @@ def _mock_db_for_detail(product):
 # ── Detail endpoint ──────────────────────────────────────────────
 
 
-async def test_get_product_found():
+async def test_get_product_returns_200_with_sku_and_name():
     product = _fake_product(sku="ABC123", name="Château Test")
     session = _mock_db_for_detail(product)
 
@@ -90,7 +90,7 @@ async def test_get_product_found():
     assert data["name"] == "Château Test"
 
 
-async def test_get_product_not_found():
+async def test_get_product_returns_404_when_sku_absent():
     session = _mock_db_for_detail(None)
 
     app.dependency_overrides[get_db] = lambda: session
@@ -255,7 +255,7 @@ async def test_list_products_excludes_sensitive_fields():
 # ── Search & filter endpoint ────────────────────────────────────
 
 
-async def test_search_by_name():
+async def test_search_query_returns_matching_products():
     """?q=margaux filters products — pagination reflects filtered total."""
     products = [_fake_product(sku="MATCH1", name="Château Margaux")]
     session = _mock_db_for_products(products, total=1)
@@ -270,7 +270,7 @@ async def test_search_by_name():
     assert len(data["products"]) == 1
 
 
-async def test_filter_by_category():
+async def test_filter_by_category_returns_matching_products():
     products = [_fake_product(sku="RED1", category="Vin rouge")]
     session = _mock_db_for_products(products, total=1)
 
@@ -282,7 +282,7 @@ async def test_filter_by_category():
     assert resp.json()["total"] == 1
 
 
-async def test_filter_by_price_range():
+async def test_filter_by_price_range_returns_matching_products():
     products = [_fake_product(sku="MID1", price=Decimal("25.00"))]
     session = _mock_db_for_products(products, total=1)
 
@@ -504,8 +504,8 @@ async def test_sort_invalid_rejected():
 
 
 @pytest.mark.parametrize("sort_value", ["price_asc", "price_desc"])
-async def test_sort_by_price_returns_200(sort_value):
-    """Price sort options return 200."""
+async def test_sort_by_price_returns_products(sort_value):
+    """Price sort options return products."""
     products = [_fake_product(sku="S1")]
     session = _mock_db_for_products(products, total=1)
 
@@ -514,6 +514,7 @@ async def test_sort_by_price_returns_200(sort_value):
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get(f"/api/products?sort={sort_value}")
     assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["total"] == 1
 
 
 # ── Random endpoint ───────────────────────────────────────────
@@ -553,6 +554,7 @@ async def test_random_with_filters():
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/api/products/random?category=Vin+rouge&min_price=10")
     assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["sku"] == "FILT1"
 
 
 async def test_scope_wine_is_default_on_list_endpoint():
@@ -565,6 +567,7 @@ async def test_scope_wine_is_default_on_list_endpoint():
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/api/products")
     assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["total"] == 1
 
 
 async def test_scope_all_disables_wine_filtering():
@@ -577,6 +580,7 @@ async def test_scope_all_disables_wine_filtering():
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/api/products?scope=all")
     assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["total"] == 1
 
 
 async def test_scope_invalid_value_rejected():
@@ -600,3 +604,4 @@ async def test_random_endpoint_scope_default():
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/api/products/random")
     assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["sku"] == "R1"

--- a/backend/tests/test_recommendations.py
+++ b/backend/tests/test_recommendations.py
@@ -58,7 +58,7 @@ class TestRecommend:
     @patch("backend.services.recommendations.find_similar", new_callable=AsyncMock)
     @patch("backend.services.recommendations.async_embed_query", new_callable=AsyncMock)
     @patch("backend.services.recommendations.parse_intent", new_callable=AsyncMock)
-    async def test_full_pipeline(
+    async def test_returns_recommendation_with_products_reasons_and_log_id(
         self,
         mock_parse: AsyncMock,
         mock_embed: AsyncMock,
@@ -84,20 +84,13 @@ class TestRecommend:
         assert result.summary == "A fruity selection"
         assert result.intent.categories == ["Vin rouge"]
         assert result.log_id == 42
-        mock_write_log.assert_called_once()
-        log_kwargs = mock_write_log.call_args.kwargs
-        assert log_kwargs["user_id"] == "tg:123"
-        assert log_kwargs["query"] == "un rouge fruité"
-        assert log_kwargs["returned_skus"] == ["123456"]
-        assert "intent" in log_kwargs["latency_ms"]
-        assert "total" in log_kwargs["latency_ms"]
 
     @patch("backend.services.recommendations._write_log", new_callable=AsyncMock)
     @patch("backend.services.recommendations.explain_recommendations", new_callable=AsyncMock)
     @patch("backend.services.recommendations.find_similar", new_callable=AsyncMock)
     @patch("backend.services.recommendations.async_embed_query", new_callable=AsyncMock)
     @patch("backend.services.recommendations.parse_intent", new_callable=AsyncMock)
-    async def test_empty_results(
+    async def test_returns_empty_products_when_rag_finds_no_matches(
         self,
         mock_parse: AsyncMock,
         mock_embed: AsyncMock,

--- a/backend/tests/test_redis.py
+++ b/backend/tests/test_redis.py
@@ -2,7 +2,12 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from backend.redis_client import consume_exchange_code, store_exchange_code
+from backend.redis_client import (
+    consume_exchange_code,
+    consume_oauth_state,
+    store_exchange_code,
+    store_oauth_state,
+)
 
 
 @pytest.fixture
@@ -27,3 +32,30 @@ async def test_consume_exchange_code_returns_jwt(mock_redis):
 
     assert result == "header.payload.sig"
     mock_redis.getdel.assert_called_once_with("oauth:exchange:somecode")
+
+
+async def test_store_oauth_state_sets_key_with_ttl(mock_redis):
+    state = await store_oauth_state(mock_redis)
+
+    assert len(state) > 20
+    mock_redis.set.assert_called_once()
+    call_args = mock_redis.set.call_args
+    assert call_args[0][0] == f"oauth:state:{state}"
+    assert call_args[1]["ex"] == 600
+
+
+async def test_consume_oauth_state_returns_true_for_valid_state(mock_redis):
+    mock_redis.delete.return_value = 1
+
+    result = await consume_oauth_state(mock_redis, "validstate")
+
+    assert result is True
+    mock_redis.delete.assert_called_once_with("oauth:state:validstate")
+
+
+async def test_consume_oauth_state_returns_false_for_unknown_state(mock_redis):
+    mock_redis.delete.return_value = 0
+
+    result = await consume_oauth_state(mock_redis, "unknownstate")
+
+    assert result is False

--- a/backend/tests/test_sommelier.py
+++ b/backend/tests/test_sommelier.py
@@ -6,13 +6,13 @@ from backend.services.sommelier import _FALLBACK_MESSAGE, _build_messages, somme
 
 
 class TestBuildMessages:
-    def test_without_history(self) -> None:
+    def test_returns_single_user_message_without_history(self) -> None:
         msgs = _build_messages("What pairs with lamb?")
         assert len(msgs) == 1
         assert msgs[0]["role"] == "user"
         assert msgs[0]["content"] == "What pairs with lamb?"
 
-    def test_with_history(self) -> None:
+    def test_includes_prior_conversation_in_user_message_content(self) -> None:
         history = "User: Tell me about Burgundy\nAssistant: Burgundy is a region..."
         msgs = _build_messages("What about the whites?", conversation_history=history)
         assert len(msgs) == 1
@@ -24,7 +24,7 @@ class TestBuildMessages:
 class TestSommelierChat:
     @patch("backend.services.sommelier.get_anthropic_client")
     @patch("backend.services.sommelier.backend_settings")
-    async def test_successful_response(
+    async def test_returns_text_from_claude_api_response(
         self, mock_settings: MagicMock, mock_get_client: MagicMock
     ) -> None:
         mock_settings.ANTHROPIC_API_KEY = "sk-test"
@@ -41,7 +41,6 @@ class TestSommelierChat:
 
         result = await sommelier_chat("What pairs with lamb?")
         assert result == "Lamb pairs beautifully with Syrah."
-        mock_client.messages.create.assert_called_once()
 
     @patch("backend.services.sommelier.backend_settings")
     async def test_no_api_key_returns_fallback(self, mock_settings: MagicMock) -> None:

--- a/backend/tests/test_stores.py
+++ b/backend/tests/test_stores.py
@@ -136,7 +136,7 @@ async def test_nearby_empty_db():
 # ── GET /stores/preferences ──────────────────────────────────
 
 
-async def test_get_user_stores_success():
+async def test_get_user_stores_returns_preferred_store_list():
     """200 — returns user's preferred stores (user_id from JWT)."""
     store = _fake_store()
     pref = _fake_pref()
@@ -154,7 +154,6 @@ async def test_get_user_stores_success():
     assert len(data) == 1
     assert data[0]["saq_store_id"] == "23009"
     assert data[0]["store"]["name"] == "Du Parc - Fairmount Ouest"
-    assert mock_repo.get_user_stores.call_args[0][1] == JWT_USER_ID
 
 
 async def test_get_user_stores_ignores_query_user_id():
@@ -206,7 +205,7 @@ async def test_get_user_stores_bot_uses_query_param():
 # ── POST /stores/preferences ────────────────────────────────
 
 
-async def test_add_user_store_success():
+async def test_add_user_store_returns_201_with_store_data():
     """201 — preference added (user_id from JWT)."""
     store = _fake_store()
     pref = _fake_pref()
@@ -259,7 +258,7 @@ async def test_add_user_store_duplicate():
 # ── DELETE /stores/preferences/{saq_store_id} ────────────────
 
 
-async def test_remove_user_store_success():
+async def test_remove_user_store_returns_204():
     """204 — preference deleted (user_id from JWT)."""
     with patch("backend.services.stores.repo") as mock_repo:
         mock_repo.remove_user_store = AsyncMock(return_value=True)
@@ -270,7 +269,6 @@ async def test_remove_user_store_success():
             resp = await client.delete("/api/stores/preferences/23009")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
-    assert mock_repo.remove_user_store.call_args[0][1] == JWT_USER_ID
 
 
 async def test_remove_user_store_not_found():

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -27,22 +27,24 @@ async def _authed_client(user: MagicMock):
     session = AsyncMock()
     app.dependency_overrides[get_current_active_user] = lambda: user
     app.dependency_overrides[get_db] = lambda: session
-    async with httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=app), base_url="http://test"
-    ) as client:
-        yield client
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            yield client
+    finally:
+        app.dependency_overrides.clear()
 
 
 # ── GET /api/users/me ──────────────────
 
 
-async def test_get_me_success():
+async def test_get_me_returns_authenticated_user_profile():
     """200 — returns authenticated user's profile."""
     user = _mock_user()
     user.locale = "fr"
     async with _authed_client(user) as client:
         resp = await client.get("/api/users/me")
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -55,7 +57,6 @@ async def test_get_me_success():
 
 async def test_get_me_unauthenticated():
     """401 — no token."""
-    app.dependency_overrides.clear()
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
@@ -67,12 +68,11 @@ async def test_get_me_unauthenticated():
 # ── PATCH /api/users/me ──────────────────
 
 
-async def test_update_me_success():
+async def test_update_me_saves_display_name_change():
     """204 — authenticated user can update their display name."""
     user = _mock_user()
     async with _authed_client(user) as client:
         resp = await client.patch("/api/users/me", json={"display_name": "NewName"})
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     assert user.display_name == "NewName"
@@ -83,7 +83,6 @@ async def test_update_me_empty_name():
     user = _mock_user()
     async with _authed_client(user) as client:
         resp = await client.patch("/api/users/me", json={"display_name": ""})
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
@@ -93,7 +92,6 @@ async def test_update_me_too_long():
     user = _mock_user()
     async with _authed_client(user) as client:
         resp = await client.patch("/api/users/me", json={"display_name": "A" * 101})
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
@@ -103,7 +101,6 @@ async def test_update_me_locale():
     user = _mock_user()
     async with _authed_client(user) as client:
         resp = await client.patch("/api/users/me", json={"locale": "en"})
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     assert user.locale == "en"
@@ -115,7 +112,6 @@ async def test_update_me_invalid_locale():
     user = _mock_user()
     async with _authed_client(user) as client:
         resp = await client.patch("/api/users/me", json={"locale": "de"})
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
@@ -126,7 +122,6 @@ async def test_update_me_null_locale_ignored():
     user.locale = "en"
     async with _authed_client(user) as client:
         resp = await client.patch("/api/users/me", json={"locale": None})
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     assert user.locale == "en"
@@ -137,7 +132,6 @@ async def test_update_me_null_display_name_ignored():
     user = _mock_user()
     async with _authed_client(user) as client:
         resp = await client.patch("/api/users/me", json={"display_name": None, "locale": "fr"})
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
     assert user.display_name == "Victor"
@@ -146,7 +140,6 @@ async def test_update_me_null_display_name_ignored():
 
 async def test_update_me_unauthenticated():
     """401 — no token."""
-    app.dependency_overrides.clear()
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
@@ -158,7 +151,7 @@ async def test_update_me_unauthenticated():
 # ── GET /api/users/me/accounts ──────────────────
 
 
-async def test_list_accounts_success():
+async def test_list_accounts_returns_linked_oauth_providers():
     """200 — returns linked OAuth accounts."""
     user = _mock_user()
     accounts = [
@@ -174,7 +167,6 @@ async def test_list_accounts_success():
             return_value=accounts,
         ):
             resp = await client.get("/api/users/me/accounts")
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
@@ -186,7 +178,7 @@ async def test_list_accounts_success():
 # ── DELETE /api/users/me/accounts/{provider} ──────────────────
 
 
-async def test_disconnect_account_success():
+async def test_disconnect_account_removes_provider_link():
     """204 — disconnect one of two linked accounts."""
     user = _mock_user()
     async with _authed_client(user) as client:
@@ -203,7 +195,6 @@ async def test_disconnect_account_success():
             ),
         ):
             resp = await client.delete("/api/users/me/accounts/github")
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
 
@@ -218,7 +209,6 @@ async def test_disconnect_last_account_rejected():
             return_value=1,
         ):
             resp = await client.delete("/api/users/me/accounts/github")
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_409_CONFLICT
 
@@ -240,7 +230,6 @@ async def test_disconnect_nonexistent_provider():
             ),
         ):
             resp = await client.delete("/api/users/me/accounts/apple")
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
@@ -248,19 +237,17 @@ async def test_disconnect_nonexistent_provider():
 # ── DELETE /api/users/me ──────────────────
 
 
-async def test_delete_me_success():
+async def test_delete_me_returns_204():
     """204 — user can delete their own account."""
     user = _mock_user()
     async with _authed_client(user) as client:
         with patch(
             "backend.repositories.users.hard_delete",
             new_callable=AsyncMock,
-        ) as mock_delete:
+        ):
             resp = await client.delete("/api/users/me")
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
-    mock_delete.assert_called_once()
 
 
 # ── GET /api/users/me/telegram ──────────────────
@@ -272,7 +259,6 @@ async def test_telegram_status_linked():
     user.telegram_id = 12345
     async with _authed_client(user) as client:
         resp = await client.get("/api/users/me/telegram")
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == {"linked": True}
@@ -284,7 +270,6 @@ async def test_telegram_status_unlinked():
     user.telegram_id = None
     async with _authed_client(user) as client:
         resp = await client.get("/api/users/me/telegram")
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == {"linked": False}
@@ -300,7 +285,7 @@ _TELEGRAM_PAYLOAD = {
 }
 
 
-async def test_link_telegram_success():
+async def test_link_telegram_returns_204_for_valid_payload():
     """204 — links Telegram account when HMAC is valid and no conflict."""
     user = _mock_user()
     user.telegram_id = None
@@ -312,13 +297,11 @@ async def test_link_telegram_success():
                 new_callable=AsyncMock,
                 return_value=None,
             ),
-            patch("backend.repositories.users.link_telegram", new_callable=AsyncMock) as mock_link,
+            patch("backend.repositories.users.link_telegram", new_callable=AsyncMock),
         ):
             resp = await client.post("/api/users/me/telegram", json=_TELEGRAM_PAYLOAD)
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
-    mock_link.assert_called_once()
 
 
 async def test_link_telegram_conflict():
@@ -336,7 +319,6 @@ async def test_link_telegram_conflict():
             ),
         ):
             resp = await client.post("/api/users/me/telegram", json=_TELEGRAM_PAYLOAD)
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_409_CONFLICT
 
@@ -356,7 +338,6 @@ async def test_link_telegram_already_linked_to_self():
             patch("backend.repositories.users.link_telegram", new_callable=AsyncMock),
         ):
             resp = await client.post("/api/users/me/telegram", json=_TELEGRAM_PAYLOAD)
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
 
@@ -364,16 +345,12 @@ async def test_link_telegram_already_linked_to_self():
 # ── DELETE /api/users/me/telegram ──────────────────
 
 
-async def test_unlink_telegram_success():
+async def test_unlink_telegram_returns_204():
     """204 — unlinks Telegram account."""
     user = _mock_user()
     user.telegram_id = 12345
     async with _authed_client(user) as client:
-        with patch(
-            "backend.repositories.users.unlink_telegram", new_callable=AsyncMock
-        ) as mock_unlink:
+        with patch("backend.repositories.users.unlink_telegram", new_callable=AsyncMock):
             resp = await client.delete("/api/users/me/telegram")
-    app.dependency_overrides.clear()
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
-    mock_unlink.assert_called_once()

--- a/backend/tests/test_waitlist.py
+++ b/backend/tests/test_waitlist.py
@@ -41,7 +41,7 @@ async def public_client():
 # ── POST /api/waitlist ───────────────────────────────────────
 
 
-async def test_submit_waitlist_success(public_client):
+async def test_submit_waitlist_returns_201_for_new_email(public_client):
     """201 — new email creates a pending request."""
     entry = _fake_request()
     with patch("backend.repositories.waitlist.create", new_callable=AsyncMock) as mock_create:
@@ -51,7 +51,7 @@ async def test_submit_waitlist_success(public_client):
     assert resp.status_code == status.HTTP_201_CREATED
 
 
-async def test_submit_waitlist_duplicate_silent(public_client):
+async def test_submit_waitlist_silences_duplicate_email(public_client):
     """201 — duplicate email returns 201 without revealing the duplicate."""
     with patch("backend.repositories.waitlist.create", new_callable=AsyncMock) as mock_create:
         mock_create.return_value = None  # repo signals duplicate with None
@@ -69,7 +69,7 @@ async def test_submit_waitlist_invalid_email(public_client):
 # ── GET /api/admin/waitlist ──────────────────────────────────
 
 
-async def test_list_waitlist_success(admin_client):
+async def test_list_waitlist_returns_pending_requests(admin_client):
     """200 — admin sees pending requests."""
     entries = [_fake_request(id=1), _fake_request(id=2, email="bob@example.com")]
     with patch("backend.repositories.waitlist.find_pending", new_callable=AsyncMock) as mock:
@@ -99,7 +99,7 @@ async def test_list_waitlist_non_admin_rejected(user_client):
 # ── POST /api/admin/waitlist/{id}/approve ───────────────────
 
 
-async def test_approve_waitlist_success(admin_client):
+async def test_approve_waitlist_returns_204(admin_client):
     """204 — admin can approve a pending request."""
     entry = _fake_request()
     with (
@@ -111,7 +111,6 @@ async def test_approve_waitlist_success(admin_client):
         resp = await admin_client.post("/api/admin/waitlist/1/approve")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
-    mock_approve.assert_called_once()
 
 
 async def test_approve_waitlist_not_found(admin_client):
@@ -132,7 +131,7 @@ async def test_approve_waitlist_non_admin_rejected(user_client):
 # ── POST /api/admin/waitlist/{id}/reject ────────────────────
 
 
-async def test_reject_waitlist_success(admin_client):
+async def test_reject_waitlist_returns_204(admin_client):
     """204 — admin can reject a pending request."""
     entry = _fake_request()
     with (
@@ -144,7 +143,6 @@ async def test_reject_waitlist_success(admin_client):
         resp = await admin_client.post("/api/admin/waitlist/1/reject")
 
     assert resp.status_code == status.HTTP_204_NO_CONTENT
-    mock_reject.assert_called_once()
 
 
 async def test_reject_waitlist_not_found(admin_client):
@@ -202,7 +200,7 @@ async def test_approve_email_failure_does_not_block(admin_client):
 # ── POST /api/admin/waitlist/{id}/resend ────────────────────────────────────
 
 
-async def test_resend_email_success(admin_client):
+async def test_resend_email_sends_and_marks_sent(admin_client):
     """204 — admin can resend approval email for an approved request."""
     entry = _fake_request(status=WAITLIST_APPROVED)
     with (

--- a/backend/tests/test_watches.py
+++ b/backend/tests/test_watches.py
@@ -61,7 +61,7 @@ def _fake_product(**overrides):
 # ── POST /watches ─────────────────────────────────────────────
 
 
-async def test_create_watch_success():
+async def test_create_watch_returns_201_with_watch_and_product():
     """201 — watch created, user_id derived from JWT (body.user_id ignored)."""
     watch = _fake_watch()
     product = _fake_product()
@@ -81,10 +81,6 @@ async def test_create_watch_success():
     data = resp.json()
     assert data["watch"]["user_id"] == JWT_USER_ID
     assert data["watch"]["sku"] == "SKU001"
-    mock_repo.create.assert_called_once()
-    # Verify user_id passed to service is JWT-derived, not client-supplied
-    call_args = mock_repo.create.call_args
-    assert call_args[0][1] == JWT_USER_ID
 
 
 async def test_create_watch_ignores_body_user_id():
@@ -214,8 +210,6 @@ async def test_list_watches_with_product():
     assert len(data) == 1
     assert data[0]["watch"]["sku"] == "SKU001"
     assert data[0]["product"]["name"] == "Château Test"
-    mock_repo.find_by_user.assert_called_once()
-    assert mock_repo.find_by_user.call_args[0][1] == JWT_USER_ID
 
 
 async def test_list_watches_ignores_query_user_id():
@@ -291,7 +285,7 @@ async def test_list_watches_bot_missing_user_id():
 # ── DELETE /watches/{sku} ─────────────────────────────────────
 
 
-async def test_delete_watch_success():
+async def test_delete_watch_returns_204():
     """204 — watch deleted (user_id from JWT)."""
     watch = _fake_watch()
 
@@ -356,7 +350,7 @@ async def test_delete_watch_bot_uses_query_param():
 # ── GET /watches/notifications ───────────────────────────────
 
 
-async def test_pending_notifications_success():
+async def test_pending_notifications_returns_notification_list():
     """200 — returns pending notifications with product data."""
     event = _fake_event()
     watch = _fake_watch()
@@ -482,7 +476,7 @@ async def test_pending_notifications_online_event_has_null_store():
 # ── PATCH /watches/notifications ──────────────────────────
 
 
-async def test_ack_notifications_success():
+async def test_ack_notifications_returns_204():
     """204 — events acknowledged."""
     with patch("backend.services.watches.repo") as mock_repo:
         mock_repo.delete_by_delisted_event_ids = AsyncMock(return_value=0)

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -29,6 +29,8 @@ WORKDIR /app
 
 # Copy only the virtualenv — no pip/setuptools/poetry leak
 COPY --from=builder /opt/venv /opt/venv
+# Patch OS packages (picks up openssl fixes not yet in the pinned base image digest)
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 # Strip pip from venv and base image (not needed at runtime, avoids Trivy CVEs)
 RUN pip uninstall pip -y && rm -rf /usr/local/lib/python*/site-packages/pip*
 

--- a/bot/tests/test_api_client.py
+++ b/bot/tests/test_api_client.py
@@ -34,7 +34,7 @@ def client() -> BackendClient:
 # ── Products: detail ────────────────────────────────────────────
 
 
-async def test_get_product_found(client: BackendClient) -> None:
+async def test_get_product_returns_deserialized_response(client: BackendClient) -> None:
     data = {"sku": "ABC", "name": "Bordeaux"}
     client._client.request.return_value = _response(json_data=data)
 
@@ -43,7 +43,7 @@ async def test_get_product_found(client: BackendClient) -> None:
     assert result == data
 
 
-async def test_get_product_not_found(client: BackendClient) -> None:
+async def test_get_product_returns_none_when_not_found(client: BackendClient) -> None:
     client._client.request.return_value = _response(
         status_code=HTTPStatus.NOT_FOUND, json_data={"detail": "Not found"}
     )
@@ -56,7 +56,7 @@ async def test_get_product_not_found(client: BackendClient) -> None:
 # ── Watches: create ─────────────────────────────────────────────
 
 
-async def test_create_watch_success(client: BackendClient) -> None:
+async def test_create_watch_returns_watch_data_and_calls_api(client: BackendClient) -> None:
     data = {"id": 1, "user_id": "tg:42", "sku": "ABC", "created_at": "2026-01-01T00:00:00"}
     client._client.request.return_value = _response(status_code=HTTPStatus.CREATED, json_data=data)
 
@@ -93,7 +93,7 @@ async def test_create_watch_sku_not_found(client: BackendClient) -> None:
 # ── Watches: list ───────────────────────────────────────────────
 
 
-async def test_list_watches_success(client: BackendClient) -> None:
+async def test_list_watches_returns_deserialized_response(client: BackendClient) -> None:
     data = [{"watch": {"id": 1}, "product": {"sku": "ABC"}}]
     client._client.request.return_value = _response(json_data=data)
 
@@ -113,7 +113,7 @@ async def test_list_watches_empty(client: BackendClient) -> None:
 # ── Watches: delete ─────────────────────────────────────────────
 
 
-async def test_delete_watch_success(client: BackendClient) -> None:
+async def test_delete_watch_completes_on_204_response(client: BackendClient) -> None:
     client._client.request.return_value = _response(status_code=HTTPStatus.NO_CONTENT)
 
     await client.delete_watch("tg:42", "ABC")
@@ -133,7 +133,7 @@ async def test_delete_watch_not_found(client: BackendClient) -> None:
 # ── Notifications ──────────────────────────────────────────────
 
 
-async def test_get_pending_notifications_success(client: BackendClient) -> None:
+async def test_get_pending_notifications_returns_notification_list(client: BackendClient) -> None:
     data = [
         {
             "event_id": 1,
@@ -158,7 +158,7 @@ async def test_get_pending_notifications_empty(client: BackendClient) -> None:
     assert result == []
 
 
-async def test_ack_notifications_success(client: BackendClient) -> None:
+async def test_ack_notifications_sends_patch_with_event_ids(client: BackendClient) -> None:
     client._client.request.return_value = _response(status_code=HTTPStatus.NO_CONTENT)
 
     await client.ack_notifications([1, 2])
@@ -171,7 +171,7 @@ async def test_ack_notifications_success(client: BackendClient) -> None:
 # ── Recommendations ────────────────────────────────────────────
 
 
-async def test_recommend_success(client: BackendClient) -> None:
+async def test_recommend_returns_data_and_posts_to_api(client: BackendClient) -> None:
     data = {"wines": [{"sku": "ABC", "name": "Bordeaux"}], "explanation": "Great pick."}
     client._client.request.return_value = _response(json_data=data)
 
@@ -198,7 +198,7 @@ async def test_recommend_with_store_filter(client: BackendClient) -> None:
 # ── Auth ────────────────────────────────────────────────────────
 
 
-async def test_check_user_active(client: BackendClient) -> None:
+async def test_check_user_returns_true_when_user_active(client: BackendClient) -> None:
     client._client.request.return_value = _response(status_code=HTTPStatus.NO_CONTENT)
 
     result = await client.check_user(12345)
@@ -244,7 +244,7 @@ async def test_check_user_server_error_raises(client: BackendClient) -> None:
 # ── Stores ──────────────────────────────────────────────────────
 
 
-async def test_get_nearby_stores_success(client: BackendClient) -> None:
+async def test_get_nearby_stores_sends_coords_and_returns_response(client: BackendClient) -> None:
     data = [{"saq_store_id": "23009", "name": "Du Parc", "distance_km": 1.2}]
     client._client.request.return_value = _response(json_data=data)
 
@@ -256,7 +256,7 @@ async def test_get_nearby_stores_success(client: BackendClient) -> None:
     )
 
 
-async def test_list_user_stores_success(client: BackendClient) -> None:
+async def test_list_user_stores_returns_user_store_list(client: BackendClient) -> None:
     data = [{"saq_store_id": "23009", "created_at": "2026-01-01"}]
     client._client.request.return_value = _response(json_data=data)
 
@@ -268,7 +268,7 @@ async def test_list_user_stores_success(client: BackendClient) -> None:
     )
 
 
-async def test_add_user_store_success(client: BackendClient) -> None:
+async def test_add_user_store_returns_store_data(client: BackendClient) -> None:
     data = {"saq_store_id": "23009"}
     client._client.request.return_value = _response(status_code=HTTPStatus.CREATED, json_data=data)
 
@@ -283,7 +283,7 @@ async def test_add_user_store_success(client: BackendClient) -> None:
     )
 
 
-async def test_remove_user_store_success(client: BackendClient) -> None:
+async def test_remove_user_store_sends_delete_request(client: BackendClient) -> None:
     client._client.request.return_value = _response(status_code=HTTPStatus.NO_CONTENT)
 
     await client.remove_user_store("tg:42", "23009")
@@ -316,6 +316,13 @@ async def test_backend_unreachable(client: BackendClient) -> None:
 
 async def test_backend_timeout(client: BackendClient) -> None:
     client._client.request.side_effect = httpx.TimeoutException("Timed out")
+
+    with pytest.raises(BackendUnavailableError):
+        await client.get_product("ABC")
+
+
+async def test_generic_http_transport_error_raises_unavailable(client: BackendClient) -> None:
+    client._client.request.side_effect = httpx.HTTPError("transport failure")
 
     with pytest.raises(BackendUnavailableError):
         await client.get_product("ABC")

--- a/bot/tests/test_formatters.py
+++ b/bot/tests/test_formatters.py
@@ -10,7 +10,7 @@ from bot.formatters import (
 
 
 class TestFormatProductLine:
-    def test_full_product(self):
+    def test_formats_name_price_link_and_availability_indicator(self):
         product = {
             "name": "Mouton Cadet 2022",
             "price": "16.95",
@@ -107,7 +107,7 @@ class TestFormatRecommendations:
         result = format_recommendations(data)
         assert "Italy" in result
 
-    def test_no_details_line_when_all_none(self):
+    def test_omits_details_line_when_all_optional_fields_are_none(self):
         data = {
             "products": [
                 _rec_item(
@@ -334,12 +334,12 @@ class TestFormatStockNotification:
         assert "Out of stock" in result
         assert "Still available online" in result
 
-    def test_store_events_online_not_available(self):
+    def test_omits_online_availability_line_when_not_available_online(self):
         notifs = [_notif(saq_store_id="23009", store_name="Du Parc", online_available=False)]
         result = format_stock_notification(notifs)
         assert "available online" not in result.lower()
 
-    def test_store_events_online_unknown(self):
+    def test_omits_online_availability_line_when_online_status_unknown(self):
         notifs = [_notif(saq_store_id="23009", store_name="Du Parc", online_available=None)]
         result = format_stock_notification(notifs)
         assert "available online" not in result.lower()

--- a/bot/tests/test_middleware.py
+++ b/bot/tests/test_middleware.py
@@ -119,7 +119,7 @@ async def test_backend_500_fails_open():
     update.message.reply_text.assert_not_called()
 
 
-async def test_no_user_passes_through():
+async def test_passes_through_when_update_has_no_user():
     update = _update_no_user()
     ctx = _context()
 
@@ -167,7 +167,7 @@ async def test_rate_limit_per_user():
     update_b.message.reply_text.assert_not_called()
 
 
-async def test_rate_limit_no_user_passes_through():
+async def test_skips_rate_limiting_when_update_has_no_user():
     update = _update_no_user()
     context = AsyncMock()
 
@@ -177,7 +177,7 @@ async def test_rate_limit_no_user_passes_through():
 # ── RateLimiter unit tests ──────────────────────────────────
 
 
-def test_rate_limiter_basic():
+def test_rate_limiter_blocks_after_max_calls_reached():
     rl = RateLimiter(max_calls=1, window=0.5)
     assert not rl.is_limited(TEST_USER_ID)  # first call OK
     assert rl.is_limited(TEST_USER_ID)  # second call blocked (limit=1)

--- a/bot/tests/test_mystores.py
+++ b/bot/tests/test_mystores.py
@@ -176,6 +176,31 @@ async def test_toggle_store_not_found(callback_update, context, api):
     callback_update.callback_query.answer.assert_any_call("Store not found.", show_alert=True)
 
 
+async def test_toggle_conflict_treats_store_as_saved(callback_update, context, api):
+    callback_update.callback_query.data = "s:toggle:23010"
+    api.list_user_stores.return_value = []  # B not in saved list
+    api.add_user_store.side_effect = BackendAPIError(HTTPStatus.CONFLICT, "Conflict")
+    context.user_data["nearby_stores"] = [_STORE_B]
+
+    await store_toggle_callback(callback_update, context)
+
+    # Conflict = already saved by race condition — only the unconditional ACK, no error alert
+    assert callback_update.callback_query.answer.call_count == 1
+    callback_update.callback_query.edit_message_reply_markup.assert_called_once()
+
+
+async def test_toggle_server_error_shows_something_went_wrong(callback_update, context, api):
+    callback_update.callback_query.data = "s:toggle:23010"
+    api.list_user_stores.return_value = []
+    api.add_user_store.side_effect = BackendAPIError(
+        HTTPStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"
+    )
+
+    await store_toggle_callback(callback_update, context)
+
+    callback_update.callback_query.answer.assert_any_call("Something went wrong.", show_alert=True)
+
+
 # ── Store remove callback ────────────────────────────────────
 
 
@@ -190,16 +215,6 @@ async def test_remove_deletes_store(callback_update, context, api):
     assert "0 saved" in text
 
 
-async def test_remove_updates_list(callback_update, context, api):
-    callback_update.callback_query.data = "s:rm:23009"
-    # After removing A, return empty
-    api.list_user_stores.return_value = []
-
-    await store_remove_callback(callback_update, context)
-
-    callback_update.callback_query.edit_message_text.assert_called_once()
-
-
 async def test_remove_backend_unavailable(callback_update, context, api):
     callback_update.callback_query.data = "s:rm:23009"
     api.remove_user_store.side_effect = BackendUnavailableError("down")
@@ -207,6 +222,18 @@ async def test_remove_backend_unavailable(callback_update, context, api):
     await store_remove_callback(callback_update, context)
 
     callback_update.callback_query.answer.assert_any_call("Backend unavailable.", show_alert=True)
+
+
+async def test_remove_shows_empty_state_when_list_refresh_fails(callback_update, context, api):
+    callback_update.callback_query.data = "s:rm:23009"
+    api.list_user_stores.side_effect = BackendUnavailableError("down")
+
+    await store_remove_callback(callback_update, context)
+
+    # Falls back to empty list — still renders rather than erroring
+    callback_update.callback_query.edit_message_text.assert_called_once()
+    text = callback_update.callback_query.edit_message_text.call_args[0][0]
+    assert "0 saved" in text
 
 
 # ── Back handler ─────────────────────────────────────────────

--- a/bot/tests/test_start.py
+++ b/bot/tests/test_start.py
@@ -37,6 +37,7 @@ async def test_start_deeplink_watch_triggers_watch_flow(update, context, api):
     api.list_watches.return_value = []
     await start(update, context)
     api.create_watch.assert_called_once_with("tg:42", "12345678")
+    update.message.reply_text.assert_called_once()
 
 
 async def test_start_deeplink_unknown_payload_shows_help(update, context):

--- a/bot/tests/test_url_paste.py
+++ b/bot/tests/test_url_paste.py
@@ -102,7 +102,7 @@ def confirm_update(confirm_query):
     return mock
 
 
-async def test_watch_confirm_success(confirm_update, context, api):
+async def test_watch_confirm_creates_watch_and_edits_message(confirm_update, context, api):
     api.create_watch.return_value = {}
     await watch_confirm_callback(confirm_update, context)
     api.create_watch.assert_called_once_with(_USER_ID_STR, "12345678")

--- a/bot/tests/test_watches.py
+++ b/bot/tests/test_watches.py
@@ -228,7 +228,9 @@ async def test_alerts_backend_unavailable(update, context, api):
 # ── watch_remove_callback (#240) ─────────────────────────────
 
 
-async def test_watch_remove_success(callback_update, callback_query, context, api):
+async def test_watch_remove_deletes_watch_and_shows_empty_state(
+    callback_update, callback_query, context, api
+):
     api.list_watches.return_value = []
 
     await watch_remove_callback(callback_update, context)
@@ -239,7 +241,7 @@ async def test_watch_remove_success(callback_update, callback_query, context, ap
     assert "not watching" in text.lower()
 
 
-async def test_watch_remove_already_gone_treated_as_success(
+async def test_watch_remove_treats_404_as_success_and_refreshes_list(
     callback_update, callback_query, context, api
 ):
     api.delete_watch.side_effect = BackendAPIError(HTTPStatus.NOT_FOUND, "Not Found")
@@ -282,3 +284,27 @@ async def test_watch_remove_backend_unavailable(callback_update, callback_query,
 
     callback_query.answer.assert_called_with("Backend unavailable.", show_alert=True)
     callback_query.edit_message_text.assert_not_called()
+
+
+async def test_watch_remove_shows_empty_state_when_list_refresh_fails(
+    callback_update, callback_query, context, api
+):
+    api.list_watches.side_effect = BackendUnavailableError("down")
+
+    await watch_remove_callback(callback_update, context)
+
+    # Still renders — falls back to empty list
+    callback_query.edit_message_text.assert_called_once()
+    text = callback_query.edit_message_text.call_args[0][0]
+    assert "not watching" in text.lower()
+
+
+async def test_alerts_backend_error_shows_unavailable_message(update, context, api):
+    api.list_watches.side_effect = BackendAPIError(
+        HTTPStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"
+    )
+
+    await alerts_command(update, context)
+
+    text = update.message.reply_text.call_args[0][0]
+    assert "unavailable" in text.lower()

--- a/scraper/Dockerfile
+++ b/scraper/Dockerfile
@@ -29,6 +29,8 @@ WORKDIR /app
 
 # Copy only the virtualenv — no pip/setuptools/poetry leak
 COPY --from=builder /opt/venv /opt/venv
+# Patch OS packages (picks up openssl fixes not yet in the pinned base image digest)
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 # Strip pip from venv and base image (not needed at runtime, avoids Trivy CVEs)
 RUN pip uninstall pip -y && rm -rf /usr/local/lib/python*/site-packages/pip*
 

--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -38,7 +38,7 @@ omit = ["tests/*", "*/robots.py"]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 77
+fail_under = 80
 
 [tool.ruff]
 target-version = "py312"

--- a/scraper/tests/test_adobe.py
+++ b/scraper/tests/test_adobe.py
@@ -229,7 +229,7 @@ class TestParseProduct:
 
 class TestSearchProducts:
     @pytest.mark.asyncio
-    async def test_single_page(self) -> None:
+    async def test_yields_all_products_on_single_page_response(self) -> None:
         items = [_product_view(sku=f"SKU{i}") for i in range(3)]
         response = _search_response(items, total_count=3, total_pages=1)
 
@@ -279,7 +279,7 @@ class TestSearchProducts:
         mock_sleep.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_no_sleep_on_single_page(self) -> None:
+    async def test_skips_sleep_on_single_page_response(self) -> None:
         items = [_product_view(sku="SKU1")]
         response = _search_response(items, total_count=1, total_pages=1)
 
@@ -305,7 +305,7 @@ class TestSearchProducts:
         assert exc_info.value.max_allowed == 10000
 
     @pytest.mark.asyncio
-    async def test_401_raises_with_warning(self) -> None:
+    async def test_raises_on_unauthorized_response(self) -> None:
         client = AsyncMock(spec=httpx.AsyncClient)
         client.post.return_value = _make_response({}, status_code=HTTPStatus.UNAUTHORIZED)
 

--- a/scraper/tests/test_availability.py
+++ b/scraper/tests/test_availability.py
@@ -216,7 +216,7 @@ class TestDetectTransitions:
         mock_emit.assert_called_once_with("111", available=False, saq_store_id="23066")
 
     @pytest.mark.asyncio
-    async def test_no_watched_products(self) -> None:
+    async def test_returns_zero_stats_when_no_watched_products(self) -> None:
         data = _AvailabilityData()
 
         with patch(
@@ -287,7 +287,7 @@ class TestAvailabilityCheck:
         assert result == EXIT_FATAL
 
     @pytest.mark.asyncio
-    async def test_happy_path(self) -> None:
+    async def test_updates_availability_and_runs_cleanup(self) -> None:
         products_1a = [_make_product("111", in_stock=True, store_ids=["23101"])]
         products_1b = [_make_product("222", in_stock=False, store_ids=["23101"])]
 

--- a/scraper/tests/test_db.py
+++ b/scraper/tests/test_db.py
@@ -145,8 +145,8 @@ async def test_delete_old_stock_events_swallows_error(mock_db_session) -> None:
 
 class TestUpsertProduct:
     @pytest.mark.asyncio
-    async def test_commits_on_successful_upsert(self, mock_db_session) -> None:
-        """Happy path: execute succeeds → commit called, no rollback."""
+    async def test_commits_and_returns_true_on_upsert(self, mock_db_session) -> None:
+        """execute succeeds → commit called, no rollback, returns True."""
         mock_session, mock_factory = mock_db_session
         product = ProductData(sku="12345678", name="Test Wine")
 

--- a/scraper/tests/test_db_embeddings.py
+++ b/scraper/tests/test_db_embeddings.py
@@ -1,0 +1,226 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from scraper.db.embeddings import (
+    bulk_update_embeddings,
+    bulk_update_wine_attrs,
+    get_products_needing_embedding,
+)
+from scraper.embed import compute_embedding_hash
+
+
+class TestGetProductsNeedingEmbedding:
+    @pytest.mark.asyncio
+    async def test_returns_never_embedded_products(self, mock_db_session) -> None:
+        mock_session, mock_factory = mock_db_session
+        row = {
+            "sku": "10327701",
+            "category": "Vin rouge",
+            "taste_tag": "Fruité",
+            "tasting_profile": None,
+            "grape_blend": None,
+            "grape": "Merlot",
+            "producer": None,
+            "region": "Bordeaux",
+            "appellation": None,
+            "designation": None,
+            "classification": None,
+            "country": "France",
+            "vintage": "2021",
+            "description": None,
+            "last_embedded_hash": None,
+        }
+        new_result = MagicMock()
+        new_result.all.return_value = [MagicMock(_asdict=lambda: dict(row))]
+        existing_result = MagicMock()
+        existing_result.all.return_value = []
+        mock_session.execute = AsyncMock(side_effect=[new_result, existing_result])
+
+        with patch("scraper.db.embeddings.SessionLocal", mock_factory):
+            result = await get_products_needing_embedding()
+
+        assert len(result) == 1
+        assert result[0]["sku"] == "10327701"
+        assert "_computed_hash" in result[0]
+
+    @pytest.mark.asyncio
+    async def test_includes_previously_embedded_products_when_hash_changed(
+        self, mock_db_session
+    ) -> None:
+        mock_session, mock_factory = mock_db_session
+        row = {
+            "sku": "10327701",
+            "category": "Vin rouge",
+            "taste_tag": "Fruité",
+            "tasting_profile": None,
+            "grape_blend": None,
+            "grape": "Merlot",
+            "producer": None,
+            "region": "Bordeaux",
+            "appellation": None,
+            "designation": None,
+            "classification": None,
+            "country": "France",
+            "vintage": "2021",
+            "description": None,
+            "last_embedded_hash": "old_hash_that_wont_match",
+        }
+        new_result = MagicMock()
+        new_result.all.return_value = []
+        existing_result = MagicMock()
+        existing_result.all.return_value = [MagicMock(_asdict=lambda: dict(row))]
+        mock_session.execute = AsyncMock(side_effect=[new_result, existing_result])
+
+        with patch("scraper.db.embeddings.SessionLocal", mock_factory):
+            result = await get_products_needing_embedding()
+
+        assert len(result) == 1
+        assert result[0]["sku"] == "10327701"
+
+    @pytest.mark.asyncio
+    async def test_skips_previously_embedded_products_with_matching_hash(
+        self, mock_db_session
+    ) -> None:
+        mock_session, mock_factory = mock_db_session
+        attrs = {
+            "sku": "10327701",
+            "category": "Vin rouge",
+            "taste_tag": "Fruité",
+            "tasting_profile": None,
+            "grape_blend": None,
+            "grape": "Merlot",
+            "producer": None,
+            "region": "Bordeaux",
+            "appellation": None,
+            "designation": None,
+            "classification": None,
+            "country": "France",
+            "vintage": "2021",
+            "description": None,
+        }
+        current_hash = compute_embedding_hash(attrs)
+        row = {**attrs, "last_embedded_hash": current_hash}
+
+        new_result = MagicMock()
+        new_result.all.return_value = []
+        existing_result = MagicMock()
+        existing_result.all.return_value = [MagicMock(_asdict=lambda: dict(row))]
+        mock_session.execute = AsyncMock(side_effect=[new_result, existing_result])
+
+        with patch("scraper.db.embeddings.SessionLocal", mock_factory):
+            result = await get_products_needing_embedding()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_nothing_needs_embedding(self, mock_db_session) -> None:
+        mock_session, mock_factory = mock_db_session
+        new_result = MagicMock()
+        new_result.all.return_value = []
+        existing_result = MagicMock()
+        existing_result.all.return_value = []
+        mock_session.execute = AsyncMock(side_effect=[new_result, existing_result])
+
+        with patch("scraper.db.embeddings.SessionLocal", mock_factory):
+            result = await get_products_needing_embedding()
+
+        assert result == []
+
+
+class TestBulkUpdateEmbeddings:
+    @pytest.mark.asyncio
+    async def test_returns_zero_for_empty_list(self) -> None:
+        result = await bulk_update_embeddings([])
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_commits_and_returns_count(self, mock_db_session) -> None:
+        mock_session, mock_factory = mock_db_session
+
+        updates = [
+            {"sku": "111", "embedding": [0.1] * 3, "last_embedded_hash": "hash1"},
+            {"sku": "222", "embedding": [0.2] * 3, "last_embedded_hash": "hash2"},
+        ]
+
+        with patch("scraper.db.embeddings.SessionLocal", mock_factory):
+            result = await bulk_update_embeddings(updates)
+
+        assert result == 2
+        mock_session.execute.assert_called_once()
+        mock_session.commit.assert_called_once()
+        mock_session.rollback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rolls_back_and_raises_on_db_error(self, mock_db_session) -> None:
+        mock_session, mock_factory = mock_db_session
+        mock_session.execute.side_effect = SQLAlchemyError("connection lost")
+
+        updates = [{"sku": "111", "embedding": [0.1] * 3, "last_embedded_hash": "h1"}]
+
+        with (
+            patch("scraper.db.embeddings.SessionLocal", mock_factory),
+            pytest.raises(SQLAlchemyError),
+        ):
+            await bulk_update_embeddings(updates)
+
+        mock_session.rollback.assert_called_once()
+        mock_session.commit.assert_not_called()
+
+
+class TestBulkUpdateWineAttrs:
+    @pytest.mark.asyncio
+    async def test_returns_zero_for_empty_dict(self) -> None:
+        result = await bulk_update_wine_attrs({})
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_commits_and_returns_count(self, mock_db_session) -> None:
+        mock_session, mock_factory = mock_db_session
+
+        updates = {
+            "111": {
+                "taste_tag": "Fruité",
+                "vintage": "2021",
+                "tasting_profile": None,
+                "grape_blend": None,
+            },
+            "222": {
+                "taste_tag": "Corsé",
+                "vintage": "2020",
+                "tasting_profile": None,
+                "grape_blend": None,
+            },
+        }
+
+        with patch("scraper.db.embeddings.SessionLocal", mock_factory):
+            result = await bulk_update_wine_attrs(updates)
+
+        assert result == 2
+        mock_session.execute.assert_called_once()
+        mock_session.commit.assert_called_once()
+        mock_session.rollback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rolls_back_and_raises_on_db_error(self, mock_db_session) -> None:
+        mock_session, mock_factory = mock_db_session
+        mock_session.execute.side_effect = SQLAlchemyError("connection lost")
+
+        updates = {
+            "111": {
+                "taste_tag": "Fruité",
+                "vintage": None,
+                "tasting_profile": None,
+                "grape_blend": None,
+            },
+        }
+
+        with (
+            patch("scraper.db.embeddings.SessionLocal", mock_factory),
+            pytest.raises(SQLAlchemyError),
+        ):
+            await bulk_update_wine_attrs(updates)
+
+        mock_session.rollback.assert_called_once()
+        mock_session.commit.assert_not_called()

--- a/scraper/tests/test_embed.py
+++ b/scraper/tests/test_embed.py
@@ -2,7 +2,7 @@ from scraper.embed import build_embedding_text, compute_embedding_hash
 
 
 class TestBuildEmbeddingText:
-    def test_full_product(self) -> None:
+    def test_formats_all_fields_into_structured_text_lines(self) -> None:
         text = build_embedding_text(
             category="Vin rouge",
             taste_tag="Aromatique et souple",

--- a/scraper/tests/test_embed_sync.py
+++ b/scraper/tests/test_embed_sync.py
@@ -32,7 +32,7 @@ def _make_product(**overrides: object) -> dict:
 @pytest.mark.asyncio
 class TestEmbedSync:
     @patch("scraper.commands.embed.settings")
-    async def test_no_api_key(self, mock_settings: MagicMock) -> None:
+    async def test_returns_fatal_when_api_key_missing(self, mock_settings: MagicMock) -> None:
         mock_settings.OPENAI_API_KEY = ""
         result = await embed_sync()
         assert result == EXIT_FATAL
@@ -49,7 +49,7 @@ class TestEmbedSync:
     @patch("scraper.commands.embed.get_products_needing_embedding", new_callable=AsyncMock)
     @patch("scraper.commands.embed.create_embeddings")
     @patch("scraper.commands.embed.bulk_update_embeddings", new_callable=AsyncMock)
-    async def test_full_sync(
+    async def test_embeds_all_products_and_persists_vectors(
         self,
         mock_bulk: AsyncMock,
         mock_embed: MagicMock,

--- a/scraper/tests/test_enrich.py
+++ b/scraper/tests/test_enrich.py
@@ -168,7 +168,7 @@ class TestEnrichWines:
         assert result == EXIT_FATAL
 
     @pytest.mark.asyncio
-    async def test_happy_path(self) -> None:
+    async def test_updates_matched_products_and_skips_unknown_skus(self) -> None:
         products = [
             _make_product(
                 "111",

--- a/scraper/tests/test_incremental.py
+++ b/scraper/tests/test_incremental.py
@@ -84,10 +84,10 @@ class TestSkuValidation:
 
 
 class TestExitCode:
-    def test_clean_run(self) -> None:
+    def test_returns_ok_when_saved_without_errors(self) -> None:
         assert _exit_code(saved=10, errors=0) == EXIT_OK
 
-    def test_no_work_is_clean(self) -> None:
+    def test_returns_ok_when_nothing_saved_and_no_errors(self) -> None:
         assert _exit_code(saved=0, errors=0) == EXIT_OK
 
     def test_partial_failure(self) -> None:

--- a/scraper/tests/test_main.py
+++ b/scraper/tests/test_main.py
@@ -41,7 +41,7 @@ class TestDetectDelists:
         mock_emit.assert_called_once_with("10327701", available=False)
 
     @pytest.mark.asyncio
-    async def test_no_event_when_delisted_sku_not_watched(self) -> None:
+    async def test_skips_event_when_delisted_sku_not_watched(self) -> None:
         from scraper.commands.scrape import _detect_delists
 
         with (
@@ -56,7 +56,7 @@ class TestDetectDelists:
         mock_emit.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_no_event_when_nothing_delisted(self) -> None:
+    async def test_skips_event_emission_when_nothing_delisted(self) -> None:
         from scraper.commands.scrape import _detect_delists
 
         with (

--- a/scraper/tests/test_scrape.py
+++ b/scraper/tests/test_scrape.py
@@ -1,0 +1,203 @@
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from scraper.commands.scrape import (
+    _detect_delists,
+    _scrape_products,
+)
+from scraper.db import ProductState
+from scraper.products import ProductData
+from scraper.sitemap import SitemapEntry
+
+
+def _entry(sku: str, url: str | None = None, lastmod: str | None = None) -> SitemapEntry:
+    return SitemapEntry(url=url or f"https://www.saq.com/fr/{sku}", lastmod=lastmod)
+
+
+def _state(sku: str, updated: str = "2026-01-01", content_hash: str | None = None) -> ProductState:
+    return ProductState(updated_date=date.fromisoformat(updated), content_hash=content_hash)
+
+
+def _product_response(content: bytes = b"<html></html>") -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.content = content
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+# ── _scrape_products ──────────────────────────────────────────
+
+
+class TestScrapeProducts:
+    @pytest.mark.asyncio
+    async def test_inserts_new_product_and_returns_saved_count(self) -> None:
+        entries = [_entry("111")]
+        product_states: dict = {}
+
+        product = ProductData(sku="111", name="Wine A")
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.get.return_value = _product_response()
+
+        with (
+            patch("scraper.commands.scrape.asyncio.sleep"),
+            patch("scraper.commands.scrape.parse_product", return_value=product),
+            patch("scraper.commands.scrape.compute_content_hash", return_value="hash_new"),
+            patch("scraper.commands.scrape.upsert_product", new_callable=AsyncMock),
+        ):
+            stats = await _scrape_products(client, entries, product_states)
+
+        assert stats.saved == 1
+        assert stats.inserted == 1
+        assert stats.updated == 0
+        assert stats.errors == 0
+
+    @pytest.mark.asyncio
+    async def test_updates_existing_product_when_content_changed(self) -> None:
+        entries = [_entry("111")]
+        product_states = {"111": _state("111", content_hash="old_hash")}
+
+        product = ProductData(sku="111", name="Wine A Updated")
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.get.return_value = _product_response()
+
+        with (
+            patch("scraper.commands.scrape.asyncio.sleep"),
+            patch("scraper.commands.scrape.parse_product", return_value=product),
+            patch("scraper.commands.scrape.compute_content_hash", return_value="new_hash"),
+            patch("scraper.commands.scrape.upsert_product", new_callable=AsyncMock),
+        ):
+            stats = await _scrape_products(client, entries, product_states)
+
+        assert stats.saved == 1
+        assert stats.updated == 1
+        assert stats.inserted == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_unchanged_product_via_content_hash(self) -> None:
+        entries = [_entry("111")]
+        product_states = {"111": _state("111", content_hash="same_hash")}
+
+        product = ProductData(sku="111", name="Wine A")
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.get.return_value = _product_response()
+
+        with (
+            patch("scraper.commands.scrape.asyncio.sleep"),
+            patch("scraper.commands.scrape.parse_product", return_value=product),
+            patch("scraper.commands.scrape.compute_content_hash", return_value="same_hash"),
+            patch("scraper.commands.scrape.upsert_product", new_callable=AsyncMock) as mock_upsert,
+        ):
+            stats = await _scrape_products(client, entries, product_states)
+
+        assert stats.unchanged == 1
+        assert stats.saved == 0
+        mock_upsert.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_counts_404_as_not_found_not_error(self) -> None:
+        entries = [_entry("111")]
+        product_states: dict = {}
+
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 404
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404", request=MagicMock(), response=resp
+        )
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.get.return_value = resp
+
+        with patch("scraper.commands.scrape.asyncio.sleep"):
+            stats = await _scrape_products(client, entries, product_states)
+
+        assert stats.not_found == 1
+        assert stats.errors == 0
+
+    @pytest.mark.asyncio
+    async def test_counts_non_404_http_error_as_error(self) -> None:
+        entries = [_entry("111")]
+        product_states: dict = {}
+
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 503
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "503", request=MagicMock(), response=resp
+        )
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.get.return_value = resp
+
+        with patch("scraper.commands.scrape.asyncio.sleep"):
+            stats = await _scrape_products(client, entries, product_states)
+
+        assert stats.errors == 1
+        assert stats.not_found == 0
+
+    @pytest.mark.asyncio
+    async def test_counts_db_error_as_error_and_continues(self) -> None:
+        entries = [_entry("111"), _entry("222")]
+        product_states: dict = {}
+
+        product = ProductData(sku="111", name="Wine")
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.get.return_value = _product_response()
+
+        with (
+            patch("scraper.commands.scrape.asyncio.sleep"),
+            patch("scraper.commands.scrape.parse_product", return_value=product),
+            patch("scraper.commands.scrape.compute_content_hash", return_value="h"),
+            patch(
+                "scraper.commands.scrape.upsert_product",
+                new_callable=AsyncMock,
+                side_effect=SQLAlchemyError("conn lost"),
+            ),
+        ):
+            stats = await _scrape_products(client, entries, product_states)
+
+        assert stats.errors == 2
+        assert stats.saved == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_stats_for_empty_entries(self) -> None:
+        client = AsyncMock(spec=httpx.AsyncClient)
+        stats = await _scrape_products(client, [], {})
+        assert stats.saved == 0
+        assert stats.errors == 0
+
+
+# ── _detect_delists ───────────────────────────────────────────
+
+
+class TestDetectDelists:
+    @pytest.mark.asyncio
+    async def test_relists_sku_back_in_sitemap(self) -> None:
+        """SKU in both sitemap and delisted table → relisted."""
+        with (
+            patch("scraper.commands.scrape.mark_delisted", AsyncMock(return_value=0)),
+            patch("scraper.commands.scrape.get_watched_skus", AsyncMock(return_value=[])),
+            patch("scraper.commands.scrape.get_delisted_skus", AsyncMock(return_value={"111"})),
+            patch(
+                "scraper.commands.scrape.clear_delisted", AsyncMock(return_value=1)
+            ) as mock_clear,
+            patch("scraper.commands.scrape.emit_stock_event", AsyncMock()),
+        ):
+            delisted, relisted = await _detect_delists(sitemap_skus={"111"}, db_skus={"111"})
+
+        assert relisted == 1
+        assert delisted == 0
+        mock_clear.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_zeros_on_db_error(self) -> None:
+        """SQLAlchemyError is swallowed — returns (0, 0) for best-effort behavior."""
+        with patch(
+            "scraper.commands.scrape.mark_delisted",
+            AsyncMock(side_effect=SQLAlchemyError("fail")),
+        ):
+            delisted, relisted = await _detect_delists(sitemap_skus=set(), db_skus={"111"})
+
+        assert delisted == 0
+        assert relisted == 0


### PR DESCRIPTION
## Summary

Audits all Python test suites across backend, bot, and scraper for naming clarity, falsifiability, and test isolation. Adds three new test files for previously untested modules.

## Related issue(s)

Closes #646

## Changes

- Rename vague test function names (`test_*_success`, `test_happy_path`, `test_clean_run`, etc.) to active-voice outcome names across all services
- Remove implementation-detail mock assertions (`assert_called_once()` on internal routing) — keep only assertions that are the observable contract (e.g. DB write shape, HTTP response body)
- Strengthen outcome assertions where only a status code was checked (`test_sort_by_price_returns_products`, `test_scope_wine_is_default_on_list_endpoint`, etc.)
- Fix `_authed_client` in `test_users.py` to clean up `dependency_overrides` in a `finally` block — tests were previously order-dependent
- Add `backend/tests/test_auth_service.py` — unit tests for `_verify_telegram_hash` and `verify_telegram_data` (HMAC, expiry)
- Add `scraper/tests/test_scrape.py` — unit tests for `_scrape_products` (insert/update/skip/404/DB error) and `_detect_delists` (relist, DB error swallowed)
- Add `scraper/tests/test_db_embeddings.py` — unit tests for `get_products_needing_embedding`, `bulk_update_embeddings`, `bulk_update_wine_attrs` (hash logic, rollback on error)
- Add new bot tests: toggle conflict (409 treated as already-saved), list-refresh failure fallback, `BackendAPIError` on `alerts_command`
- Raise scraper `fail_under` threshold from 77% → 80%; update CLAUDE.md coverage table to match enforced values
- Add testing standards §5 (falsifiability) and order-independence rule to CLAUDE.md