### PR TITLE
chore: add CVE ignore entries and unblock frontend audit

### DIFF
--- a/.pip-audit-ignore
+++ b/.pip-audit-ignore
@@ -14,3 +14,14 @@ PYSEC-2026-196
 # FastAPI currently locked at 0.136.1; starlette>=1.0 needs explicit compatibility testing.
 # Track upgrade as a separate chore; remove this entry once FastAPI is bumped.
 CVE-2026-48710
+
+# starlette 0.52.1 — same FastAPI 1.x blocker as CVE-2026-48710 (2026-06-13).
+# poetry update starlette is a no-op while FastAPI is locked at 0.136.1.
+PYSEC-2026-161
+
+# starlette 0.52.1 — fixed in 1.1.0, same FastAPI 1.x blocker (2026-06-16).
+# Surfaced by redis 8.0.0 PR audit; unfixable without starlette 1.x migration.
+CVE-2026-48817
+
+# starlette 0.52.1 — fixed in 1.1.0, same FastAPI 1.x blocker (2026-06-16).
+CVE-2026-48818

--- a/.trivyignore
+++ b/.trivyignore
@@ -4,3 +4,13 @@
 # starlette 0.52.1 — fixed in 1.0.1, but starlette 1.x requires FastAPI 1.x.
 # FastAPI pinned at 0.136.1; compatibility testing needed before upgrade.
 CVE-2026-48710
+
+# starlette 0.52.1 — same FastAPI 1.x blocker as CVE-2026-48710 (2026-06-13).
+PYSEC-2026-161
+
+# starlette 0.52.1 — fixed in 1.1.0, same FastAPI 1.x blocker (2026-06-16).
+# Surfaced by redis 8.0.0 PR audit; unfixable without starlette 1.x migration.
+CVE-2026-48817
+
+# starlette 0.52.1 — fixed in 1.1.0, same FastAPI 1.x blocker (2026-06-16).
+CVE-2026-48818

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,9 @@ audit-bot:
 
 audit-frontend:
 	@echo "\n▶ Auditing frontend/"
-	cd frontend && yarn audit
+	# 1120792: js-yaml quadratic DoS — dev-only transitive dep of build tools; no runtime
+	# exposure. Remove once js-yaml >=4.2.0 is in yarn.lock (Dependabot PR #787).
+	cd frontend && yarn audit --ignore-advisory 1120792
 
 audit: audit-core audit-backend audit-scraper audit-bot audit-frontend
 


### PR DESCRIPTION
## Summary

- **`.pip-audit-ignore` / `.trivyignore`**: add `PYSEC-2026-161`, `CVE-2026-48817`, `CVE-2026-48818` — three more starlette 0.52.1 CVEs (fixed in starlette 1.0.1–1.1.0) blocked by the same FastAPI 1.x migration that's already documented for `CVE-2026-48710`
- **`Makefile` `audit-frontend`**: add `--ignore-advisory 1120792` for the js-yaml quadratic DoS advisory; js-yaml is a dev-only transitive dep of build tools with no runtime exposure — temporary until Dependabot PR #787 (js-yaml ≥4.2.0) lands on main

## Why this unblocks the Dependabot backlog

Without the Makefile change, Dependabot PRs #784–787 all fail `audit-frontend` because each individual PR only fixes one of two CVEs (`launch-editor`/`vite` via vite 8.0.16, or `js-yaml` via js-yaml 4.2.0) while the other remains. PR #784 already bundles vite 8.0.16; ignoring advisory 1120792 lets it pass and auto-merge, at which point Dependabot closes the smaller PRs as superseded and opens #787 (js-yaml) rebased on a clean base — which then also passes.

## Cleanup

Remove the `--ignore-advisory 1120792` Makefile entry once js-yaml ≥4.2.0 is in `frontend/yarn.lock` (after PR #787 or the next group update merges).