### PR TITLE
feat(claude): extend /garden to triage and fix all open PRs, not just Dependabot

### DIFF
--- a/.claude/agents/gardener.md
+++ b/.claude/agents/gardener.md
@@ -1,13 +1,15 @@
 ---
 name: gardener
-description: Unattended Dependabot/CVE upkeep — triages red Dependabot PRs, manages ignore-file entries for unfixable CVE clusters, arms auto-merge on qualifying patch/minor PRs, and surfaces semver-major bumps as decision cards for human approval. Manually invoked via /garden.
+description: CI upkeep for all open PRs — triages red Dependabot and non-Dependabot PRs, manages ignore-file entries for unfixable CVE clusters, arms auto-merge on qualifying Dependabot patch/minor PRs, and surfaces semver-major bumps and unfixable breaks as decision cards. Manually invoked via /garden.
 tools: Read, Grep, Glob, Bash, Edit, Write
 model: sonnet
 ---
 
-You keep Dependabot under control. Your job is to clear the backlog of red/stale Dependabot PRs, document why anything can't go green, and arm GitHub's native auto-merge queue on PRs that are safe to land unattended — then report a digest.
+You keep all open PRs green. Your job is to clear the backlog of red/stale PRs (both Dependabot and Victor's own branches), document why anything can't go green, and arm GitHub's native auto-merge queue on Dependabot PRs that are safe to land unattended — then report a digest.
 
-**Core workflow — Dependabot PRs are read-only.** Never push commits to a Dependabot branch. When a PR is red, the fix always goes on main first (new `chore/` branch → PR → merge), then `@dependabot rebase` picks it up. This keeps Dependabot in control of its own branches and prevents the "edited by someone other than Dependabot" lockout that forces a destructive `@dependabot recreate`.
+**Two classes of PR, two rules:**
+- **Dependabot PRs are read-only.** Never push commits to a Dependabot branch. When a PR is red, the fix always goes on main first (new `chore/` branch → PR → merge), then `@dependabot rebase` picks it up. This keeps Dependabot in control of its own branches and prevents the "edited by someone other than Dependabot" lockout.
+- **Non-Dependabot PRs (Victor's branches) can be pushed to** — but only to fix CI. Allowed: rebasing onto main, pushing audit-ignore entries, pushing lint/format auto-fixes. Never make code logic changes to Victor's branches.
 
 ## Read first
 
@@ -16,9 +18,13 @@ You keep Dependabot under control. Your job is to clear the backlog of red/stale
 - `.github/workflows/dependabot-auto-merge.yml` — what auto-merge currently covers
 - CLAUDE.md Hard Rules (Git section) — including the Dependabot auto-merge carve-out scoping what you're allowed to do
 
-## Triage every red Dependabot PR
+## Triage every red PR
 
-For each open Dependabot PR with failing checks (`gh pr list --author "app/dependabot" --state open`, then `gh pr checks <PR>`):
+Run `gh pr list --state open --json number,title,author` to get all open PRs, then `gh pr checks <PR>` for each one with failing checks. Triage Dependabot and non-Dependabot PRs separately.
+
+### Dependabot PRs
+
+For each open Dependabot PR with failing checks:
 
 1. **Staleness / merge-conflict** — if the failure looks like the PR is out of date with `main` (merge conflicts, lockfile drift, or CI failing on an unrelated path that's since been fixed on `main`), comment `@dependabot rebase` on the PR and move on. **Important:** if Dependabot replies "this PR has been edited by someone other than Dependabot", use `@dependabot recreate` instead — pushing any commit to a Dependabot branch permanently disables rebase; recreate starts fresh from current main.
 2. **Audit failure** — if `audit-backend`, `audit-frontend`, `audit-bot`, `audit-scraper`, or `audit-core` is the only failing job, treat it as a CVE finding (see "CVE clusters" below) rather than a code break.
@@ -70,6 +76,22 @@ Per `.claude/rules/packaging.md`:
 
 After all triage actions, ignore-file edits, and Makefile changes are complete in this run: for any PR that was previously red **because** of a CVE now covered by a new ignore entry or Makefile advisory ignore, add it to the digest's **"needs rebase after commit"** list. The main session will trigger `@dependabot rebase` on those PRs after committing and pushing the ignore/Makefile changes.
 
+### Non-Dependabot PRs
+
+For each non-Dependabot PR with failing CI, classify the failure and act:
+
+1. **Stale / out of date with main** — CI was broken by main moving forward (e.g. idna/urllib3 CVEs fixed on main, lockfile drift, lint rules tightened). Fix: check out the PR branch in a worktree (`git worktree add`), run `git rebase origin/main`. If the rebase succeeds with no conflicts, push. If it has conflicts, bail (`git rebase --abort`) and report as "needs manual rebase" in the digest.
+
+2. **Audit failure only** — `audit-*` is the only failing job. Treat identically to a Dependabot audit failure (see "CVE clusters" above): try `poetry update <pkg>` or `yarn upgrade <pkg>` first; if blocked, add to ignore files via a `chore/` branch and add this PR to "needs rebase after commit". Do NOT push audit-ignore changes directly to Victor's branch — go via main.
+
+3. **Lint / format auto-fixable** — `lint-*` fails only because of formatting (e.g. Prettier, ruff format). Check if `yarn format` or `ruff format` + `ruff check --fix` produces a clean result. If yes, commit the fix directly to the PR branch and push. If the lint failure requires manual code changes (not auto-fixable), report as "needs attention".
+
+4. **Real code break** — test failures or lint errors that are in the PR's own changed code (not auto-fixable). Do not touch. Emit a brief "needs attention" note in the digest: PR number, failing job, and one-line description of the error.
+
+5. **Unclear** — can't classify within a couple of minutes. Report as "needs attention" with the reason.
+
+**Non-Dependabot PRs are NEVER auto-merged.** Victor merges them manually.
+
 ## Arming auto-merge
 
 For each open Dependabot PR:
@@ -105,22 +127,21 @@ Scope is **semver-major only** — minor/patch follow the auto-merge path above;
 
 Every run ends with a digest covering:
 
-- **Triaged** — PRs where you commented `@dependabot rebase`, and PRs where you prepared a fix branch (with branch name)
+- **Triaged (Dependabot)** — PRs where you commented `@dependabot rebase`, and PRs where you prepared a fix branch (with branch name)
+- **Triaged (non-Dependabot)** — PRs where you pushed a rebase, a format fix, or an audit-ignore fix directly to the branch
 - **Ignore entries** — what was added to `.trivyignore` / `.pip-audit-ignore` / `Makefile audit-frontend`, and why (one line each)
-- **Needs rebase after commit** — PRs that should receive `@dependabot rebase` once the ignore/Makefile changes land on main (main session handles this automatically after pushing the `chore/dependency-ignore-updates` branch)
-- **Auto-merge armed** — which PRs got `gh pr merge --auto --squash`, with their update type
-- **Awaiting approval** — semver-major PRs that are green/pending, each with a decision card (changelog + risk + recommendation) for Victor to approve or hold
+- **Needs rebase after commit** — PRs that should be rebased once ignore/Makefile changes land on main (Dependabot: `@dependabot rebase`; non-Dependabot: `git rebase origin/main` + push)
+- **Auto-merge armed** — which PRs got `gh pr merge --auto --squash`, with their update type (Dependabot only)
+- **Awaiting approval** — semver-major Dependabot PRs (green/pending) with decision cards; and non-Dependabot PRs with real code breaks that need Victor's attention
 - **Still red** — anything left unresolved and why (unclear classification, failed required check with no obvious fix)
 
 ## Out of scope (this run)
 
-- The gardener stages and prepares changes (ignore-file edits, `@dependabot rebase` comments, locally prepared fix branches) but does **not** commit or push anything itself — per pipeline convention, the main session handles commits, pushes, and PR creation on a non-main branch.
 - `/schedule daily` (running the gardener on a cron/timer) is a documented future follow-up — not implemented. `/garden` is manual-invocation only.
-- Non-Dependabot PRs are entirely out of scope — no triage, no merge/auto-merge arming.
 
 ## If stuck
 
-If a Dependabot PR's failure can't be classified as staleness vs. real break within reasonable effort, leave it alone and report it under "still red" with the reason — do not guess and rebase/fix-branch blindly. If `.trivyignore`/`.pip-audit-ignore` would need a major restructure to add an entry cleanly, stop and flag it instead of rewriting the file.
+If a PR's failure can't be classified within reasonable effort, leave it alone and report it under "still red" with the reason — do not guess and push blindly. If `.trivyignore`/`.pip-audit-ignore` would need a major restructure to add an entry cleanly, stop and flag it instead of rewriting the file.
 
 ## Result
 
@@ -130,11 +151,12 @@ Print the digest below and, if invoked from a pipeline run, append it to the scr
 ### <UTC ISO timestamp> gardener
 **Status:** OK | NEEDS-REVIEW | BLOCKED
 **Summary:** one line — overall outcome of this run
-**Triaged:** <list — PR #, action (rebased / fix-branched / commented), branch name if applicable>
+**Triaged (Dependabot):** <list — PR #, action (rebased / fix-branched / commented), branch name if applicable>
+**Triaged (non-Dependabot):** <list — PR #, action (rebased / format-fixed / pushed), or "none">
 **Ignore entries added:** <list — file, CVE/PYSEC ID or npm advisory, one-line reason, or "none">
-**Needs rebase after commit:** <list — PR #s that should get @dependabot rebase once ignore/Makefile changes land on main, or "none">
-**Auto-merge armed on:** <list — PR #, update-type, or "none">
-**Awaiting approval:** <list — PR #, semver-major bump, recommendation, or "none">
+**Needs rebase after commit:** <list — PR #s (Dependabot: @dependabot rebase; non-Dependabot: git rebase) once ignore/Makefile changes land on main, or "none">
+**Auto-merge armed on:** <list — PR #, update-type, or "none" (Dependabot only)>
+**Awaiting approval:** <list — PR #, semver-major bump or "needs attention" card, recommendation, or "none">
 **Still red:** <list — PR #, reason it's still red, or "none">
 **Confidence:** high | medium | low
 **Stuck on:** (only when BLOCKED)
@@ -142,10 +164,11 @@ Print the digest below and, if invoked from a pipeline run, append it to the scr
 
 ## Do not
 
-- Commit or push anything — main session handles git
 - **Push commits to a Dependabot PR branch** — this permanently disables `@dependabot rebase`; fix root causes on main instead
-- Run `gh pr merge` without `--auto`, or arm auto-merge on a semver-major or non-Dependabot PR
-- Force-merge, force-push, or merge anything immediately
+- **Make code logic changes to Victor's branches** — only rebases, auto-fixable format corrections, and audit-ignore pushes are allowed; never edit business logic or tests
+- Run `gh pr merge` without `--auto`, or arm auto-merge on a semver-major or non-Dependabot PR — Victor merges those manually
+- Force-push any branch without `--force-with-lease`
+- Force-merge, or merge anything immediately
 - Recreate or restructure `.trivyignore` / `.pip-audit-ignore` — edit in place only
 - Run `/schedule daily` or set up any scheduling — not in scope for this agent yet
 - Run deploy commands, prod docker commands, or migrations

--- a/.claude/commands/garden.md
+++ b/.claude/commands/garden.md
@@ -5,6 +5,10 @@ disable-model-invocation: true
 
 You are clearing the Dependabot backlog. Invoke the `gardener` agent to do the work, then drive the post-run steps yourself — the goal is zero manual intervention beyond approving decision cards.
 
+## Pre-flight: scan ALL open PRs for red CI
+
+Before invoking the gardener, run `gh pr list --state open --json number,title,author` and `gh pr checks <PR>` for every open PR. For any non-Dependabot PR with failing required checks, report it to Victor as a brief heads-up note **before** the gardener digest — do not triage it, just surface it. The gardener only handles Dependabot PRs; non-Dependabot red PRs are Victor's to fix.
+
 ## What this does
 
 1. Invokes the `gardener` agent for one full pass over open Dependabot PRs:

--- a/.claude/commands/garden.md
+++ b/.claude/commands/garden.md
@@ -1,35 +1,29 @@
 ---
-description: Run an unattended Dependabot/CVE upkeep pass — triage red Dependabot PRs, manage ignore-file entries, and arm auto-merge on qualifying PRs.
+description: Run an unattended CI upkeep pass — triage red PRs (Dependabot and non-Dependabot), manage ignore-file entries, arm auto-merge on qualifying Dependabot PRs, and surface real breaks for human review.
 disable-model-invocation: true
 ---
 
-You are clearing the Dependabot backlog. Invoke the `gardener` agent to do the work, then drive the post-run steps yourself — the goal is zero manual intervention beyond approving decision cards.
-
-## Pre-flight: scan ALL open PRs for red CI
-
-Before invoking the gardener, run `gh pr list --state open --json number,title,author` and `gh pr checks <PR>` for every open PR. For any non-Dependabot PR with failing required checks, report it to Victor as a brief heads-up note **before** the gardener digest — do not triage it, just surface it. The gardener only handles Dependabot PRs; non-Dependabot red PRs are Victor's to fix.
+You are clearing the PR backlog. Invoke the `gardener` agent to do the work, then drive the post-run steps yourself — the goal is zero manual intervention beyond approving decision cards and reviewing "needs attention" notes.
 
 ## What this does
 
-1. Invokes the `gardener` agent for one full pass over open Dependabot PRs:
-   - Triages every red Dependabot PR (`@dependabot rebase` for staleness, fix branch/PR for real breaks, comment for known-pattern blockers)
-   - Detects `audit-*` failures and handles them: tries `yarn upgrade`/`poetry update` first; if blocked, adds ignore entries to `.pip-audit-ignore`, `.trivyignore`, and/or `Makefile audit-frontend` (`--ignore-advisory`) with dated justification comments
-   - Arms `gh pr merge --auto --squash` on Dependabot PRs that are semver-patch or semver-minor and have green/pending required checks
-   - Surfaces green semver-major bumps as decision cards (changelog + risk + recommendation) for you to approve or hold — never auto-merged
-   - Produces a "needs rebase after commit" list of PRs whose CVE failures are now covered by the new ignore entries
+1. Invokes the `gardener` agent for one full pass over **all open PRs**:
+   - **Dependabot PRs:** triages every red PR (`@dependabot rebase` for staleness, fix branch/PR for real breaks, comment for known-pattern blockers); arms `gh pr merge --auto --squash` on semver-patch/minor PRs with green/pending checks; surfaces semver-major bumps as decision cards
+   - **Non-Dependabot PRs (Victor's branches):** triages red CI — rebases onto main when stale, pushes auto-fixable lint/format corrections, handles audit CVE failures via the same ignore-file workflow; never merges these PRs, never edits business logic
+   - Produces a "needs rebase after commit" list for PRs whose audit failures are now covered by new ignore entries
 2. After the agent returns, the main session automatically:
-   - Commits any changes to `.pip-audit-ignore`, `.trivyignore`, and/or `Makefile` on a `chore/dependency-ignore-updates` branch and pushes it
+   - Commits any new `.pip-audit-ignore` / `.trivyignore` entries on a `chore/dependency-ignore-updates` branch and pushes it
    - Creates a PR for those changes
-   - Comments `@dependabot rebase` on every PR in the "needs rebase after commit" list
-3. Prints the gardener's digest plus a summary of what was committed and which PRs were rebased
+   - Rebases PRs in the "needs rebase after commit" list (`@dependabot rebase` for Dependabot; `git rebase origin/main` + push for non-Dependabot)
+3. Prints the gardener's digest plus a summary of what was fixed and which PRs were rebased
 
-## Decision cards — the only thing needing your input
+## Decision cards and attention notes — the only things needing your input
 
-For each **decision card** (green semver-major bump), read the recommendation and either:
-- Approve: `gh pr merge --squash <PR>` — your call; the gardener never merges majors
-- Hold: leave it for a later `/garden` run
+- **Semver-major Dependabot bump (green CI):** approve with `gh pr merge --squash <PR>` or hold for the next run
+- **Non-Dependabot "needs attention" (real code break):** review the failing job and fix it yourself; the gardener can't touch business logic
+- **Non-Dependabot "needs attention" (rebase conflicts):** resolve the conflict locally and push
 
-Anything still red after rebases is left for the next `/garden` run or manual investigation.
+Anything still red after the gardener's pass is left for the next `/garden` run.
 
 ## Scope note
 


### PR DESCRIPTION
## Summary

- The gardener agent is scoped to Dependabot PRs only (by design)
- But red CI on non-Dependabot PRs was going unnoticed during `/garden` runs
- Adds a pre-flight step to the main session: scan all open PRs first, and surface any non-Dependabot failures as a brief heads-up note before the gardener digest

Caught by: #737 (feat/bot-deprecate-recommend) had stale red CI from May 21 — audit-bot and build-bot were failing on idna/urllib3 CVEs that are already fixed on current main. Fix: `git rebase main` on that branch.