### PR TITLE
chore(claude): correct gardener known-pattern for instrumentator/FastAPI 0.137+

### DIFF
--- a/.claude/agents/gardener.md
+++ b/.claude/agents/gardener.md
@@ -29,11 +29,11 @@ For each open Dependabot PR with failing checks (`gh pr list --author "app/depen
 
 These failures have a diagnosed root cause and a standard response — don't re-investigate, just apply the template:
 
-**fastapi 0.137+ with prometheus-fastapi-instrumentator ≤7.x**
-Symptom: `AttributeError: '_IncludedRouter' object has no attribute 'path'` in `test-backend`.
-Cause: FastAPI 0.137.0 changed `router.routes` from a flat list to a tree of `_IncludedRouter` objects; instrumentator 7.x assumes a flat list.
-Fix: instrumentator 8.0.0, but that requires `starlette>=1.0` (major migration, deliberately deferred).
-Action: post a comment on the PR with this explanation and "Blocked until FastAPI/starlette 1.x migration is planned. Leaving open for tracking." Report under "still red".
+**fastapi 0.137+ with prometheus-fastapi-instrumentator (any version ≤8.0.0)**
+Symptom: `AttributeError: '_IncludedRouter' object has no attribute 'path'` in `test-backend` (`routing.py:55`).
+Cause: FastAPI 0.137.0 changed `router.routes` from a flat list to a tree containing `_IncludedRouter` container nodes; instrumentator's `get_route_name` assumes every element in that list is a real route with a `.path` attribute. This is unfixed in instrumentator 7.x AND 8.0.0 — 8.0.0 only migrated to starlette 1.x, it did not fix the router-tree traversal.
+Fix: wait for instrumentator ≥8.1.0 (or equivalent) to handle `_IncludedRouter` nodes, OR remove instrumentator and expose metrics via a lighter alternative.
+Action: post a comment on the PR with this explanation: "Blocked: prometheus-fastapi-instrumentator is incompatible with FastAPI 0.137.x (`_IncludedRouter` AttributeError). Not fixed in 8.0.0 — waiting for upstream fix. Leaving open for tracking." Report under "still red".
 
 ## CVE clusters that can't go green individually
 


### PR DESCRIPTION
## Summary

- Fixes incorrect claim in `.claude/agents/gardener.md` that instrumentator 8.0.0 resolves the `_IncludedRouter` AttributeError with FastAPI 0.137.x
- Confirmed via CI log on #788: instrumentator 8.0.0 is installed but the error persists at `routing.py:55` — the version only migrated to starlette 1.x, the router-tree traversal bug is unfixed
- Updated the known-pattern to reflect the real status: blocked until instrumentator ≥8.1.0 or similar upstream fix

## Test plan

- [ ] No code change — agent definition doc update only