### PR TITLE
chore: add starlette CVE-2026-54282/54283 to ignore files

### DIFF
--- a/.pip-audit-ignore
+++ b/.pip-audit-ignore
@@ -25,3 +25,10 @@ CVE-2026-48817
 
 # starlette 0.52.1 — fixed in 1.1.0, same FastAPI 1.x blocker (2026-06-16).
 CVE-2026-48818
+
+# starlette 0.52.1 — fixed in 1.3.1, same FastAPI 1.x blocker (2026-06-16).
+# Surfaced by redis 8.0.0 PR audit; unfixable without starlette 1.x migration.
+CVE-2026-54283
+
+# starlette 0.52.1 — fixed in 1.3.0, same FastAPI 1.x blocker (2026-06-16).
+CVE-2026-54282

--- a/.trivyignore
+++ b/.trivyignore
@@ -14,3 +14,10 @@ CVE-2026-48817
 
 # starlette 0.52.1 — fixed in 1.1.0, same FastAPI 1.x blocker (2026-06-16).
 CVE-2026-48818
+
+# starlette 0.52.1 — fixed in 1.3.1, same FastAPI 1.x blocker (2026-06-16).
+# Surfaced by redis 8.0.0 PR audit; unfixable without starlette 1.x migration.
+CVE-2026-54283
+
+# starlette 0.52.1 — fixed in 1.3.0, same FastAPI 1.x blocker (2026-06-16).
+CVE-2026-54282


### PR DESCRIPTION
Two new starlette 0.52.1 CVEs surfaced by the redis 8.0.0 PR (#781) audit — same FastAPI 1.x migration blocker as the existing entries.

- `CVE-2026-54283` — fixed in starlette 1.3.1
- `CVE-2026-54282` — fixed in starlette 1.3.0

Unfixable without the planned FastAPI/starlette 1.x migration. Added to both `.pip-audit-ignore` and `.trivyignore`. Remove once starlette ≥1.3.0 is on main.