### PR TITLE
refactor: eliminate setState-in-effect anti-patterns ahead of eslint-plugin-react-hooks 7.1

### DIFF
--- a/frontend/src/components/NoteViewModal.tsx
+++ b/frontend/src/components/NoteViewModal.tsx
@@ -48,14 +48,6 @@ function NoteViewModal({
   // Delete confirm
   const [confirmDelete, setConfirmDelete] = useState(false)
 
-  // Sync mode and note if a different note is passed without unmounting the modal
-  useEffect(() => {
-    setMode(initialMode)
-    setCurrentNote(note)
-    setProduct(null)
-    setConfirmDelete(false)
-  }, [note.id]) // eslint-disable-line react-hooks/exhaustive-deps -- intentionally only reset when a different note is opened, not on every prop change
-
   useEffect(() => {
     let cancelled = false
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -63,12 +63,11 @@ function WaitlistTab() {
 
   useEffect(() => {
     let cancelled = false
-    setLoading(true)
-    setError(null)
     apiClient<WaitlistRequestOut[]>('/admin/waitlist')
       .then((data) => {
         if (!cancelled) {
           setEntries(data)
+          setError(null)
           setLoading(false)
         }
       })
@@ -206,12 +205,11 @@ function UsersTab() {
 
   useEffect(() => {
     let cancelled = false
-    setLoading(true)
-    setError(null)
     apiClient<UserOut[]>('/admin/users')
       .then((data) => {
         if (!cancelled) {
           setUsers(data)
+          setError(null)
           setLoading(false)
         }
       })

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -58,14 +58,16 @@ function SearchPage() {
   const maxPrice = searchParams.get('max_price') ?? ''
   const page = Number(searchParams.get('page') ?? '1')
 
-  // Local input for debounced search
+  // Local input for debounced search — kept in sync with URL query when it
+  // changes externally (browser back/forward) using React's "previous prop"
+  // reset pattern: setState during render is fine when guarded.
   const [inputValue, setInputValue] = useState(query)
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  // Sync input when URL query changes externally (browser back/forward)
-  useEffect(() => {
+  const [prevQuery, setPrevQuery] = useState(query)
+  if (query !== prevQuery) {
+    setPrevQuery(query)
     setInputValue(query)
-  }, [query])
+  }
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Clean up pending debounce on unmount
   useEffect(() => {
@@ -236,10 +238,9 @@ function SearchPage() {
   ])
 
   useEffect(() => {
-    if (!results || results.products.length === 0) {
-      setUserRatings({})
-      return
-    }
+    // Skip when results are empty — stale ratings linger in state but are
+    // keyed by SKU and only read for current results, so they're never displayed.
+    if (!results || results.products.length === 0) return
     let cancelled = false
     const params = new URLSearchParams()
     for (const item of results.products) {

--- a/frontend/src/pages/StoresPage.tsx
+++ b/frontend/src/pages/StoresPage.tsx
@@ -65,14 +65,17 @@ function StoresPage() {
   const apiClient = useApiClient()
   const { geo, request: requestLocation } = useGeolocation()
 
-  const [stores, setStores] = useState<StoreWithDistance[]>([])
-  const [loading, setLoading] = useState(false)
+  // stores=null means "haven't fetched yet" (vs [] which is "fetched, no nearby stores").
+  const [stores, setStores] = useState<StoreWithDistance[] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [savedIds, setSavedIds] = useState<Set<string>>(new Set())
   const [toggling, setToggling] = useState<string | null>(null)
 
   const lat = geo.status === 'granted' ? geo.lat : null
   const lng = geo.status === 'granted' ? geo.lng : null
+
+  // loading is derived: we have coordinates and haven't yet received a result or error.
+  const loading = lat !== null && lng !== null && stores === null && error === null
 
   useEffect(() => {
     requestLocation()
@@ -105,7 +108,6 @@ function StoresPage() {
     if (lat === null || lng === null) return
 
     let cancelled = false
-    setLoading(true)
 
     async function fetchStores() {
       try {
@@ -120,8 +122,6 @@ function StoresPage() {
         if (!cancelled) {
           setError(err instanceof ApiError ? err.detail : t('editStores.failedToLoad'))
         }
-      } finally {
-        if (!cancelled) setLoading(false)
       }
     }
 
@@ -233,11 +233,11 @@ function StoresPage() {
         )}
 
         {/* Empty: location granted but no stores */}
-        {geo.status === 'granted' && !loading && stores.length === 0 && !error && (
+        {geo.status === 'granted' && !loading && stores?.length === 0 && !error && (
           <EmptyState icon={<Buildings size={28} />} title={t('editStores.noStores')} />
         )}
 
-        {stores.length > 0 && (
+        {stores && stores.length > 0 && (
           <ul className="flex flex-col gap-2">
             {stores.map((store) => {
               const isSaved = savedIds.has(store.saq_store_id)

--- a/frontend/src/pages/TastingsPage.tsx
+++ b/frontend/src/pages/TastingsPage.tsx
@@ -71,7 +71,6 @@ function TastingsPage() {
 
   useEffect(() => {
     let cancelled = false
-    setLoading(true)
     fetchPage(0)
       .then((data) => {
         if (!cancelled) {
@@ -444,6 +443,7 @@ function TastingsPage() {
 
       {viewNote !== null && (
         <NoteViewModal
+          key={viewNote.note.id}
           note={viewNote.note}
           initialMode={viewNote.mode}
           onClose={() => setViewNote(null)}


### PR DESCRIPTION
## Summary

Refactors 7 \`setState\`-in-\`useEffect\` patterns flagged by the new \`react-hooks/set-state-in-effect\` rule shipped in \`eslint-plugin-react-hooks@7.1\`. Each fix uses a proper React 19 idiom (no eslint-disables), so the codebase is clean before #694 lands and bumps the plugin.

## Related issue(s)

Unblocks #694 (frontend minor-and-patch dependabot group, currently failing \`lint-frontend\` because of the new rule).

## Changes

- **\`NoteViewModal.tsx\` + \`TastingsPage.tsx\`** — caller passes \`key={note.id}\`, modal remounts on note switch, sync effect deleted (also drops a pre-existing \`exhaustive-deps\` disable as a bonus)
- **\`SearchPage.tsx:67\`** — adopt the [official "previous prop" pattern](https://react.dev/reference/react/useState#storing-information-from-previous-renders) (guarded \`setState\` during render) for syncing URL query into the local input
- **\`SearchPage.tsx:240\`** — drop \`setUserRatings({})\` reset; ratings are keyed by SKU and only read for current results, so stale keys never display
- **\`AdminPage.tsx\`** ×2 — drop synchronous \`setLoading(true)/setError(null)\` from fetch effects; initial \`useState(true)\` already covers first load, retries get optimistic-update UX (stale data visible during refetch instead of a loading flash)
- **\`StoresPage.tsx\`** — refactor \`loading\` to derived state (\`stores === null && !error\`), drop the \`loading\` \`useState\` and all \`setLoading\` calls
- **\`TastingsPage.tsx:74\`** — same as Admin: drop synchronous \`setLoading(true)\`

Net diff: 5 files, -9 lines.

## Behavior changes

- AdminPage Waitlist/Users tabs and TastingsPage list: on retry, users see stale data while the new fetch runs instead of a flash of the loading skeleton. This matches the optimistic-UX direction in CLAUDE.md (Linear-style).
- StoresPage: identical behavior — \`loading\` is now derived rather than a separate state, but evaluates to the same value at every render where it matters.

## How to test

- \`cd frontend && yarn lint\` — passes with 0 errors locally (the only warning is a pre-existing one at \`AppShell.tsx:577\`).
- \`cd frontend && yarn build\` — builds clean.
- Manual: open Admin → Waitlist, Users → click retry on a failed load; confirm UX is acceptable. Open /search → use browser back/forward across queries → confirm input syncs. Open /stores → grant location → confirm loading skeleton shows during fetch and clears on data.