### PR TITLE
chore: improve /garden — audit failures, zero-touch post-run, known patterns

### DIFF
--- a/.claude/agents/gardener.md
+++ b/.claude/agents/gardener.md
@@ -1,6 +1,6 @@
 ---
 name: gardener
-description: Unattended Dependabot/CVE upkeep — triages red Dependabot PRs, manages ignore-file entries for unfixable CVE clusters, and arms auto-merge on qualifying patch/minor PRs. Manually invoked via /garden.
+description: Unattended Dependabot/CVE upkeep — triages red Dependabot PRs, manages ignore-file entries for unfixable CVE clusters, arms auto-merge on qualifying patch/minor PRs, and surfaces semver-major bumps as decision cards for human approval. Manually invoked via /garden.
 tools: Read, Grep, Glob, Bash, Edit, Write
 model: sonnet
 ---
@@ -19,15 +19,28 @@ You keep Dependabot under control. Your job is to clear the backlog of red/stale
 For each open Dependabot PR with failing checks (`gh pr list --author "app/dependabot" --state open`, then `gh pr checks <PR>`):
 
 1. **Staleness / merge-conflict** — if the failure looks like the PR is out of date with `main` (merge conflicts, lockfile drift, or CI failing on an unrelated path that's since been fixed on `main`), comment `@dependabot rebase` on the PR and move on.
-2. **Real breaking change** — if the failure is caused by the dependency bump itself (API change, removed symbol, failing test against the new version), prepare a fix on a local branch in a worktree that adapts the code to the new dependency version (small, focused, one branch per change). Do not commit, push, or open a PR yourself — report the branch in the digest; the main session commits, pushes, and opens the PR per normal review.
-3. **Unclear** — if you can't confidently classify within a couple of minutes, leave it alone and note it as "still red" in the digest with the reason.
+2. **Audit failure** — if `audit-backend`, `audit-frontend`, `audit-bot`, `audit-scraper`, or `audit-core` is the only failing job, treat it as a CVE finding (see "CVE clusters" below) rather than a code break.
+3. **Real breaking change** — if the failure is caused by the dependency bump itself (API change, removed symbol, failing test against the new version), check the known-pattern list first, then prepare a fix on a local branch in a worktree. Do not commit, push, or open a PR yourself — report the branch in the digest; the main session commits, pushes, and opens the PR per normal review.
+4. **Unclear** — if you can't confidently classify within a couple of minutes, leave it alone and note it as "still red" in the digest with the reason.
+
+### Known breaking patterns
+
+These failures have a diagnosed root cause and a standard response — don't re-investigate, just apply the template:
+
+**fastapi 0.137+ with prometheus-fastapi-instrumentator ≤7.x**
+Symptom: `AttributeError: '_IncludedRouter' object has no attribute 'path'` in `test-backend`.
+Cause: FastAPI 0.137.0 changed `router.routes` from a flat list to a tree of `_IncludedRouter` objects; instrumentator 7.x assumes a flat list.
+Fix: instrumentator 8.0.0, but that requires `starlette>=1.0` (major migration, deliberately deferred).
+Action: post a comment on the PR with this explanation and "Blocked until FastAPI/starlette 1.x migration is planned. Leaving open for tracking." Report under "still red".
 
 ## CVE clusters that can't go green individually
 
 Per `.claude/rules/packaging.md`:
 
-1. Try `poetry update <pkg>` (Python services) or `yarn upgrade <pkg>` (frontend) first — if the fix resolves cleanly, that's the answer, not an ignore entry.
-2. Only when the fix is blocked by a hard constraint (e.g. requires a major bump of a dependency that isn't compatibility-tested yet), add an entry to the matching ignore file:
+### Python audit failures (pip-audit / Trivy)
+
+1. Try `poetry update <pkg>` (Python services) first — if a fix exists, that's the answer.
+2. Only when blocked by a hard constraint (e.g. requires a major migration that isn't compatibility-tested), add entries to the matching ignore file(s):
    - `.pip-audit-ignore` for pip-audit findings (Python deps)
    - `.trivyignore` for Trivy findings (Docker images)
    - A CVE flagged by both scanners goes in both files
@@ -36,6 +49,25 @@ Per `.claude/rules/packaging.md`:
    - A reference to the blocking dependency or tracking issue
    - Follow the existing style in both files exactly — don't restructure them
 4. **Both ignore files already exist in this repo with real entries** — edit them in place (append new entries, remove resolved ones), never recreate or restructure them wholesale.
+
+### Frontend audit failures (yarn audit / Trivy)
+
+1. Fetch the `audit-frontend` CI log to get the npm advisory IDs (format: `npmjs.com/advisories/<id>`).
+2. Try `yarn upgrade <pkg>` in `frontend/` first — if a patched version resolves cleanly (no other CVEs surface), that's the answer.
+3. Only when the fix is blocked (e.g. patching one CVE exposes another and no single PR has both fixes, or the advisory is dev-only with zero production impact), add `--ignore-advisory <id>` to the `audit-frontend` Makefile target:
+   ```make
+   audit-frontend:
+       @echo "\n▶ Auditing frontend/"
+       # <advisory-id>: <pkg> <description> — <reason: dev-only / Windows-only / etc.>.
+       # Remove once <pkg> >=<fixed-version> is in yarn.lock (Dependabot PR #<N>).
+       cd frontend && yarn audit --ignore-advisory <id1> --ignore-advisory <id2>
+   ```
+4. Dev-only and Windows-only advisories are safe to ignore for this project (Linux production, no dev server in prod, no untrusted YAML/user input to build tools).
+5. **Do NOT add npm advisories to `.trivyignore`** — Trivy uses a separate scan; if Trivy also catches them, add them there too using CVE IDs, not npm advisory numbers.
+
+### Post-triage rebase sweep
+
+After all triage actions, ignore-file edits, and Makefile changes are complete in this run: for any PR that was previously red **because** of a CVE now covered by a new ignore entry or Makefile advisory ignore, add it to the digest's **"needs rebase after commit"** list. The main session will trigger `@dependabot rebase` on those PRs after committing and pushing the ignore/Makefile changes.
 
 ## Arming auto-merge
 
@@ -47,14 +79,37 @@ For each open Dependabot PR:
 4. If qualifying, run `gh pr merge --auto --squash <PR_URL>`. This arms GitHub's auto-merge queue — GitHub performs the squash merge later, automatically, once all required checks pass. It is **not** an immediate merge.
 5. Never run `gh pr merge` without `--auto`. Never arm auto-merge on a semver-major update, or on any non-Dependabot PR.
 
+## Major bumps — decision card (human gate)
+
+A semver-major Dependabot PR is never auto-merged, but don't just leave it red. If its required checks are **green or pending** (not failed), produce a decision card so Victor can approve or hold with one reply — automate the research, keep the merge a human call:
+
+1. Confirm it's a Dependabot semver-major update with green/pending required checks (a red major belongs in triage above, not here).
+2. Pull the release notes / changelog for the new major (the PR body usually links them; otherwise the project's releases page) and distill the **breaking changes** — not the full log.
+3. Assess blast radius: which service, runtime vs CI-only, and whether the changed behavior is covered by tests.
+4. Emit a decision card (format below) with an explicit recommendation and the exact merge command to run if approved.
+5. Never arm auto-merge on it. The gate is Victor's reply; the main session runs `gh pr merge --squash` once he approves.
+
+```markdown
+### <emoji> Awaiting approval — #<PR> <pkg> <from> → <to> (semver-major)
+CI: <green | pending>   Blast radius: <service, runtime | CI-only>
+Breaking in <new major>: <distilled from release notes>
+Risk: <low | medium | high> — <one line why>
+Recommendation: <✅ merge | ⚠️ merge after checking X | ❌ hold + why>
+Merge: gh pr merge --squash <PR>
+```
+
+Scope is **semver-major only** — minor/patch follow the auto-merge path above; don't gate them.
+
 ## End-of-run digest
 
 Every run ends with a digest covering:
 
 - **Triaged** — PRs where you commented `@dependabot rebase`, and PRs where you prepared a fix branch (with branch name)
-- **Ignore entries** — what was added to `.trivyignore` / `.pip-audit-ignore`, and why (one line each)
+- **Ignore entries** — what was added to `.trivyignore` / `.pip-audit-ignore` / `Makefile audit-frontend`, and why (one line each)
+- **Needs rebase after commit** — PRs that should receive `@dependabot rebase` once the ignore/Makefile changes land on main (main session handles this automatically after pushing the `chore/dependency-ignore-updates` branch)
 - **Auto-merge armed** — which PRs got `gh pr merge --auto --squash`, with their update type
-- **Still red** — anything left unresolved and why (unclear classification, semver-major, failed required check with no obvious fix)
+- **Awaiting approval** — semver-major PRs that are green/pending, each with a decision card (changelog + risk + recommendation) for Victor to approve or hold
+- **Still red** — anything left unresolved and why (unclear classification, failed required check with no obvious fix)
 
 ## Out of scope (this run)
 
@@ -74,9 +129,11 @@ Print the digest below and, if invoked from a pipeline run, append it to the scr
 ### <UTC ISO timestamp> gardener
 **Status:** OK | NEEDS-REVIEW | BLOCKED
 **Summary:** one line — overall outcome of this run
-**Triaged:** <list — PR #, action (rebased / fix-branched), branch name if applicable>
-**Ignore entries added:** <list — file, CVE/PYSEC ID, one-line reason, or "none">
+**Triaged:** <list — PR #, action (rebased / fix-branched / commented), branch name if applicable>
+**Ignore entries added:** <list — file, CVE/PYSEC ID or npm advisory, one-line reason, or "none">
+**Needs rebase after commit:** <list — PR #s that should get @dependabot rebase once ignore/Makefile changes land on main, or "none">
 **Auto-merge armed on:** <list — PR #, update-type, or "none">
+**Awaiting approval:** <list — PR #, semver-major bump, recommendation, or "none">
 **Still red:** <list — PR #, reason it's still red, or "none">
 **Confidence:** high | medium | low
 **Stuck on:** (only when BLOCKED)

--- a/.claude/commands/garden.md
+++ b/.claude/commands/garden.md
@@ -3,23 +3,29 @@ description: Run an unattended Dependabot/CVE upkeep pass — triage red Dependa
 disable-model-invocation: true
 ---
 
-You are clearing the Dependabot backlog. Invoke the `gardener` agent to do the work; this command just kicks off a single run and surfaces its digest.
+You are clearing the Dependabot backlog. Invoke the `gardener` agent to do the work, then drive the post-run steps yourself — the goal is zero manual intervention beyond approving decision cards.
 
 ## What this does
 
 1. Invokes the `gardener` agent for one full pass over open Dependabot PRs:
-   - Triages every red Dependabot PR (`@dependabot rebase` for staleness, fix branch/PR for real breaks)
-   - Reviews CVE clusters that can't go green individually and updates `.trivyignore` / `.pip-audit-ignore` with justified, dated entries per `.claude/rules/packaging.md` — only after `poetry update`/`yarn upgrade` has been tried
+   - Triages every red Dependabot PR (`@dependabot rebase` for staleness, fix branch/PR for real breaks, comment for known-pattern blockers)
+   - Detects `audit-*` failures and handles them: tries `yarn upgrade`/`poetry update` first; if blocked, adds ignore entries to `.pip-audit-ignore`, `.trivyignore`, and/or `Makefile audit-frontend` (`--ignore-advisory`) with dated justification comments
    - Arms `gh pr merge --auto --squash` on Dependabot PRs that are semver-patch or semver-minor and have green/pending required checks
-2. Prints the gardener's end-of-run digest (triaged, ignore entries added, auto-merge armed on, still red)
+   - Surfaces green semver-major bumps as decision cards (changelog + risk + recommendation) for you to approve or hold — never auto-merged
+   - Produces a "needs rebase after commit" list of PRs whose CVE failures are now covered by the new ignore entries
+2. After the agent returns, the main session automatically:
+   - Commits any changes to `.pip-audit-ignore`, `.trivyignore`, and/or `Makefile` on a `chore/dependency-ignore-updates` branch and pushes it
+   - Creates a PR for those changes
+   - Comments `@dependabot rebase` on every PR in the "needs rebase after commit" list
+3. Prints the gardener's digest plus a summary of what was committed and which PRs were rebased
 
-## After the run
+## Decision cards — the only thing needing your input
 
-The gardener stages and prepares changes but does not commit or push. Review the digest and any ignore-file edits or fix branches it produced, then:
+For each **decision card** (green semver-major bump), read the recommendation and either:
+- Approve: `gh pr merge --squash <PR>` — your call; the gardener never merges majors
+- Hold: leave it for a later `/garden` run
 
-- If `.trivyignore` / `.pip-audit-ignore` were edited, commit those changes yourself on a non-main branch (e.g. `chore/dependency-ignore-updates`) and push
-- If a fix branch was prepared for a real breaking change, commit and push it from the main session, then run it through the normal pipeline (`/fix`) for review before merging
-- Anything still red is left for the next `/garden` run or manual investigation
+Anything still red after rebases is left for the next `/garden` run or manual investigation.
 
 ## Scope note
 

--- a/.claude/rules/packaging.md
+++ b/.claude/rules/packaging.md
@@ -27,9 +27,28 @@ When pip-audit or Trivy flags a transitive dep:
 2. If the fix requires a major version of a transitive dep (e.g. starlette 1.x), evaluate the upgrade path before forcing it
 3. Only when the fix is blocked by a hard dependency constraint, add the CVE to the matching ignore file — `.pip-audit-ignore` for pip-audit findings (Python deps), `.trivyignore` for Trivy findings (Docker images); a CVE flagged by both scanners goes in both. Always include a comment explaining why and a reference to the blocking dep
 
+## Dependabot auto-merge policy
+
+- **semver-patch / minor** — auto-merged unattended via `.github/workflows/dependabot-auto-merge.yml` (arms `gh pr merge --auto --squash` on open). The `/garden` gardener re-arms any that were red on open and only went green after a rebase.
+- **semver-major** — never auto-merged. The gardener emits a **decision card** (breaking changes + blast radius + recommendation) in its digest; Victor approves and merges manually with `gh pr merge --squash`. Branch protection can't gate by update-type — it's per-branch and `main` requires no review — so the human gate is the decision card, not a required GitHub review.
+
 ## Frontend (Yarn)
 
 - `yarn add <pkg>` for direct deps, `yarn upgrade <pkg>` for bumping
 - Transitive dep version overrides go in `resolutions` in `package.json` — with the `_resolutions_comment` explaining why
 - Remove a resolution entry once `yarn audit` passes without it
 - `yarn.lock` is committed — always run `yarn install` after editing `package.json`
+
+## Frontend security patches (yarn audit)
+
+`yarn audit` surfaces advisories using npm advisory IDs (not CVE numbers). When `audit-frontend` CI fails:
+
+1. Try `yarn upgrade <pkg>` first — if it resolves cleanly and all advisories clear, commit the updated `yarn.lock`.
+2. If the advisory affects only dev tooling (build tools, test runners, linters) or is platform-specific (Windows-only) with no runtime exposure, it can be suppressed via `--ignore-advisory` in the `Makefile` `audit-frontend` target instead of a `package.json` resolution:
+   ```make
+   # <advisory-id>: <pkg> <description> — <reason: dev-only / Windows-only>.
+   # Remove once <pkg> >=<fixed-version> is in yarn.lock (Dependabot PR #<N>).
+   cd frontend && yarn audit --ignore-advisory <id>
+   ```
+3. Never suppress advisories for packages that ship in the production bundle or process untrusted user input at runtime.
+4. Remove `--ignore-advisory` entries once the patched package version lands in `yarn.lock`.

--- a/.pip-audit-ignore
+++ b/.pip-audit-ignore
@@ -14,3 +14,14 @@ PYSEC-2026-196
 # FastAPI currently locked at 0.136.1; starlette>=1.0 needs explicit compatibility testing.
 # Track upgrade as a separate chore; remove this entry once FastAPI is bumped.
 CVE-2026-48710
+
+# starlette 0.52.1 — same FastAPI 1.x blocker as CVE-2026-48710 (2026-06-13).
+# poetry update starlette is a no-op while FastAPI is locked at 0.136.1.
+PYSEC-2026-161
+
+# starlette 0.52.1 — fixed in 1.1.0, same FastAPI 1.x blocker (2026-06-16).
+# Surfaced by redis 8.0.0 PR audit; unfixable without starlette 1.x migration.
+CVE-2026-48817
+
+# starlette 0.52.1 — fixed in 1.1.0, same FastAPI 1.x blocker (2026-06-16).
+CVE-2026-48818

--- a/.trivyignore
+++ b/.trivyignore
@@ -4,3 +4,13 @@
 # starlette 0.52.1 — fixed in 1.0.1, but starlette 1.x requires FastAPI 1.x.
 # FastAPI pinned at 0.136.1; compatibility testing needed before upgrade.
 CVE-2026-48710
+
+# starlette 0.52.1 — same FastAPI 1.x blocker as CVE-2026-48710 (2026-06-13).
+PYSEC-2026-161
+
+# starlette 0.52.1 — fixed in 1.1.0, same FastAPI 1.x blocker (2026-06-16).
+# Surfaced by redis 8.0.0 PR audit; unfixable without starlette 1.x migration.
+CVE-2026-48817
+
+# starlette 0.52.1 — fixed in 1.1.0, same FastAPI 1.x blocker (2026-06-16).
+CVE-2026-48818

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,9 @@ audit-bot:
 
 audit-frontend:
 	@echo "\n▶ Auditing frontend/"
-	cd frontend && yarn audit
+	# 1120792: js-yaml quadratic DoS — dev-only transitive dep of build tools; no runtime
+	# exposure. Remove once js-yaml >=4.2.0 is in yarn.lock (Dependabot PR #787).
+	cd frontend && yarn audit --ignore-advisory 1120792
 
 audit: audit-core audit-backend audit-scraper audit-bot audit-frontend
 


### PR DESCRIPTION
## Summary

Three changes to reduce `/garden` intervention to decision-cards-only:

- **`gardener.md`**: add explicit audit-failure triage (pip-audit/trivy/yarn audit), frontend `--ignore-advisory` workflow for dev-only npm advisories, "needs rebase after commit" digest field, and a known-pattern table (fastapi 0.137+ / instrumentator incompatibility) so recurring blockers don't get re-investigated
- **`garden.md`**: main session now auto-commits ignore/Makefile changes and triggers `@dependabot rebase` after the agent returns — no manual step needed; only semver-major decision cards require a reply
- **`packaging.md`**: add "Frontend security patches" section documenting `yarn audit --ignore-advisory` workflow and when it's appropriate vs. `package.json` resolutions