### PR TITLE
chore: harden frontend tests — edit mode, watch/unwatch, i18n pin

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,11 @@
     "react-router": "^7.14.0",
     "tailwind-merge": "^3.5.0"
   },
+  "_resolutions_comment": "Pinned until shadcn bumps @modelcontextprotocol/sdk to pull patched hono — remove when yarn audit passes without these",
+  "resolutions": {
+    "hono": ">=4.12.12",
+    "@hono/node-server": ">=1.19.13"
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@size-limit/file": "^12.0.1",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { describe, it, expect } from 'vitest'
 import { AuthProvider } from '@/contexts/AuthContext'
-import './i18n'
 import App from './App'
 
 function renderApp(route = '/') {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { describe, it, expect } from 'vitest'
 import { AuthProvider } from '@/contexts/AuthContext'
@@ -16,8 +16,8 @@ function renderApp(route = '/') {
 }
 
 describe('App', () => {
-  it('renders the root route', () => {
-    const { container } = renderApp('/')
-    expect(container.firstChild).toBeTruthy()
+  it('renders LandingPage at root route', () => {
+    renderApp('/')
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/TastingForm.test.tsx
+++ b/frontend/src/components/TastingForm.test.tsx
@@ -2,8 +2,9 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useApiClient, ApiError } from '@/lib/api'
 import '../i18n'
+import { product, fakeNote } from '@/tests/factories'
 import TastingForm from './TastingForm'
-import type { ProductOut, TastingNoteOut } from '@/lib/types'
+import type { TastingNoteOut } from '@/lib/types'
 
 vi.mock('@/lib/api', () => ({
   useApiClient: vi.fn(),
@@ -29,55 +30,6 @@ vi.mock('@/components/WineSearch', () => ({
 
 const mockApiClient = vi.fn()
 
-function product(overrides: Partial<ProductOut> = {}): ProductOut {
-  return {
-    sku: 'SKU001',
-    name: 'Château Test',
-    category: 'Vin rouge',
-    country: 'France',
-    region: 'Bordeaux',
-    size: '750 ml',
-    price: '24.95',
-    url: 'https://saq.com/SKU001',
-    online_availability: false,
-    store_availability: [],
-    rating: null,
-    review_count: null,
-    appellation: null,
-    designation: null,
-    classification: null,
-    grape: 'Merlot',
-    grape_blend: null,
-    alcohol: '13.5%',
-    sugar: null,
-    producer: null,
-    vintage: '2021',
-    taste_tag: null,
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
-    ...overrides,
-  } as ProductOut
-}
-
-function fakeNote(overrides: Partial<TastingNoteOut> = {}): TastingNoteOut {
-  return {
-    id: 1,
-    sku: 'SKU001',
-    rating: 87,
-    notes: null,
-    pairing: null,
-    tasted_at: '2026-01-01',
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
-    product_name: 'Château Test',
-    product_category: 'Vin rouge',
-    product_region: 'Bordeaux',
-    product_grape: 'Merlot',
-    product_price: '24.95',
-    ...overrides,
-  }
-}
-
 beforeEach(() => {
   mockApiClient.mockReset()
   vi.mocked(useApiClient).mockReturnValue(mockApiClient)
@@ -100,8 +52,7 @@ describe('TastingForm', () => {
         onCancel={vi.fn()}
       />,
     )
-    // Rating value is rendered in a span next to the slider
-    expect(screen.getByText('92')).toBeInTheDocument()
+    expect(screen.getByRole('slider')).toHaveValue('92')
     expect(screen.getByDisplayValue('Lovely finish')).toBeInTheDocument()
   })
 
@@ -124,6 +75,8 @@ describe('TastingForm', () => {
     fireEvent.click(screen.getByRole('button', { name: /save/i }))
     expect(await screen.findByRole('button', { name: /saving/i })).toBeDisabled()
     resolve!(fakeNote())
+    // Drain the resolved promise so setSaving(false) runs inside act()
+    await waitFor(() => expect(screen.getByRole('button', { name: /save/i })).toBeEnabled())
   })
 
   it('shows error message with retry when save fails', async () => {
@@ -145,5 +98,35 @@ describe('TastingForm', () => {
     render(<TastingForm onSave={vi.fn()} onCancel={vi.fn()} />)
     expect(screen.queryByRole('slider')).not.toBeInTheDocument()
     expect(screen.queryByText('Impressions')).not.toBeInTheDocument()
+  })
+
+  it('PATCHes existing note when noteId is provided', async () => {
+    mockApiClient.mockResolvedValue(fakeNote({ id: 42, rating: 90 }))
+    const onSave = vi.fn()
+    render(
+      <TastingForm
+        noteId={42}
+        initialProduct={product()}
+        initialRating={90}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    await waitFor(() => expect(onSave).toHaveBeenCalledOnce())
+    expect(mockApiClient).toHaveBeenCalledWith(
+      '/tastings/42',
+      expect.objectContaining({ method: 'PATCH' }),
+    )
+    // PATCH body omits sku (only POST includes it)
+    const body = JSON.parse(mockApiClient.mock.calls[0][1].body)
+    expect(body).not.toHaveProperty('sku')
+  })
+
+  it('hides change-wine button in edit mode', () => {
+    render(
+      <TastingForm noteId={42} initialProduct={product()} onSave={vi.fn()} onCancel={vi.fn()} />,
+    )
+    expect(screen.queryByRole('button', { name: /change wine/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/TastingForm.test.tsx
+++ b/frontend/src/components/TastingForm.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useApiClient, ApiError } from '@/lib/api'
-import '../i18n'
 import { product, fakeNote } from '@/tests/factories'
 import TastingForm from './TastingForm'
 import type { TastingNoteOut } from '@/lib/types'

--- a/frontend/src/components/TastingForm.test.tsx
+++ b/frontend/src/components/TastingForm.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useApiClient, ApiError } from '@/lib/api'
+import '../i18n'
+import TastingForm from './TastingForm'
+import type { ProductOut, TastingNoteOut } from '@/lib/types'
+
+vi.mock('@/lib/api', () => ({
+  useApiClient: vi.fn(),
+  ApiError: class ApiError extends Error {
+    status: number
+    detail: string
+    constructor(status: number, detail: string) {
+      super(detail)
+      this.status = status
+      this.detail = detail
+    }
+  },
+}))
+
+// Stub WineSearch — its API calls are out of scope for TastingForm tests
+vi.mock('@/components/WineSearch', () => ({
+  default: ({ onCancel }: { onSelect: unknown; onCancel: () => void }) => (
+    <button type="button" onClick={onCancel}>
+      Cancel
+    </button>
+  ),
+}))
+
+const mockApiClient = vi.fn()
+
+function product(overrides: Partial<ProductOut> = {}): ProductOut {
+  return {
+    sku: 'SKU001',
+    name: 'Château Test',
+    category: 'Vin rouge',
+    country: 'France',
+    region: 'Bordeaux',
+    size: '750 ml',
+    price: '24.95',
+    url: 'https://saq.com/SKU001',
+    online_availability: false,
+    store_availability: [],
+    rating: null,
+    review_count: null,
+    appellation: null,
+    designation: null,
+    classification: null,
+    grape: 'Merlot',
+    grape_blend: null,
+    alcohol: '13.5%',
+    sugar: null,
+    producer: null,
+    vintage: '2021',
+    taste_tag: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as ProductOut
+}
+
+function fakeNote(overrides: Partial<TastingNoteOut> = {}): TastingNoteOut {
+  return {
+    id: 1,
+    sku: 'SKU001',
+    rating: 87,
+    notes: null,
+    pairing: null,
+    tasted_at: '2026-01-01',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    product_name: 'Château Test',
+    product_category: 'Vin rouge',
+    product_region: 'Bordeaux',
+    product_grape: 'Merlot',
+    product_price: '24.95',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  mockApiClient.mockReset()
+  vi.mocked(useApiClient).mockReturnValue(mockApiClient)
+})
+
+describe('TastingForm', () => {
+  it('renders rating slider and impressions section when initialProduct provided', () => {
+    render(<TastingForm initialProduct={product()} onSave={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByRole('slider')).toBeInTheDocument()
+    expect(screen.getByText('Impressions')).toBeInTheDocument()
+  })
+
+  it('pre-fills rating and notes from initial values', () => {
+    render(
+      <TastingForm
+        initialProduct={product()}
+        initialRating={92}
+        initialNotes="Lovely finish"
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    // Rating value is rendered in a span next to the slider
+    expect(screen.getByText('92')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Lovely finish')).toBeInTheDocument()
+  })
+
+  it('calls onSave with correct sku and rating after successful POST', async () => {
+    mockApiClient.mockResolvedValue(fakeNote({ rating: 87 }))
+    const onSave = vi.fn()
+    render(<TastingForm initialProduct={product()} onSave={onSave} onCancel={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    await waitFor(() => expect(onSave).toHaveBeenCalledOnce())
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ sku: 'SKU001', rating: 87 }))
+  })
+
+  it('shows saving label and disables button while request is in flight', async () => {
+    let resolve: (n: TastingNoteOut) => void
+    const pending = new Promise<TastingNoteOut>((r) => {
+      resolve = r
+    })
+    mockApiClient.mockReturnValue(pending)
+    render(<TastingForm initialProduct={product()} onSave={vi.fn()} onCancel={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(await screen.findByRole('button', { name: /saving/i })).toBeDisabled()
+    resolve!(fakeNote())
+  })
+
+  it('shows error message with retry when save fails', async () => {
+    mockApiClient.mockRejectedValue(new ApiError(500, 'DB error'))
+    render(<TastingForm initialProduct={product()} onSave={vi.fn()} onCancel={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(await screen.findByText(/Couldn't save/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+  })
+
+  it('calls onCancel when cancel is clicked', () => {
+    const onCancel = vi.fn()
+    render(<TastingForm initialProduct={product()} onSave={vi.fn()} onCancel={onCancel} />)
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('hides rating and notes form when no initialProduct provided', () => {
+    render(<TastingForm onSave={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.queryByRole('slider')).not.toBeInTheDocument()
+    expect(screen.queryByText('Impressions')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/UserMenu.test.tsx
+++ b/frontend/src/components/UserMenu.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi } from 'vitest'
-import '../i18n'
 import UserMenu from './UserMenu'
 
 describe('UserMenu', () => {

--- a/frontend/src/components/WineCard.test.tsx
+++ b/frontend/src/components/WineCard.test.tsx
@@ -1,38 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import '../i18n'
-import type { ProductOut } from '@/lib/types'
+import { product } from '@/tests/factories'
 import WineCard from './WineCard'
-
-function product(overrides: Partial<ProductOut> = {}): ProductOut {
-  return {
-    sku: 'SKU001',
-    name: 'Château Test',
-    category: 'Vin rouge',
-    country: 'France',
-    region: 'Bordeaux',
-    size: '750 ml',
-    price: '24.95',
-    url: 'https://saq.com/SKU001',
-    online_availability: true,
-    store_availability: [],
-    rating: null,
-    review_count: null,
-    appellation: null,
-    designation: null,
-    classification: null,
-    grape: 'Merlot',
-    grape_blend: null,
-    alcohol: '13.5%',
-    sugar: null,
-    producer: null,
-    vintage: '2021',
-    taste_tag: null,
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
-    ...overrides,
-  } as ProductOut
-}
 
 describe('WineCard', () => {
   it('renders wine name and vintage', () => {

--- a/frontend/src/components/WineCard.test.tsx
+++ b/frontend/src/components/WineCard.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
-import '../i18n'
 import { product } from '@/tests/factories'
 import WineCard from './WineCard'
 

--- a/frontend/src/components/WineCard.test.tsx
+++ b/frontend/src/components/WineCard.test.tsx
@@ -67,9 +67,8 @@ describe('WineCard', () => {
   })
 
   it('renders colored dot for Vin rouge category', () => {
-    const { container } = render(<WineCard product={product({ category: 'Vin rouge' })} />)
-    const dot = container.querySelector('.bg-red-500\\/80')
-    expect(dot).toBeInTheDocument()
+    render(<WineCard product={product({ category: 'Vin rouge' })} />)
+    expect(screen.getByTestId('category-dot')).toBeInTheDocument()
   })
 
   it('renders reason when provided', () => {

--- a/frontend/src/components/WineCard.tsx
+++ b/frontend/src/components/WineCard.tsx
@@ -48,7 +48,10 @@ function WineCard({ product, reason, storeNames, watchSlot, userRating }: WineCa
         {/* Top: dot + name + price */}
         <div className="flex items-start gap-2.5">
           {dotColor && (
-            <span className={`mt-[5px] h-2 w-2 flex-shrink-0 rounded-full ${dotColor}`} />
+            <span
+              data-testid="category-dot"
+              className={`mt-[5px] h-2 w-2 flex-shrink-0 rounded-full ${dotColor}`}
+            />
           )}
           <div className="flex min-w-0 flex-1 items-start justify-between gap-3">
             <p className="line-clamp-2 min-w-0 flex-1 text-[14px] leading-snug font-medium">

--- a/frontend/src/components/WineDetailPanel.test.tsx
+++ b/frontend/src/components/WineDetailPanel.test.tsx
@@ -3,7 +3,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { MemoryRouter } from 'react-router'
 import { useAuth } from '@/contexts/AuthContext'
 import { useApiClient, ApiError } from '@/lib/api'
-import '../i18n'
 import { product } from '@/tests/factories'
 import WineDetailPanel from './WineDetailPanel'
 
@@ -31,9 +30,14 @@ function renderPanel(sku: string | null, onClose = vi.fn()) {
   )
 }
 
-function apiReturning(p: ReturnType<typeof product>) {
-  mockApiClient.mockImplementation((url: string) => {
+function apiReturning(
+  p: ReturnType<typeof product>,
+  overrides?: { watchPost?: () => Promise<unknown> },
+) {
+  mockApiClient.mockImplementation((url: string, opts?: RequestInit) => {
     if (url.startsWith('/products/')) return Promise.resolve(p)
+    if (url.includes('/watches') && opts?.method === 'POST')
+      return overrides?.watchPost?.() ?? Promise.resolve({})
     if (url.includes('/watches')) return Promise.resolve([])
     if (url.includes('/stores/preferences')) return Promise.resolve([])
     return Promise.reject(new Error(`unexpected api call: ${url}`))
@@ -92,13 +96,7 @@ describe('WineDetailPanel', () => {
   })
 
   it('optimistically switches to Watching on watch click', async () => {
-    mockApiClient.mockImplementation((url: string, opts?: RequestInit) => {
-      if (url.startsWith('/products/')) return Promise.resolve(product())
-      if (url.includes('/watches') && opts?.method === 'POST') return Promise.resolve({})
-      if (url.includes('/watches')) return Promise.resolve([])
-      if (url.includes('/stores/preferences')) return Promise.resolve([])
-      return Promise.reject(new Error(`unexpected: ${url}`))
-    })
+    apiReturning(product())
     renderPanel('SKU001')
     await screen.findByRole('heading', { level: 2 })
     fireEvent.click(screen.getByRole('button', { name: /watch$/i }))
@@ -106,13 +104,8 @@ describe('WineDetailPanel', () => {
   })
 
   it('rolls back to Watch when watch API call fails', async () => {
-    mockApiClient.mockImplementation((url: string, opts?: RequestInit) => {
-      if (url.startsWith('/products/')) return Promise.resolve(product())
-      if (url.includes('/watches') && opts?.method === 'POST')
-        return Promise.reject(new Error('network'))
-      if (url.includes('/watches')) return Promise.resolve([])
-      if (url.includes('/stores/preferences')) return Promise.resolve([])
-      return Promise.reject(new Error(`unexpected: ${url}`))
+    apiReturning(product(), {
+      watchPost: () => Promise.reject(new Error('network')),
     })
     renderPanel('SKU001')
     await screen.findByRole('heading', { level: 2 })

--- a/frontend/src/components/WineDetailPanel.test.tsx
+++ b/frontend/src/components/WineDetailPanel.test.tsx
@@ -4,8 +4,8 @@ import { MemoryRouter } from 'react-router'
 import { useAuth } from '@/contexts/AuthContext'
 import { useApiClient, ApiError } from '@/lib/api'
 import '../i18n'
+import { product } from '@/tests/factories'
 import WineDetailPanel from './WineDetailPanel'
-import type { ProductOut } from '@/lib/types'
 
 vi.mock('@/contexts/AuthContext', () => ({ useAuth: vi.fn() }))
 vi.mock('@/lib/api', () => ({
@@ -23,36 +23,6 @@ vi.mock('@/lib/api', () => ({
 
 const mockApiClient = vi.fn()
 
-function product(overrides: Partial<ProductOut> = {}): ProductOut {
-  return {
-    sku: 'SKU001',
-    name: 'Château Test',
-    category: 'Vin rouge',
-    country: 'France',
-    region: 'Bordeaux',
-    size: '750 ml',
-    price: '24.95',
-    url: 'https://saq.com/SKU001',
-    online_availability: false,
-    store_availability: [],
-    rating: null,
-    review_count: null,
-    appellation: null,
-    designation: null,
-    classification: null,
-    grape: 'Merlot',
-    grape_blend: null,
-    alcohol: '13.5%',
-    sugar: null,
-    producer: null,
-    vintage: '2021',
-    taste_tag: null,
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
-    ...overrides,
-  } as ProductOut
-}
-
 function renderPanel(sku: string | null, onClose = vi.fn()) {
   return render(
     <MemoryRouter>
@@ -61,7 +31,7 @@ function renderPanel(sku: string | null, onClose = vi.fn()) {
   )
 }
 
-function apiReturning(p: ProductOut) {
+function apiReturning(p: ReturnType<typeof product>) {
   mockApiClient.mockImplementation((url: string) => {
     if (url.startsWith('/products/')) return Promise.resolve(p)
     if (url.includes('/watches')) return Promise.resolve([])
@@ -72,13 +42,7 @@ function apiReturning(p: ProductOut) {
 
 beforeEach(() => {
   mockApiClient.mockReset()
-  vi.mocked(useAuth).mockReturnValue({
-    user: { id: 1, display_name: 'Victor', role: 'user', locale: 'en' },
-    login: vi.fn(),
-    logout: vi.fn(),
-    updateUser: vi.fn(),
-    isLoading: false,
-  } as ReturnType<typeof useAuth>)
+  vi.mocked(useAuth).mockReturnValue({ user: { id: 1 } } as ReturnType<typeof useAuth>)
   vi.mocked(useApiClient).mockReturnValue(mockApiClient)
 })
 
@@ -92,20 +56,19 @@ describe('WineDetailPanel', () => {
   it('renders price with currency symbol', async () => {
     apiReturning(product())
     renderPanel('SKU001')
-    await screen.findByRole('heading', { level: 2 })
-    expect(screen.getByText('24.95 $')).toBeInTheDocument()
+    expect(await screen.findByText('24.95 $')).toBeInTheDocument()
   })
 
   it('renders grape variety when present', async () => {
-    apiReturning(product({ grape: 'Merlot' }))
+    apiReturning(product())
     renderPanel('SKU001')
-    await screen.findByRole('heading', { level: 2 })
-    expect(screen.getByText('Merlot')).toBeInTheDocument()
+    expect(await screen.findByText('Merlot')).toBeInTheDocument()
   })
 
   it('omits grape section when grape is null', async () => {
     apiReturning(product({ grape: null }))
     renderPanel('SKU001')
+    // Wait for loaded state (h2 present), then assert absence
     await screen.findByRole('heading', { level: 2 })
     expect(screen.queryByText('Grapes')).not.toBeInTheDocument()
   })
@@ -126,5 +89,37 @@ describe('WineDetailPanel', () => {
     renderPanel('SKU001')
     await waitFor(() => expect(screen.getByText(/Server error/)).toBeInTheDocument())
     expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+  })
+
+  it('optimistically switches to Watching on watch click', async () => {
+    mockApiClient.mockImplementation((url: string, opts?: RequestInit) => {
+      if (url.startsWith('/products/')) return Promise.resolve(product())
+      if (url.includes('/watches') && opts?.method === 'POST') return Promise.resolve({})
+      if (url.includes('/watches')) return Promise.resolve([])
+      if (url.includes('/stores/preferences')) return Promise.resolve([])
+      return Promise.reject(new Error(`unexpected: ${url}`))
+    })
+    renderPanel('SKU001')
+    await screen.findByRole('heading', { level: 2 })
+    fireEvent.click(screen.getByRole('button', { name: /watch$/i }))
+    expect(await screen.findByRole('button', { name: /watching/i })).toBeInTheDocument()
+  })
+
+  it('rolls back to Watch when watch API call fails', async () => {
+    mockApiClient.mockImplementation((url: string, opts?: RequestInit) => {
+      if (url.startsWith('/products/')) return Promise.resolve(product())
+      if (url.includes('/watches') && opts?.method === 'POST')
+        return Promise.reject(new Error('network'))
+      if (url.includes('/watches')) return Promise.resolve([])
+      if (url.includes('/stores/preferences')) return Promise.resolve([])
+      return Promise.reject(new Error(`unexpected: ${url}`))
+    })
+    renderPanel('SKU001')
+    await screen.findByRole('heading', { level: 2 })
+    fireEvent.click(screen.getByRole('button', { name: /watch$/i }))
+    // During the request, button shows "..." (busy state masks the optimistic text)
+    expect(screen.getByRole('button', { name: '...' })).toBeDisabled()
+    // After rejection settles: rolls back to Watch
+    await waitFor(() => expect(screen.getByRole('button', { name: /watch$/i })).toBeInTheDocument())
   })
 })

--- a/frontend/src/components/WineDetailPanel.test.tsx
+++ b/frontend/src/components/WineDetailPanel.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router'
+import { useAuth } from '@/contexts/AuthContext'
+import { useApiClient, ApiError } from '@/lib/api'
+import '../i18n'
+import WineDetailPanel from './WineDetailPanel'
+import type { ProductOut } from '@/lib/types'
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: vi.fn() }))
+vi.mock('@/lib/api', () => ({
+  useApiClient: vi.fn(),
+  ApiError: class ApiError extends Error {
+    status: number
+    detail: string
+    constructor(status: number, detail: string) {
+      super(detail)
+      this.status = status
+      this.detail = detail
+    }
+  },
+}))
+
+const mockApiClient = vi.fn()
+
+function product(overrides: Partial<ProductOut> = {}): ProductOut {
+  return {
+    sku: 'SKU001',
+    name: 'Château Test',
+    category: 'Vin rouge',
+    country: 'France',
+    region: 'Bordeaux',
+    size: '750 ml',
+    price: '24.95',
+    url: 'https://saq.com/SKU001',
+    online_availability: false,
+    store_availability: [],
+    rating: null,
+    review_count: null,
+    appellation: null,
+    designation: null,
+    classification: null,
+    grape: 'Merlot',
+    grape_blend: null,
+    alcohol: '13.5%',
+    sugar: null,
+    producer: null,
+    vintage: '2021',
+    taste_tag: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as ProductOut
+}
+
+function renderPanel(sku: string | null, onClose = vi.fn()) {
+  return render(
+    <MemoryRouter>
+      <WineDetailPanel sku={sku} onClose={onClose} />
+    </MemoryRouter>,
+  )
+}
+
+function apiReturning(p: ProductOut) {
+  mockApiClient.mockImplementation((url: string) => {
+    if (url.startsWith('/products/')) return Promise.resolve(p)
+    if (url.includes('/watches')) return Promise.resolve([])
+    if (url.includes('/stores/preferences')) return Promise.resolve([])
+    return Promise.reject(new Error(`unexpected api call: ${url}`))
+  })
+}
+
+beforeEach(() => {
+  mockApiClient.mockReset()
+  vi.mocked(useAuth).mockReturnValue({
+    user: { id: 1, display_name: 'Victor', role: 'user', locale: 'en' },
+    login: vi.fn(),
+    logout: vi.fn(),
+    updateUser: vi.fn(),
+    isLoading: false,
+  } as ReturnType<typeof useAuth>)
+  vi.mocked(useApiClient).mockReturnValue(mockApiClient)
+})
+
+describe('WineDetailPanel', () => {
+  it('renders wine name in heading when product loads', async () => {
+    apiReturning(product())
+    renderPanel('SKU001')
+    expect(await screen.findByRole('heading', { level: 2 })).toHaveTextContent('Château Test')
+  })
+
+  it('renders price with currency symbol', async () => {
+    apiReturning(product())
+    renderPanel('SKU001')
+    await screen.findByRole('heading', { level: 2 })
+    expect(screen.getByText('24.95 $')).toBeInTheDocument()
+  })
+
+  it('renders grape variety when present', async () => {
+    apiReturning(product({ grape: 'Merlot' }))
+    renderPanel('SKU001')
+    await screen.findByRole('heading', { level: 2 })
+    expect(screen.getByText('Merlot')).toBeInTheDocument()
+  })
+
+  it('omits grape section when grape is null', async () => {
+    apiReturning(product({ grape: null }))
+    renderPanel('SKU001')
+    await screen.findByRole('heading', { level: 2 })
+    expect(screen.queryByText('Grapes')).not.toBeInTheDocument()
+  })
+
+  it('calls onClose when close button is clicked', () => {
+    apiReturning(product())
+    const onClose = vi.fn()
+    renderPanel('SKU001', onClose)
+    fireEvent.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('shows error message with retry when product fetch fails', async () => {
+    mockApiClient.mockImplementation((url: string) => {
+      if (url.startsWith('/products/')) return Promise.reject(new ApiError(500, 'Server error'))
+      return Promise.resolve([])
+    })
+    renderPanel('SKU001')
+    await waitFor(() => expect(screen.getByText(/Server error/)).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/contexts/WineDetailContext.test.tsx
+++ b/frontend/src/contexts/WineDetailContext.test.tsx
@@ -14,7 +14,7 @@ describe('useWineDetail', () => {
     )
   })
 
-  it('starts with null selectedSku', () => {
+  it('initializes selectedSku as null', () => {
     const { result } = renderHook(() => useWineDetail(), { wrapper })
     expect(result.current.selectedSku).toBeNull()
   })

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,6 +1,10 @@
 import { cleanup } from '@testing-library/react'
 import { afterEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
+import i18n from './i18n'
+
+// Pin locale so text-based assertions don't depend on jsdom's navigator.language
+i18n.changeLanguage('en')
 
 // RTL auto-cleanup needs a global afterEach — wire it explicitly since globals: false
 afterEach(cleanup)

--- a/frontend/src/tests/factories.ts
+++ b/frontend/src/tests/factories.ts
@@ -1,0 +1,51 @@
+import type { ProductOut, TastingNoteOut } from '@/lib/types'
+
+export function product(overrides: Partial<ProductOut> = {}): ProductOut {
+  return {
+    sku: 'SKU001',
+    name: 'Château Test',
+    category: 'Vin rouge',
+    country: 'France',
+    region: 'Bordeaux',
+    size: '750 ml',
+    price: '24.95',
+    url: 'https://saq.com/SKU001',
+    online_availability: false,
+    store_availability: [],
+    rating: null,
+    review_count: null,
+    appellation: null,
+    designation: null,
+    classification: null,
+    grape: 'Merlot',
+    grape_blend: null,
+    alcohol: '13.5%',
+    sugar: null,
+    producer: null,
+    vintage: '2021',
+    taste_tag: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+export function fakeNote(overrides: Partial<TastingNoteOut> = {}): TastingNoteOut {
+  return {
+    id: 1,
+    sku: 'SKU001',
+    rating: 87,
+    notes: null,
+    pairing: null,
+    tasted_at: '2026-01-01',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    product_name: 'Château Test',
+    product_image_url: null,
+    product_category: 'Vin rouge',
+    product_region: 'Bordeaux',
+    product_grape: 'Merlot',
+    product_price: '24.95',
+    ...overrides,
+  }
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -14,7 +14,7 @@ export default mergeConfig(
         reporter: ['text', 'cobertura'],
         reportsDirectory: './coverage',
         include: ['src/**/*.{ts,tsx}'],
-        exclude: ['src/**/*.test.{ts,tsx}', 'src/setupTests.ts', 'src/components/ui/**'],
+        exclude: ['src/**/*.test.{ts,tsx}', 'src/setupTests.ts', 'src/components/ui/**', 'src/tests/**'],
         thresholds: { lines: 0, branches: 0, functions: 0, statements: 0 },
       },
     },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -501,10 +501,10 @@
   resolved "https://registry.yarnpkg.com/@fontsource-variable/outfit/-/outfit-5.2.8.tgz#f9caa5f5057ebf58942394734604f162342b1ae0"
   integrity sha512-4oUDCZx/Tcz6HZP423w/niqEH31Gks5IsqHV2ZZz1qKHaVIZdj2f0/S1IK2n8jl6Xo0o3N+3RjNHlV9R73ozQA==
 
-"@hono/node-server@^1.19.9":
-  version "1.19.12"
-  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.12.tgz#dae075247959b6d7d2dba4c8bdc8c452ca0c7b40"
-  integrity sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==
+"@hono/node-server@>=1.19.13", "@hono/node-server@^1.19.9":
+  version "1.19.13"
+  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.13.tgz#4838c766a1237253d4dde3281cf7d5c65186fd32"
+  integrity sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==
 
 "@humanfs/core@^0.19.1":
   version "0.19.1"
@@ -2447,10 +2447,10 @@ hermes-parser@^0.25.1:
   dependencies:
     hermes-estree "0.25.1"
 
-hono@^4.11.4:
-  version "4.12.9"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.9.tgz#7cd59dec4abf02022f5baad87f6413a04081144c"
-  integrity sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==
+hono@>=4.12.12, hono@^4.11.4:
+  version "4.12.12"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.12.tgz#1f14b0ffb47c386ff50d457d66e706d9c9a7f09c"
+  integrity sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==
 
 html-encoding-sniffer@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
## Summary

Fill coverage gaps flagged by QA review: TastingForm edit mode (PATCH), WineDetailPanel watch/unwatch optimistic mutations, and test infrastructure reliability.

## Related issue(s)

No linked issue — follow-up from #647 (component tests + testing standards).

## Changes

- **TastingForm tests**: add PATCH/edit mode test (verifies endpoint, method, body shape), add hidden change-wine button in edit mode test, fix dangling async in saving-in-flight test
- **WineDetailPanel tests**: add optimistic watch test (button switches to Watching on success), add rollback test (reverts to Watch on API failure)
- **i18n pin**: `setupTests.ts` now imports i18n and pins locale to English — text-based assertions no longer depend on jsdom's `navigator.language`
- **Cleanup**: remove redundant `import '../i18n'` from 5 test files (now handled globally), extract shared `apiReturning()` helper with `watchPost` override to eliminate mock router duplication
- **Shared factories**: `product()` and `fakeNote()` extracted to `src/tests/factories.ts`, reused across WineCard, TastingForm, and WineDetailPanel tests
- **Assertion upgrades**: App test asserts H1 heading (not `container.firstChild`), WineCard dot test uses `data-testid` (not CSS class selector), slider value asserted via `toHaveValue()`
- **Test naming**: align with testing standards (active voice, specific outcomes)